### PR TITLE
fix(ui): stream job logs live during execution

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,7 +10,21 @@ type DB struct {
 }
 
 func Initialize(path string) (*DB, error) {
-	db, err := sql.Open("sqlite", path)
+	// File-backed SQLite needs WAL journaling plus a busy timeout. With the
+	// default rollback journal, a concurrent reader + writer pair (the SSE
+	// log-stream poller and the job goroutines INSERTing log lines) reliably
+	// collides on the shared journal and the writer fails with "database is
+	// locked (SQLITE_BUSY)" — a failure that internal/ui swallows, silently
+	// dropping log lines mid-run. WAL lets readers run concurrently with a
+	// writer (each sees the last committed snapshot), and busy_timeout makes a
+	// colliding writer wait up to 5s instead of failing outright. ":memory:"
+	// is untouched: its single pinned connection needs no journaling pragma
+	// (and WAL only makes sense on a file anyway).
+	dsn := path
+	if path != ":memory:" {
+		dsn = path + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+	}
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,7 +1,10 @@
 package db
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,4 +18,25 @@ func TestDatabaseInitialization(t *testing.T) {
 	err = db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table'").Scan(&count)
 	assert.NoError(t, err)
 	assert.Greater(t, count, 0)
+}
+
+// TestFileDBEnablesWALAndBusyTimeout guards the fix for silently dropped log
+// lines: a file-backed DB must run in WAL mode with a busy timeout so the SSE
+// log-stream reader and the job-goroutine log writers can operate concurrently
+// without "database is locked (SQLITE_BUSY)" write failures.
+func TestFileDBEnablesWALAndBusyTimeout(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "gitrieve.db")
+	testDB, err := Initialize(dbPath)
+	assert.NoError(t, err)
+	defer testDB.Close()
+
+	var mode string
+	err = testDB.QueryRow("PRAGMA journal_mode").Scan(&mode)
+	assert.NoError(t, err)
+	assert.Equal(t, "wal", strings.ToLower(mode), "file-backed DB must run in WAL journal mode")
+
+	var timeout int
+	err = testDB.QueryRow("PRAGMA busy_timeout").Scan(&timeout)
+	assert.NoError(t, err)
+	assert.Equal(t, 5000, timeout, "busy_timeout must be 5000ms")
 }

--- a/internal/repository/progress.go
+++ b/internal/repository/progress.go
@@ -1,0 +1,70 @@
+package repository
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wnarutou/gitrieve/internal/ui"
+)
+
+// progressWriter routes go-git clone/fetch/pull progress into the log sink so
+// long-running network operations stream live status to the UI. It replaces
+// the previous Progress: os.Stdout, which wrote to the process stdout —
+// visible in a terminal, but invisible to the web UI and the daemon, leaving
+// the log stream silent for the entire clone/fetch.
+//
+// go-git emits a progress update per object, frequently as \r-separated
+// in-place updates (thousands of lines for a large clone). To keep the logs
+// table bounded, at most one line per second is emitted; the terminal "done"
+// line of each phase always passes so the stream ends on a meaningful state.
+//
+// Progress writes happen on the goroutine that runs the clone/fetch/pull
+// (the job goroutine, which ui.Bind has associated with the execution), so
+// ui.Printf forwards them through the sink into the DB.
+type progressWriter struct {
+	mu       sync.Mutex
+	buf      []byte
+	last     time.Time
+	interval time.Duration // emit throttle; zero means the 1s default
+}
+
+func (w *progressWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf = append(w.buf, p...)
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		j := bytes.IndexByte(w.buf, '\r')
+		var idx int
+		switch {
+		case i >= 0 && (j < 0 || i < j):
+			idx = i
+		case j >= 0:
+			idx = j
+		default:
+			// No complete segment yet — buffer the partial line and wait.
+			return len(p), nil
+		}
+		seg := strings.TrimSpace(string(w.buf[:idx]))
+		w.buf = w.buf[idx+1:]
+		if seg != "" {
+			w.emit(seg)
+		}
+	}
+}
+
+// emit throttles progress lines to one per interval (1s by default); a "done"
+// line always passes so the stream ends on a meaningful state.
+func (w *progressWriter) emit(line string) {
+	iv := w.interval
+	if iv == 0 {
+		iv = time.Second
+	}
+	now := time.Now()
+	if strings.Contains(line, "done") || now.Sub(w.last) >= iv {
+		ui.Printf("%s\n", line)
+		w.last = now
+	}
+}

--- a/internal/repository/progress_test.go
+++ b/internal/repository/progress_test.go
@@ -1,0 +1,92 @@
+package repository
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/ui"
+)
+
+// recSink captures messages forwarded through the ui sink, like the SSE log
+// stream does in production.
+type recSink struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (s *recSink) Log(executionID, jobName, level, message string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.msgs = append(s.msgs, message)
+	return nil
+}
+
+func (s *recSink) snapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.msgs))
+	copy(out, s.msgs)
+	return out
+}
+
+// TestProgressWriterForwardsToSink verifies the whole chain Fix 2 relies on:
+// progress bytes written through progressWriter reach the log sink (via
+// ui.Printf on the bound goroutine) as complete, trimmed lines, instead of
+// going to os.Stdout where the web UI never sees them.
+func TestProgressWriterForwardsToSink(t *testing.T) {
+	sink := &recSink{}
+	ui.SetSink(sink)
+	unbind := ui.Bind("exec-progress", "test-repo")
+	defer func() {
+		unbind()
+		ui.SetSink(nil)
+	}()
+
+	w := &progressWriter{}
+	// Simulated server progress: a \r-separated in-place update followed by
+	// \n-terminated lines, the last one being the "done" marker.
+	data := []byte("remote: Enumerating objects: 50%\rremote: Counting objects: 100% (287/287)\nremote: Counting objects: 100% (287/287), done.\n")
+	n, err := w.Write(data)
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+
+	got := sink.snapshot()
+	require.NotEmpty(t, got, "bound-goroutine progress must reach the sink")
+	for _, m := range got {
+		require.Contains(t, m, "remote:", "each emitted line is a complete, trimmed progress line")
+	}
+}
+
+// TestProgressWriterThrottlesAndPassesDone verifies the throttle: at most one
+// line per interval is emitted, except "done" lines which always pass — keeping
+// the logs table bounded during long clones.
+func TestProgressWriterThrottlesAndPassesDone(t *testing.T) {
+	sink := &recSink{}
+	ui.SetSink(sink)
+	unbind := ui.Bind("exec-progress", "test-repo")
+	defer func() {
+		unbind()
+		ui.SetSink(nil)
+	}()
+
+	// A huge throttle window so no real waiting is needed in the test.
+	w := &progressWriter{interval: time.Hour}
+
+	// A burst of \n-terminated lines within one Write call.
+	burst := []byte("remote: a\nremote: b\nremote: c\nremote: done.\n")
+	n, err := w.Write(burst)
+	require.NoError(t, err)
+	require.Equal(t, len(burst), n)
+	require.Equal(t, []string{"remote: a", "remote: done."}, sink.snapshot(),
+		"only the first burst line and the done line should be emitted")
+
+	// Reset the throttle window: the next line must pass again.
+	w.mu.Lock()
+	w.last = time.Time{}
+	w.mu.Unlock()
+	_, err = w.Write([]byte("remote: d\n"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"remote: a", "remote: done.", "remote: d"}, sink.snapshot())
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -154,12 +154,19 @@ func Sync(ctx context.Context, repo typedef.Repository, iswiki bool, storages []
 	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 
+	// Route git's own progress (server-side "Enumerating/Counting/Compressing
+	// objects" lines) into the log sink so a long clone/fetch streams live
+	// status to the UI instead of leaving it silent until the sync completes.
+	// One writer is shared across clone/fetch/pull so the throttle window is
+	// continuous for the whole sync.
+	progress := &progressWriter{}
+
 	// clone the repo if it does not exist, otherwise pull
 	if !exist {
 		isUpdated = true
 		_, err = git.PlainCloneContext(syncCtx, gitDir, false, &git.CloneOptions{
 			URL:      "https://" + gitUrl,
-			Progress: os.Stdout,
+			Progress: progress,
 			Depth:    depth,
 		})
 
@@ -187,7 +194,8 @@ func Sync(ctx context.Context, repo typedef.Repository, iswiki bool, storages []
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
-		Force: true,
+		Force:    true,
+		Progress: progress,
 	})
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		ui.Errorf("Error fetching remote branches, %s", err)
@@ -306,7 +314,8 @@ func Sync(ctx context.Context, repo typedef.Repository, iswiki bool, storages []
 				RemoteName:    "origin",
 				ReferenceName: branchRef,
 				// pull all commits, not only the latest
-				Depth: depth,
+				Depth:    depth,
+				Progress: progress,
 			})
 			if err == git.NoErrAlreadyUpToDate {
 				ui.Printf("local branch %s already up to date. \n", localBranchName)

--- a/internal/server/sse_live_test.go
+++ b/internal/server/sse_live_test.go
@@ -1,0 +1,170 @@
+package server_test
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/executor"
+	"github.com/wnarutou/gitrieve/internal/logger"
+	server "github.com/wnarutou/gitrieve/internal/server"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+)
+
+// TestSSELogStreamingDeliversIncrementally reproduces the reported symptom
+// ("only the start log shows, the rest appear only when the job completes")
+// through the complete pipeline: logger INSERT → SSE poll → EventSource body.
+//
+// Logs are inserted across several 1s SSE poll cycles; the job is then marked
+// completed so the stream ends with a "done" event and every surviving log row
+// is flushed. Arrival timestamps tell us whether rows stream in as they are
+// written (healthy), are batched until the stream ends (SSE/DB buffering bug),
+// or never arrive at all (silently dropped on write failure).
+func TestSSELogStreamingDeliversIncrementally(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "gitrieve.db")
+
+	testDB, err := db.Initialize(dbPath)
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{{Name: "test-repo", URL: "github.com/test/repo"}},
+	}
+	log := logger.NewLogger(testDB)
+	exec := executor.NewExecutor(log, testDB, cfg)
+	s := server.NewTestServerWithExecutor(testDB, exec)
+	httpSrv := httptest.NewServer(s)
+	defer httpSrv.Close()
+
+	const jobID = "job-live"
+	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, start_time, status) VALUES (?, ?, ?, ?)`,
+		jobID, "test-repo", time.Now(), "running")
+	require.NoError(t, err)
+
+	// First log is already present before the stream opens.
+	require.NoError(t, log.Log(jobID, "test-repo", "info", "log-1"))
+
+	// Producer inserts logs spread across several SSE poll cycles, then marks
+	// the job completed so the stream ends with "done".
+	type step struct {
+		at time.Duration
+		fn func()
+	}
+	steps := []step{
+		{at: 300 * time.Millisecond, fn: func() { _ = log.Log(jobID, "test-repo", "info", "log-2") }},
+		{at: 900 * time.Millisecond, fn: func() { _ = log.Log(jobID, "test-repo", "info", "log-3") }},
+		{at: 1500 * time.Millisecond, fn: func() { _ = log.Log(jobID, "test-repo", "info", "log-4") }},
+		{at: 2300 * time.Millisecond, fn: func() {
+			_, _ = testDB.Exec(`UPDATE executions SET status='completed', end_time=? WHERE id=?`, time.Now(), jobID)
+		}},
+	}
+
+	// Reader: connect and record arrival time of every data line / done event.
+	type rec struct {
+		at  time.Duration
+		raw string
+	}
+	var mu sync.Mutex
+	var lines []rec
+	gotDone := false
+	var gotDoneAt time.Duration
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		resp, err := http.Get(httpSrv.URL + "/api/jobs/" + jobID + "/logs")
+		if err != nil {
+			t.Errorf("SSE connect: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		scanner := bufio.NewScanner(resp.Body)
+		start := time.Now()
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "data:"):
+				mu.Lock()
+				lines = append(lines, rec{at: time.Since(start), raw: strings.TrimSpace(line[len("data:"):])})
+				mu.Unlock()
+			case line == "event: done":
+				mu.Lock()
+				gotDone = true
+				gotDoneAt = time.Since(start)
+				mu.Unlock()
+			}
+		}
+	}()
+
+	// Run the producer steps on a schedule.
+	go func() {
+		for _, st := range steps {
+			time.Sleep(st.at)
+			st.fn()
+		}
+	}()
+
+	// The stream should end when the job is completed + done is flushed. Guard
+	// against a silent deadlock so this fails fast instead of hanging.
+	select {
+	case <-readerDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("SSE stream did not end after 10s — possible deadlock")
+	}
+
+	// Ground truth: which rows actually reached the logs table?
+	ground := map[string]bool{}
+	if rows, err := testDB.Query(`SELECT message FROM logs WHERE execution_id = ?`, jobID); err == nil {
+		for rows.Next() {
+			var m string
+			if rows.Scan(&m) == nil {
+				ground[m] = true
+			}
+		}
+		rows.Close()
+	}
+	t.Logf("rows in logs table: %v", ground)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(t, gotDone, "expected a done event to end the stream")
+
+	// Map message -> earliest arrival, extracting the message from each data line.
+	arrival := map[string]time.Duration{}
+	for _, l := range lines {
+		var entry server.LogEntry
+		if err := json.Unmarshal([]byte(l.raw), &entry); err != nil {
+			continue
+		}
+		if _, ok := arrival[entry.Message]; !ok {
+			arrival[entry.Message] = l.at
+		}
+	}
+
+	t.Logf("done event at %v", gotDoneAt)
+	for _, name := range []string{"log-1", "log-2", "log-3", "log-4"} {
+		if arr, ok := arrival[name]; ok {
+			t.Logf("%s arrived at %v", name, arr)
+		} else {
+			t.Errorf("log %q never arrived (dropped on write or never flushed)", name)
+		}
+	}
+
+	// The bug: every log after the first arrives only at the end, i.e. at (or
+	// near) the done event. In a healthy stream log-2 (inserted at 300ms) must
+	// be delivered on an earlier poll than the terminal flush.
+	if arr2, ok := arrival["log-2"]; ok && gotDone {
+		if arr2 >= gotDoneAt-time.Millisecond {
+			t.Errorf("log-2 only arrived at the end (%v, done at %v) — logs are buffered until job completion", arr2, gotDoneAt)
+		}
+	}
+}

--- a/internal/server/sse_scan_test.go
+++ b/internal/server/sse_scan_test.go
@@ -1,0 +1,46 @@
+package server_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/logger"
+	server "github.com/wnarutou/gitrieve/internal/server"
+)
+
+// TestLogScanAfterInsert verifies that a log row committed via the logger is
+// readable and scannable by the exact query the SSE handler runs. If the
+// modernc driver cannot scan the stored DATETIME into time.Time, every SSE
+// poll silently aborts (rows.Scan error → return true) and no logs are ever
+// streamed.
+func TestLogScanAfterInsert(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "gitrieve.db")
+	testDB, err := db.Initialize(dbPath)
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	log := logger.NewLogger(testDB)
+	require.NoError(t, log.Log("job-scan", "test-repo", "info", "hello-world"))
+
+	rows, err := testDB.Query(
+		"SELECT id, execution_id, timestamp, level, message FROM logs WHERE execution_id = ? AND id > 0 ORDER BY id ASC",
+		"job-scan")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		count++
+		var entry server.LogEntry
+		err := rows.Scan(&entry.ID, &entry.ExecutionID, &entry.Timestamp, &entry.Level, &entry.Message)
+		t.Logf("scan err=%v entry=%+v", err, entry)
+		require.NoError(t, err)
+		require.Equal(t, "hello-world", entry.Message)
+		require.False(t, entry.Timestamp.IsZero())
+	}
+	require.Equal(t, 1, count)
+	_ = time.Now()
+}


### PR DESCRIPTION
## Problem

When executing a repository from the web UI, the log pane showed only the start log ("开始执行的日志") and then nothing until the entire run finished, at which point all logs appeared at once — real-time log output did not work.

## Root cause

Two independent defects left the log stream silent during a run:

1. **git progress bypassed the log system entirely.** `git.PlainCloneContext` wrote progress to `os.Stdout` (invisible to the web UI and daemon), and `FetchContext`/`PullContext` passed no `Progress` at all. For a large repo the clone/fetch phase — often minutes — produced zero log rows.

2. **Log INSERTs were silently dropped under concurrency.** File-backed SQLite ran with the default rollback journal and no `busy_timeout`. The SSE log-stream reader and the job goroutines writing log lines collided, and a write failed with `database is locked (SQLITE_BUSY)` — an error `internal/ui` swallowed (`_ = s.Log(...)`), dropping the line.

## Fix

- **`internal/db/db.go`** — file-backed DBs now open with `?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)`. WAL lets the SSE reader run concurrently with log writers (each sees the last committed snapshot); `busy_timeout` makes a colliding writer wait instead of failing. `:memory:` is unchanged.
- **`internal/repository/progress.go`** (new) — a throttled `progressWriter` forwards go-git clone/fetch/pull progress through `ui.Printf` into the log sink, so long network phases stream live status. One line per second (the "done" line always passes) keeps the logs table bounded.
- **`internal/repository/repository.go`** — the clone/fetch/pull options now route through the shared `progressWriter`.

## Verification

New regression tests (kept in this PR):

- `internal/server/sse_live_test.go` — end-to-end streaming test. Timing shows each log arriving on its own ~1s poll cycle *while the job runs*, well before the terminal `done` event (previously these inserts failed with `SQLITE_BUSY`).
- `internal/server/sse_scan_test.go` — committed log rows scan back into `server.LogEntry`.
- `internal/db/db_test.go` — asserts `PRAGMA journal_mode` = `wal` and `busy_timeout` = 5000 for file DBs.
- `internal/repository/progress_test.go` — progress reaches the sink on the bound goroutine, and the throttle/done-pass behavior.

`go test ./...` passes for the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
