### PR TITLE
feat: repository identity refactor — URL as primary key

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -48,6 +48,11 @@ func (s *Server) setupRoutes(cfg *config.Config) {
 		ui.ErrorfExit("Failed to initialize database: %s", err)
 	}
 
+	// 迁移旧库（新增 repo_key 列）。失败宁可起不来，也不在坏 schema 上跑。
+	if err := db.Migrate(database); err != nil {
+		ui.ErrorfExit("Failed to migrate database: %s", err)
+	}
+
 	// Initialize logger
 	log := logger.NewLogger(database)
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -97,8 +97,11 @@ func (s *Server) setupRoutes(cfg *config.Config) {
 	apiGroup.GET("/api/jobs/:id/logs", api.GetJobLogs)
 	apiGroup.GET("/api/repositories", api.GetRepositories)
 	apiGroup.POST("/api/repositories", api.CreateRepository)
-	apiGroup.PUT("/api/repositories/:id", api.UpdateRepository)
-	apiGroup.DELETE("/api/repositories/:id", api.DeleteRepository)
+	// *id catch-all: the identity key is a URL like github.com/owner/repo and
+	// contains "/", so a single-segment :id param cannot match it. gin prefixes
+	// the captured value with "/" (trimmed inside the handlers).
+	apiGroup.PUT("/api/repositories/*id", api.UpdateRepository)
+	apiGroup.DELETE("/api/repositories/*id", api.DeleteRepository)
 	apiGroup.GET("/api/storage", api.GetStorages)
 	apiGroup.POST("/api/storage", api.CreateStorage)
 	apiGroup.PUT("/api/storage/:id", api.UpdateStorage)

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,26 +58,26 @@ POST /api/jobs
 
 ```json
 {
-  "repository": "gitrieve"
+  "repository_key": "github.com/wnarutou/gitrieve"
 }
 ```
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `repository` | string | yes | The `name` of a repository defined in `config.yaml` |
+| `repository_key` | string | yes | The repository identity key — the normalized URL (e.g. `github.com/wnarutou/gitrieve`) of a repository defined in `config.yaml`. For `user`/`org` entries, use the synthesized `https://github.com/<orgName>` (server normalizes it). A bare display name is not accepted. |
 
 **Response `data`**
 
 ```json
 {
-  "job_id": "1719800000",
+  "job_ids": ["1719800000", "1719800001"],
   "status": "running"
 }
 ```
 
 | Field | Type | Description |
 |---|---|---|
-| `job_id` | string | Job identifier; pass to logs/cancel endpoints |
+| `job_ids` | array of string | One job identifier per expanded repository; pass each to the logs/cancel endpoints. A `repo`-type entry yields a single ID; a `user`/`org` entry yields one ID per concrete member repository |
 | `status` | string | Initial status, one of `pending` \| `running` \| `completed` \| `failed` \| `cancelled` |
 
 **Example**
@@ -85,7 +85,7 @@ POST /api/jobs
 ```bash
 curl -X POST http://localhost:8080/api/jobs \
   -H "Content-Type: application/json" \
-  -d '{"repository": "gitrieve"}'
+  -d '{"repository_key": "github.com/wnarutou/gitrieve"}'
 ```
 
 **Status codes**
@@ -111,7 +111,7 @@ DELETE /api/jobs/:id
 
 | Name | Description |
 |---|---|
-| `id` | The `job_id` returned by `POST /api/jobs` |
+| `id` | A job identifier from the `job_ids` array returned by `POST /api/jobs` |
 
 **Response `data`**
 
@@ -152,7 +152,7 @@ GET /api/jobs
 | `page` | int | `1` | Page number (1-based) |
 | `limit` | int | `20` | Items per page; clamped to `1`–`100` |
 | `status` | string | — | Filter by status; `all` (or omitted) returns all statuses |
-| `repository` | string | — | Fuzzy (partial) match on repository name, case-insensitive for ASCII (SQL `LIKE '%value%'`; `%`, `_`, and `\` in the value are matched literally) |
+| `repository` | string | — | Fuzzy (partial) match on repository **name or URL**, case-insensitive for ASCII. A URL term is normalized server-side (e.g. `https://github.com/wnarutou/gitrieve.git` matches the stored key `github.com/wnarutou/gitrieve`) (SQL `LIKE '%value%'`; `%`, `_`, and `\` in the value are matched literally) |
 
 **Response `data`**
 
@@ -199,8 +199,11 @@ curl http://localhost:8080/api/jobs
 # Failed jobs only, page 2
 curl "http://localhost:8080/api/jobs?status=failed&page=2&limit=50"
 
-# Jobs whose repository name contains "gitrieve" (fuzzy match)
+# Jobs whose repository name or URL contains "gitrieve" (fuzzy match)
 curl "http://localhost:8080/api/jobs?repository=gitrieve"
+
+# Match by URL (term is normalized server-side)
+curl "http://localhost:8080/api/jobs?repository=github.com/wnarutou/gitrieve"
 ```
 
 **Status codes**
@@ -279,11 +282,11 @@ es.onerror = () => es.close(); // stream ended by server or network
 
 ## Repositories
 
-Repositories are read from and written back to `config.yaml`. The `:id` path parameter is the repository **name** (not a numeric ID), because names are the unique key in the config.
+Repositories are read from and written back to `config.yaml`. The `:id` path parameter is the repository **identity key** — the normalized URL (e.g. `github.com/wnarutou/gitrieve`) — not the name. Because the identity key contains slashes, the route is registered as a gin catch-all. Names are display labels and may repeat; the normalized URL is the unique key in the config.
 
 ### List repositories
 
-List repositories from `config.yaml` (see [Configuration](../README.md#configuration)) with per-repository execution stats, pagination, and an optional fuzzy name filter.
+List repositories from `config.yaml` (see [Configuration](../README.md#configuration)) with per-repository execution stats, pagination, and an optional fuzzy name-or-URL filter.
 
 ```
 GET /api/repositories
@@ -295,7 +298,7 @@ GET /api/repositories
 |---|---|---|---|
 | `page` | int | `1` | Page number (1-based) |
 | `limit` | int | `20` | Items per page; clamped to `1`–`100` |
-| `search` | string | — | Fuzzy (partial) match on repository name, case-insensitive for ASCII |
+| `search` | string | — | Fuzzy (partial) match on repository **name or URL**, case-insensitive for ASCII |
 
 **Response `data`** — a paginated object (not a bare array). Each item embeds the repository fields (PascalCase, matching the `repository:` config entries) plus lower-cased execution stats.
 
@@ -332,7 +335,7 @@ GET /api/repositories
 | Field | Type | Description |
 |---|---|---|
 | `repositories[]` | object | A repository from config plus its per-run stats |
-| `repositories[].Name` | string | Repository name (the unique key) |
+| `repositories[].Name` | string | Repository display name (identity is the URL) |
 | `repositories[].URL` | string | Repository URL |
 | `repositories[].Cron` | string | Cron schedule, empty if none |
 | `repositories[].Storage` | array of string | Storage backend names |
@@ -355,8 +358,11 @@ Other embedded repository fields (`UseCache`, `AllBranches`, `Depth`, `DownloadR
 # All repositories, first page with the default limit
 curl http://localhost:8080/api/repositories
 
-# Fuzzy name search
+# Fuzzy name or URL search
 curl "http://localhost:8080/api/repositories?search=gitr"
+
+# URL terms match too
+curl "http://localhost:8080/api/repositories?search=github.com/wnarutou"
 
 # Page 2 with a custom limit
 curl "http://localhost:8080/api/repositories?page=2&limit=50"
@@ -395,14 +401,22 @@ POST /api/repositories
 }
 ```
 
+Identity is the URL. A `repo`-type entry must supply a `url`; a `user`/`org` entry may omit `url` and set `orgName` instead — an empty URL is auto-synthesized to `https://github.com/<orgName>`. An entry with no identity (empty URL and no `orgName`) is rejected with `400`. Names may repeat: duplicate detection compares the normalized URL, and a conflicting URL returns `409`.
+
 **Response `data`** — the created repository object.
 
 **Example**
 
 ```bash
+# repo-type entry with a URL
 curl -X POST http://localhost:8080/api/repositories \
   -H "Content-Type: application/json" \
   -d '{"name":"gitrieve","url":"github.com/wnarutou/gitrieve","storage":["localFile"],"useCache":true}'
+
+# org entry with no URL — the server synthesizes https://github.com/acme
+curl -X POST http://localhost:8080/api/repositories \
+  -H "Content-Type: application/json" \
+  -d '{"name":"acme","type":"org","orgName":"acme"}'
 ```
 
 **Status codes**
@@ -410,8 +424,8 @@ curl -X POST http://localhost:8080/api/repositories \
 | Code | Meaning |
 |---|---|
 | 200 | Repository added |
-| 400 | Invalid body or missing `name` |
-| 409 | A repository with that name already exists |
+| 400 | Invalid body, missing `name`, or no identity (empty URL for `repo` type; empty `orgName` for `user`/`org` type) |
+| 409 | A repository with that URL already exists (identity is the URL; names may repeat) |
 
 ---
 
@@ -427,7 +441,7 @@ PUT /api/repositories/:id
 
 | Name | Description |
 |---|---|
-| `id` | Repository `name` |
+| `id` | Repository identity key — the normalized URL (contains slashes; the route is a gin catch-all) |
 
 **Request body** — any subset of repository fields.
 
@@ -443,7 +457,7 @@ PUT /api/repositories/:id
 **Example**
 
 ```bash
-curl -X PUT http://localhost:8080/api/repositories/gitrieve \
+curl -X PUT http://localhost:8080/api/repositories/github.com/wnarutou/gitrieve \
   -H "Content-Type: application/json" \
   -d '{"cron":"0 */6 * * *"}'
 ```
@@ -455,6 +469,7 @@ curl -X PUT http://localhost:8080/api/repositories/gitrieve \
 | 200 | Repository updated |
 | 400 | Invalid body |
 | 404 | Repository not found |
+| 409 | The updated URL conflicts with another repository (identity is the URL) |
 | 500 | Failed to merge fields |
 
 ---
@@ -469,7 +484,7 @@ DELETE /api/repositories/:id
 
 | Name | Description |
 |---|---|
-| `id` | Repository `name` |
+| `id` | Repository identity key — the normalized URL (contains slashes; the route is a gin catch-all) |
 
 **Response `data`**
 
@@ -482,7 +497,7 @@ DELETE /api/repositories/:id
 **Example**
 
 ```bash
-curl -X DELETE http://localhost:8080/api/repositories/gitrieve
+curl -X DELETE http://localhost:8080/api/repositories/github.com/wnarutou/gitrieve
 ```
 
 **Status codes**

--- a/docs/superpowers/plans/2026-08-19-repo-identity-refactor.md
+++ b/docs/superpowers/plans/2026-08-19-repo-identity-refactor.md
@@ -1,0 +1,1462 @@
+# 仓库身份重构（URL 为主键）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把仓库身份从 `name` 重构为规范化 URL（`repo_key`），贯穿 DB → executor → API → 前端，使 URL 成为唯一判等口径，为子项目 B「配置导入导出」奠基。
+
+**Architecture:** 在 `typedef` 引入身份原语（`NormalizeURL` / `EffectiveURL` / `Key` / `Matches`）作为唯一判等口径；`executions` 新增 `repo_key` 列（保留 `job_name` 作为展示快照）；executor 按 `Matches` 定位、org/user 经 `repository.Expand` 在任务内展开为具体仓库逐条记账；server API 的创建/查询/CRUD 全部按身份键；前端把操作按钮的编码从 name 换成 URL。`cmd/daemon` 只做日志、无身份逻辑，不动。
+
+**Tech Stack:** Go 1.x, gin-gonic, modernc.org/sqlite（纯 Go 驱动）, viper, go-git, testify。
+
+## Global Constraints
+
+- **主键 = 规范化 URL**；**空 URL 即非法**：创建（400）、更新（400）、启动配置校验（`ui.ErrorfExit`）一律拒绝；无 `name:` 兜底。
+- **name 允许重复、允许改名**，仅用于展示与查询；删除按 name 判重的 409。
+- **不做历史数据回填**：`executions` 只新增 `repo_key` 列，旧行键保持 `''`（纯历史显示）。
+- **org/user 条目**：URL 为空时按 `orgName` 合成 `https://github.com/<orgName>` 并**写回条目**（config 存合成后的完整 URL）。
+- **执行/记账粒度**：运行 org/user 时任务内展开成具体仓库，每个具体仓库一条 execution；org 统计 = URL **路径边界前缀**聚合（`entry.Key()+"/"` 前缀，避免 `wnarutou` 误吞 `wnarutou2/x`）。
+- **URL 修改 = 身份变更**：允许改；旧 `repo_key` 历史保持原样、不再被新键关联；更新后与其他仓库 URL 冲突 → 409（不与自身比较）。
+- **查询**：任务过滤与仓库搜索均支持 name + URL 模糊匹配；`GetJobs` 的 URL 搜索词先 `NormalizeURL` 再包 `%`。
+- **API 破坏性变更**：`POST /api/jobs` 请求字段 `repository` → `repository_key`，响应 `job_id` → `job_ids`（数组）；仓库 `PUT/DELETE /api/repositories/:id` 的 `:id` 语义变为身份键。
+- **保留** `GetRepositories` 聚合 SQL 的 `GROUP BY xxx HAVING start_time = MAX(start_time)` 写法，以及「只有声明为 DATETIME 的列才能 scan 成 `time.Time`」的驱动约束（不能对聚合表达式 `MAX(start_time)` 做 scan）。
+- **明确不做**：`cmd/daemon` 行为改动；前端 JS 做 URL 规范化（以后端为准）；配置导入导出（子项目 B）。
+
+---
+
+### Task 1: typedef 身份原语（key.go）+ 启动配置校验
+
+**Files:**
+- Create: `internal/typedef/key.go`
+- Test: `internal/typedef/key_test.go`
+- Modify: `internal/typedef/repository.go`（无改动，仅确认 `GetType` 存在）
+- Modify: `internal/config/config.go:59` 之后追加空 URL 启动校验
+- Test: `internal/config/config_test.go` 追加校验用例
+
+**Interfaces:**
+- Produces（后续任务全部依赖）:
+  - `func NormalizeURL(raw string) string` — 规范化 URL 形态 `host/owner/repo`，空输入返回 `""`
+  - `func (r *Repository) EffectiveURL() string` — URL 非空直接用；user/org 且 URL 为空、orgName 非空时合成 `https://github.com/<orgName>`；否则 `r.URL`
+  - `func (r *Repository) Key() string` — `NormalizeURL(r.EffectiveURL())`
+  - `func (r *Repository) Matches(input string) bool` — 输入规范化后与 `Key()` 判等；`Key()` 为空或输入为空返回 false
+
+- [ ] **Step 1: 写失败测试** `internal/typedef/key_test.go`
+
+```go
+package typedef
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"github.com/wnarutou/gitrieve", "github.com/wnarutou/gitrieve"},
+		{"https://GITHUB.com/wnarutou/gitrieve/", "github.com/wnarutou/gitrieve"},
+		{"http://github.com/wnarutou/gitrieve.git", "github.com/wnarutou/gitrieve"},
+		{"https://www.github.com/wnarutou/gitrieve", "github.com/wnarutou/gitrieve"},
+		{"www.github.com/wnarutou/gitrieve", "github.com/wnarutou/gitrieve"},
+		{"https://github.com/wnarutou/gitrieve#readme", "github.com/wnarutou/gitrieve"},
+		{"https://gitlab.com/Wnarutou/proj.git/", "gitlab.com/wnarutou/proj"},
+		{"HTTPS://GitHub.com/Foo/Bar.Git", "github.com/foo/bar"},
+		{"   https://github.com/foo/bar  ", "github.com/foo/bar"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, NormalizeURL(c.in), "NormalizeURL(%q)", c.in)
+	}
+}
+
+func TestEffectiveURL(t *testing.T) {
+	cases := []struct {
+		repo Repository
+		want string
+	}{
+		{Repository{Type: TypeRepo, URL: "github.com/a/b"}, "github.com/a/b"},
+		{Repository{Type: TypeOrg, OrgName: "acme"}, "https://github.com/acme"},
+		{Repository{Type: TypeUser, OrgName: "alice"}, "https://github.com/alice"},
+		// 显式 URL 优先于合成
+		{Repository{Type: TypeOrg, URL: "gitlab.com/acme/org", OrgName: "acme"}, "gitlab.com/acme/org"},
+		// orgName 为空 → 无有效 URL
+		{Repository{Type: TypeOrg}, ""},
+		// 非 user/org 且无 URL → 无有效 URL
+		{Repository{Type: TypeRepo}, ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.repo.EffectiveURL(), "EffectiveURL(%+v)", c.repo)
+	}
+}
+
+func TestKeyAndMatches(t *testing.T) {
+	repo := Repository{Name: "x", URL: "https://GitHub.com/Foo/Bar.git"}
+	assert.Equal(t, "github.com/foo/bar", repo.Key())
+
+	assert.True(t, repo.Matches("github.com/foo/bar"))
+	assert.True(t, repo.Matches("https://github.com/foo/bar"))
+	assert.True(t, repo.Matches("HTTPS://GITHUB.COM/FOO/BAR.GIT"))
+	assert.True(t, repo.Matches("github.com/foo/bar/"))
+	assert.False(t, repo.Matches("github.com/other/bar"))
+	assert.False(t, repo.Matches(""))
+
+	// 空身份条目谁也不匹配
+	empty := Repository{Name: "orphan"}
+	assert.Equal(t, "", empty.Key())
+	assert.False(t, empty.Matches("github.com/foo/bar"))
+	assert.False(t, empty.Matches(""))
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./internal/typedef/ -run 'TestNormalizeURL|TestEffectiveURL|TestKeyAndMatches'`
+Expected: FAIL — `undefined: NormalizeURL` / `undefined: EffectiveURL` 等编译错误。
+
+- [ ] **Step 3: 实现** `internal/typedef/key.go`
+
+```go
+package typedef
+
+import (
+	"strings"
+)
+
+// NormalizeURL 归一化仓库 URL，产出无协议、小写、无 www、无尾斜杠、无 .git 的
+// 规范形态 "host/owner/repo"。处理顺序：去空白 → 去 #fragment → 小写 →
+// 去 http(s):// → 去 www. → 去尾斜杠 → 去 .git。返回 "" 表示没有可用 URL。
+func NormalizeURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexByte(s, '#'); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.ToLower(s)
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "www.")
+	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	return s
+}
+
+// EffectiveURL 返回条目的有效 URL：URL 非空直接用；type 为 user/org 且 URL 为
+// 空、orgName 非空时合成 "https://github.com/<orgName>"；否则返回 r.URL（可能
+// 为空，即非法）。
+func (r *Repository) EffectiveURL() string {
+	if (r.GetType() == TypeUser || r.GetType() == TypeOrg) &&
+		strings.TrimSpace(r.URL) == "" && r.OrgName != "" {
+		return "https://github.com/" + r.OrgName
+	}
+	return r.URL
+}
+
+// Key 返回仓库身份键 = NormalizeURL(EffectiveURL())。空 URL 会得到 ""，
+// 调用方（创建/更新/启动校验）必须拒绝。
+func (r *Repository) Key() string {
+	return NormalizeURL(r.EffectiveURL())
+}
+
+// Matches 判断一段用户输入是否命中该仓库：输入被规范化后与 Key() 比较。
+// Key() 为空（无身份）或输入为空时返回 false。
+func (r *Repository) Matches(input string) bool {
+	key := r.Key()
+	if key == "" {
+		return false
+	}
+	return NormalizeURL(input) == key
+}
+```
+
+- [ ] **Step 4: 运行 typedef 测试确认通过**
+
+Run: `go test ./internal/typedef/`
+Expected: PASS。
+
+- [ ] **Step 5: 加 `validateIdentity` 校验函数并在 `Init` 末尾调用**（`internal/config/config.go`）
+
+在 `Save` 函数前新增：
+
+```go
+// validateIdentity ensures every repository entry has a usable identity (a
+// non-empty URL, or orgName for user/org types). The repository identity is the
+// normalized URL; an entry without one can never be matched or executed.
+// Returns an error rather than exiting so it is unit-testable; Init surfaces
+// it via ui.ErrorfExit.
+func validateIdentity(cfg *Config) error {
+	for _, repo := range cfg.Repository {
+		if repo.Key() == "" {
+			return fmt.Errorf("repository %q (type %q) has an empty URL and no orgName; every repository needs a URL identity",
+				repo.Name, repo.GetType())
+		}
+	}
+	return nil
+}
+```
+
+`Init` 末尾（第 59 行 `}` 之后、`Init` 结束前）：
+
+```go
+	// 启动校验：每个仓库条目都必须有可用身份。身份键为空意味着永远无法被
+	// 匹配或执行，直接拒绝启动。
+	if err := validateIdentity(ins); err != nil {
+		ui.ErrorfExit("Invalid configuration: %s", err)
+	}
+```
+
+（注意：`ui.ErrorfExit` 调用 `os.Exit(1)` 而非 panic，因此测试必须针对 `validateIdentity` 本身，不能 `require.Panics` 包 `Init`。）
+
+- [ ] **Step 6: 追加 config 校验测试**（`internal/config/config_test.go` 末尾追加；import 增加 `github.com/wnarutou/gitrieve/internal/typedef`）
+
+```go
+func TestValidateIdentity(t *testing.T) {
+	// 非 user/org 且无 URL → 校验拒绝。
+	err := validateIdentity(&Config{Repository: []typedef.Repository{
+		{Name: "orphan", Type: typedef.TypeRepo},
+	}})
+	require.Error(t, err)
+
+	// user/org 且带 orgName → 通过；合成 URL 即为身份。
+	acme := Config{Repository: []typedef.Repository{
+		{Name: "acme", Type: typedef.TypeOrg, OrgName: "acme"},
+	}}
+	require.NoError(t, validateIdentity(&acme))
+	require.Equal(t, "https://github.com/acme", acme.Repository[0].EffectiveURL())
+
+	// 空仓库列表 → 通过。
+	require.NoError(t, validateIdentity(&Config{}))
+}
+```
+
+- [ ] **Step 7: 运行 config 测试确认通过**
+
+Run: `go test ./internal/config/`
+Expected: PASS。（现有用例的配置均不含 `repository:` 段，`ins.Repository` 为 nil，遍历空切片，不受影响。）
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add internal/typedef/key.go internal/typedef/key_test.go internal/config/config.go internal/config/config_test.go
+git commit -m "feat(typedef): repository identity as normalized URL (Key/Matches) + startup validation"
+```
+
+---
+
+### Task 2: DB 层 —— executions 增加 repo_key 列 + Migrate + server 接线
+
+**Files:**
+- Modify: `internal/db/db.go:44-52`（CREATE TABLE 加 `repo_key` 列）
+- Create: `internal/db/migrate.go`
+- Test: `internal/db/migrations_test.go`（追加 Migrate 用例）
+- Modify: `cmd/server/server.go:46-49`（`db.Initialize` 之后调用 `db.Migrate`）
+
+**Interfaces:**
+- Consumes: 无
+- Produces:
+  - `func Migrate(d *DB) error` — 幂等：`PRAGMA table_info(executions)` 缺 `repo_key` 列时 `ALTER TABLE ... ADD COLUMN repo_key TEXT NOT NULL DEFAULT ''`；**不做数据回填**
+  - `executions.repo_key TEXT NOT NULL DEFAULT ''`
+
+- [ ] **Step 1: 写失败测试**（追加到 `internal/db/migrations_test.go`）
+
+```go
+// TestMigrateAddsRepoKeyColumn verifies Migrate upgrades a legacy executions
+// table (no repo_key) in place without backfilling, and that new rows can
+// write repo_key.
+func TestMigrateAddsRepoKeyColumn(t *testing.T) {
+	testDB, err := Initialize(":memory:")
+	assert.NoError(t, err)
+	defer testDB.Close()
+
+	// Rebuild executions in the pre-migration shape (no repo_key).
+	_, err = testDB.Exec(`DROP TABLE executions`)
+	assert.NoError(t, err)
+	_, err = testDB.Exec(`
+		CREATE TABLE executions (
+			id TEXT PRIMARY KEY,
+			job_name TEXT NOT NULL,
+			start_time DATETIME NOT NULL,
+			end_time DATETIME,
+			status TEXT NOT NULL,
+			error_message TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`)
+	assert.NoError(t, err)
+
+	// A pre-existing legacy row.
+	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, start_time, status) VALUES (?, ?, ?, ?)`,
+		"old", "repo-a", time.Now(), "completed")
+	assert.NoError(t, err)
+
+	assert.NoError(t, Migrate(testDB))
+
+	// Column now exists; legacy row's key stays empty (no backfill).
+	var key string
+	err = testDB.QueryRow(`SELECT repo_key FROM executions WHERE id = 'old'`).Scan(&key)
+	assert.NoError(t, err)
+	assert.Equal(t, "", key)
+
+	// New rows can write repo_key.
+	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, status) VALUES (?, ?, ?, ?, ?)`,
+		"new", "repo-b", "github.com/b/b", time.Now(), "running")
+	assert.NoError(t, err)
+}
+
+// TestMigrateIsIdempotent verifies Migrate on a fresh (already current) DB is a no-op.
+func TestMigrateIsIdempotent(t *testing.T) {
+	testDB, err := Initialize(":memory:")
+	assert.NoError(t, err)
+	defer testDB.Close()
+
+	assert.NoError(t, Migrate(testDB))
+	assert.NoError(t, Migrate(testDB))
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./internal/db/ -run 'TestMigrate'`
+Expected: FAIL — `undefined: Migrate`。
+
+- [ ] **Step 3: 实现** `internal/db/migrate.go`
+
+```go
+package db
+
+import "fmt"
+
+// Migrate upgrades an existing database to the current schema. Additive-only:
+// it adds the repo_key column to executions when missing and never backfills or
+// drops data. Call once at server startup (after Initialize).
+func Migrate(d *DB) error {
+	has, err := columnExists(d, "executions", "repo_key")
+	if err != nil {
+		return fmt.Errorf("check executions.repo_key: %w", err)
+	}
+	if !has {
+		if _, err := d.Exec(`ALTER TABLE executions ADD COLUMN repo_key TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add executions.repo_key: %w", err)
+		}
+	}
+	return nil
+}
+
+// columnExists reports whether table has a column named column.
+func columnExists(d *DB, table, column string) (bool, error) {
+	rows, err := d.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid, notnull, pk int
+			name, ctype      string
+			dflt             *string
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+```
+
+- [ ] **Step 4: 在 CREATE TABLE 中带上新列**（`internal/db/db.go`，`job_name` 行后加一行）
+
+```go
+			job_name TEXT NOT NULL,
+			repo_key TEXT NOT NULL DEFAULT '',
+```
+
+- [ ] **Step 5: 运行 db 测试确认通过**
+
+Run: `go test ./internal/db/`
+Expected: PASS（含新增两个用例）。
+
+- [ ] **Step 6: 接线到 server 启动**（`cmd/server/server.go`，`db.Initialize` 成功之后）
+
+```go
+	// 迁移旧库（新增 repo_key 列）。失败宁可起不来，也不在坏 schema 上跑。
+	if err := db.Migrate(database); err != nil {
+		ui.ErrorfExit("Failed to migrate database: %s", err)
+	}
+```
+
+- [ ] **Step 7: 构建确认**
+
+Run: `go build ./...`
+Expected: 成功。
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add internal/db/db.go internal/db/migrate.go internal/db/migrations_test.go cmd/server/server.go
+git commit -m "feat(db): executions.repo_key column + additive Migrate wired at server startup"
+```
+
+---
+
+### Task 3: repository.Expand（导出 addRepo）+ GetRepositories 支持按 name 或 URL 匹配
+
+**Files:**
+- Modify: `internal/repository/repository.go:23-76`
+- Test: `internal/repository/expand_test.go`（新增，白盒 `package repository`，mock 掉 GitHub 客户端）
+
+**Interfaces:**
+- Consumes: `typedef.Repository.Key()` / `.Matches()`（Task 1）
+- Produces:
+  - `func Expand(repo typedef.Repository) []typedef.Repository` — type=repo 原样返回；user/org 经 GitHub API 展开为具体仓库（每个都带继承的 cron/storage/useCache 等）；非法类型返回空切片
+  - `type repoLister interface { GetRepos(name, accountType string) ([]string, error) }`
+  - `var newGithubClient = func() (repoLister, error)`（测试可替换的包级 seam）
+  - `repository.GetRepositories(query)` 的过滤改为 `repo.Name == query || repo.Matches(query)`
+
+- [ ] **Step 1: 写失败测试** `internal/repository/expand_test.go`
+
+```go
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+)
+
+type fakeRepoLister struct {
+	repos []string
+	err   error
+}
+
+func (f *fakeRepoLister) GetRepos(name, accountType string) ([]string, error) {
+	return f.repos, f.err
+}
+
+func TestExpand(t *testing.T) {
+	old := newGithubClient
+	t.Cleanup(func() { newGithubClient = old })
+	newGithubClient = func() (repoLister, error) {
+		return &fakeRepoLister{repos: []string{"github.com/acme/alpha", "github.com/acme/beta"}}, nil
+	}
+
+	t.Run("repo passthrough", func(t *testing.T) {
+		repo := typedef.Repository{Name: "solo", URL: "github.com/a/solo", Type: typedef.TypeRepo}
+		got := Expand(repo)
+		require.Len(t, got, 1)
+		assert.Equal(t, "solo", got[0].Name)
+		assert.Equal(t, "github.com/a/solo", got[0].URL)
+	})
+
+	t.Run("org expands to concrete repos inheriting options", func(t *testing.T) {
+		org := typedef.Repository{
+			Name: "acme", Type: typedef.TypeOrg, OrgName: "acme",
+			Cron: "0 2 * * *", AllBranches: true,
+		}
+		got := Expand(org)
+		require.Len(t, got, 2)
+		assert.Equal(t, "alpha", got[0].Name)
+		assert.Equal(t, "github.com/acme/alpha", got[0].URL)
+		assert.Equal(t, typedef.TypeRepo, got[0].GetType())
+		assert.Equal(t, "0 2 * * *", got[0].Cron) // 继承父条目配置
+		assert.True(t, got[0].AllBranches)
+		assert.Equal(t, "beta", got[1].Name)
+	})
+
+	t.Run("invalid type yields nothing", func(t *testing.T) {
+		bad := typedef.Repository{Name: "x", URL: "github.com/a/x", Type: "whatever"}
+		assert.Empty(t, Expand(bad))
+	})
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./internal/repository/ -run TestExpand`
+Expected: FAIL — `undefined: newGithubClient` / `undefined: Expand`。
+
+- [ ] **Step 3: 改造 `internal/repository/repository.go`**
+
+把第 46 行的 `client, err := github.New()` 改为经 seam 调用；新增 `repoLister`、`newGithubClient`、`Expand`；`GetRepositories` 的过滤改为 name 或 URL。
+
+```go
+// repoLister 抽象 GitHub 客户端，测试时替换 newGithubClient 即可 mock。
+type repoLister interface {
+	GetRepos(name, accountType string) ([]string, error)
+}
+
+// newGithubClient 是可替换的包级 seam：生产用真客户端，测试注入 fake。
+var newGithubClient = func() (repoLister, error) { return github.New() }
+```
+
+`GetRepositories` 中按名字找的循环改为：
+
+```go
+	if name != "" {
+		for _, repository := range internalconfig.GetIns().Repository {
+			if repository.Name == name || repository.Matches(name) {
+				repositories = addRepo(repository, repositories)
+			}
+		}
+		return repositories
+	}
+```
+
+`addRepo` 中创建客户端改为：
+
+```go
+		client, err := newGithubClient()
+```
+
+文件末尾新增导出函数：
+
+```go
+// Expand 返回一个配置条目实际对应的具体仓库列表。type=repo 原样返回自身；
+// type=user/org 通过 GitHub API 展开为成员仓库（继承 cron/storage 等选项）；
+// 非法类型返回空切片。CLI 与 executor 共用。
+func Expand(repo typedef.Repository) []typedef.Repository {
+	return addRepo(repo, nil)
+}
+```
+
+（`github` 包仍被 import——`newGithubClient` 闭包引用 `github.New()`。）
+
+- [ ] **Step 4: 运行 repository 测试确认通过**
+
+Run: `go test ./internal/repository/`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add internal/repository/repository.go internal/repository/expand_test.go
+git commit -m "feat(repository): export Expand + name-or-URL matching in GetRepositories"
+```
+
+---
+
+### Task 4: executor 按 repo_key 查找 + org/user 展开为多 job
+
+**Files:**
+- Modify: `internal/executor/executor.go:57-104`
+- Modify: `internal/executor/executor_test.go`（既有用例改为传 URL 键、返回值改 `[]string`；新增 repo_key 写入与 org 展开用例）
+
+**Interfaces:**
+- Consumes: `typedef.Repository.Matches()` / `.Key()`（Task 1）、`repository.Expand()`（Task 3）、`executions.repo_key` 列（Task 2）
+- Produces:
+  - `var ErrRepositoryNotFound = errors.New("repository not found in configuration")`
+  - `func (e *Executor) ExecuteJob(repoKey string) ([]string, error)` — 按 `Matches` 定位；找不到返回 `ErrRepositoryNotFound`；type=repo 返回 `[]string{jobID}`；user/org 经展开对每个具体仓库产生一条 execution，返回多个 jobID
+  - `func (e *Executor) launchJob(job typedef.Repository) (string, error)` — 原 ExecuteJob 主体：生成 jobID、INSERT（`job_name` + `repo_key`）、登记 runningJobs、异步执行
+  - `var expandRepos = repository.Expand`（executor 包级 seam，测试注入 fake）
+
+- [ ] **Step 1: 改既有 executor 测试适配新签名**
+
+`internal/executor/executor_test.go`：
+- `TestExecuteJobWritesBoundLogs`（第 34 行）、`TestExecuteJobRunsConfiguredComponents`（第 86 行）、`TestExecuteJobCreatesRecord`（第 113 行）：
+  `jobID, err := exec.ExecuteJob("test-repo")` → `jobIDs, err := exec.ExecuteJob("github.com/test/repo")` 且 `require.Len(t, jobIDs, 1)`，随后用 `jobIDs[0]`。
+- `TestExecuteJobUnknownRepository`（第 130 行）：`exec.ExecuteJob("does-not-exist")` 保持报错（规范化后仍无命中）。
+
+- [ ] **Step 2: 写失败测试**（`internal/executor/executor_test.go` 追加）
+
+```go
+func TestExecuteJobWritesRepoKey(t *testing.T) {
+	exec, testDB := newTestExecutor(t)
+
+	jobIDs, err := exec.ExecuteJob("https://github.com/test/repo")
+	require.NoError(t, err)
+	require.Len(t, jobIDs, 1)
+
+	var repoKey string
+	err = testDB.QueryRow("SELECT repo_key FROM executions WHERE id = ?", jobIDs[0]).Scan(&repoKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "github.com/test/repo", repoKey)
+}
+
+func TestExecuteJobExpandsOrgIntoMultipleJobs(t *testing.T) {
+	exec, testDB := newTestExecutor(t)
+	exec.cfg.Repository = []typedef.Repository{
+		{Name: "acme", URL: "https://github.com/acme", Type: typedef.TypeOrg, OrgName: "acme"},
+	}
+
+	old := expandRepos
+	t.Cleanup(func() { expandRepos = old })
+	expandRepos = func(repo typedef.Repository) []typedef.Repository {
+		return []typedef.Repository{
+			{Name: "alpha", URL: "github.com/acme/alpha"},
+			{Name: "beta", URL: "github.com/acme/beta"},
+		}
+	}
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme")
+	require.NoError(t, err)
+	require.Len(t, jobIDs, 2)
+
+	keys := map[string]bool{}
+	for _, id := range jobIDs {
+		var repoKey string
+		require.NoError(t, testDB.QueryRow("SELECT repo_key FROM executions WHERE id = ?", id).Scan(&repoKey))
+		keys[repoKey] = true
+	}
+	assert.True(t, keys["github.com/acme/alpha"])
+	assert.True(t, keys["github.com/acme/beta"])
+}
+```
+
+- [ ] **Step 3: 运行测试确认失败**
+
+Run: `go test ./internal/executor/ -run 'TestExecuteJobWritesRepoKey|TestExecuteJobExpandsOrgIntoMultipleJobs'`
+Expected: FAIL — `undefined: expandRepos` 编译错误（第一步对旧用例的适配也一起在这一轮生效）。
+
+- [ ] **Step 4: 重写 `ExecuteJob`**（`internal/executor/executor.go`）
+
+```go
+import "errors"
+
+// ErrRepositoryNotFound 表示配置中找不到匹配该身份键的仓库条目。
+var ErrRepositoryNotFound = errors.New("repository not found in configuration")
+
+// expandRepos 是把 user/org 条目展开为具体仓库的 seam：生产用 repository.Expand，
+// 测试注入 fake，避免真实 GitHub 调用。
+var expandRepos = repository.Expand
+
+// ExecuteJob 按仓库身份键（规范化 URL）在配置中定位条目并执行。type=repo 产生
+// 一条 execution 并返回单元素 jobID；type=user/org 先在任务内展开为具体仓库，
+// 每个具体仓库独立执行（各自 jobID / execution / 日志流 / 可取消）。
+func (e *Executor) ExecuteJob(repoKey string) ([]string, error) {
+	var repo typedef.Repository
+	found := false
+	for _, r := range e.cfg.Repository {
+		if r.Matches(repoKey) {
+			repo = r
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, ErrRepositoryNotFound
+	}
+
+	jobIDs := make([]string, 0, 1)
+	for _, concrete := range expandRepos(repo) {
+		jobID, err := e.launchJob(concrete)
+		if err != nil {
+			return nil, err
+		}
+		jobIDs = append(jobIDs, jobID)
+	}
+	return jobIDs, nil
+}
+
+// launchJob 为单个具体仓库创建 execution 记录并异步执行。
+func (e *Executor) launchJob(job typedef.Repository) (string, error) {
+	// Generate job ID
+	jobID := uuid.New().String()
+	startTime := time.Now()
+
+	// Create execution record: job_name 保存展示名快照，repo_key 是身份键。
+	_, err := e.db.Exec(`
+		INSERT INTO executions (id, job_name, repo_key, start_time, status)
+		VALUES (?, ?, ?, ?, ?)
+	`, jobID, job.Name, job.Key(), startTime, string(StatusPending))
+	if err != nil {
+		return "", fmt.Errorf("failed to create execution record: %w", err)
+	}
+
+	// Create cancellable context
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Store job context
+	e.mu.Lock()
+	e.runningJobs[jobID] = &JobContext{
+		Ctx:        ctx,
+		CancelFunc: cancel,
+	}
+	e.mu.Unlock()
+
+	// Update status to running
+	e.updateJobStatus(jobID, string(StatusRunning), "")
+
+	// Execute async
+	go e.executeAsync(ctx, jobID, job)
+
+	return jobID, nil
+}
+```
+
+- [ ] **Step 5: 运行全部 executor 测试确认通过**
+
+Run: `go test ./internal/executor/`
+Expected: PASS。（`TestExecuteJobRunsConfiguredComponents` 会真实 clone 一个不存在的仓库后失败，日志行断言仍应通过；网络受限时允许重跑一次。）
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add internal/executor/executor.go internal/executor/executor_test.go
+git commit -m "feat(executor): ExecuteJob by repo key, expand org/user into per-repo jobs"
+```
+
+---
+
+### Task 5: API —— CreateJob 用 repository_key/job_ids + GetJobs 按 repo_key 关联与过滤
+
+**Files:**
+- Modify: `internal/server/types.go`
+- Modify: `internal/server/api.go:30-74`（CreateJob）、`:105-213`（GetJobs）
+- Modify: `internal/server/api_test.go`（既有用例字段改名 + 新增 URL 过滤、URL 解析断言）
+
+**Interfaces:**
+- Consumes: `executor.ExecuteJob(repoKey) ([]string, error)` + `executor.ErrRepositoryNotFound`（Task 4）、`typedef.NormalizeURL`/`Matches`（Task 1）、`repo_key` 列（Task 2）
+- Produces:
+  - `CreateJobRequest{ RepositoryKey string json:"repository_key" binding:"required" }`
+  - `CreateJobResponse{ JobIDs []string json:"job_ids"; Status string }`
+  - `GetJobs`：SELECT 含 `repo_key`；`repository` 过滤为 `(job_name LIKE ? OR repo_key LIKE ?)`，第二个词先 `NormalizeURL`；URL 关联按 `repo.Matches(repoKey)`
+
+- [ ] **Step 1: 改 types.go**
+
+```go
+type CreateJobRequest struct {
+	RepositoryKey string `json:"repository_key" binding:"required"`
+}
+
+type CreateJobResponse struct {
+	JobIDs []string `json:"job_ids"`
+	Status string   `json:"status"`
+}
+```
+
+- [ ] **Step 2: 改 CreateJob handler**（`internal/server/api.go`）
+
+```go
+func (a *API) CreateJob(c *gin.Context) {
+	var req CreateJobRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, Response{
+			Code:    400,
+			Message: "Invalid request: " + err.Error(),
+		})
+		return
+	}
+
+	jobIDs, err := a.executor.ExecuteJob(req.RepositoryKey)
+	if err != nil {
+		if errors.Is(err, executor.ErrRepositoryNotFound) {
+			c.JSON(http.StatusNotFound, Response{
+				Code:    404,
+				Message: "Repository not found in configuration",
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, Response{
+			Code:    500,
+			Message: "Failed to execute job: " + err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, Response{
+		Code: 200,
+		Data: CreateJobResponse{
+			JobIDs: jobIDs,
+			Status: string(executor.StatusRunning),
+		},
+	})
+}
+```
+
+`internal/server/api.go` import 增加 `errors`。
+
+- [ ] **Step 3: 改 GetJobs**（`internal/server/api.go`）
+
+查询串抽成常量并加入 `repo_key`，过滤与关联改身份键：
+
+```go
+const jobSelect = "SELECT id, job_name, repo_key, start_time, end_time, status, error_message FROM executions"
+
+// Build query
+query := jobSelect + " WHERE 1=1"
+args := []interface{}{}
+
+if status != "" && status != "all" {
+	query += " AND status = ?"
+	args = append(args, status)
+}
+
+if repository != "" {
+	// name 模糊匹配原始输入；URL 搜索词先规范化，命中规范化后的 repo_key。
+	query += " AND (job_name LIKE ? ESCAPE '\\' OR repo_key LIKE ? ESCAPE '\\')"
+	args = append(args, "%"+escapeLike(repository)+"%", "%"+escapeLike(typedef.NormalizeURL(repository))+"%")
+}
+
+// Get total count
+countQuery := "SELECT COUNT(*) FROM executions" + query[len(jobSelect):]
+```
+
+扫描与关联段改为：
+
+```go
+	var repoKey string
+	err := rows.Scan(&job.ID, &job.Name, &repoKey, &startTime, &endTime, &job.Status, &errorMessage)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, Response{
+			Code:    500,
+			Message: "Failed to scan job: " + err.Error(),
+		})
+		return
+	}
+
+	job.StartTime = &startTime
+	job.EndTime = endTime
+	if errorMessage != nil {
+		job.ErrorMessage = *errorMessage
+	}
+
+	// Resolve URL from config by identity key; unmatched (renamed/deleted/old
+	// empty-key rows) keeps the job_name snapshot and empty URL.
+	for _, repo := range a.config.Repository {
+		if repo.Matches(repoKey) {
+			job.URL = repo.URL
+			break
+		}
+	}
+```
+
+（`GetJobs` 中旧的 `argPos` 变量是死代码，一并删掉。）
+
+- [ ] **Step 4: 更新 api_test.go**
+
+（import 增加 `net/url`，供新的 URL 过滤用例使用 `url.QueryEscape`。）
+
+- `TestCreateJob`：请求体 `"repository": "non-existent-repo"` → `"repository_key": "github.com/nope/repo"`（仍 404）；`"missing_repository_field"` 用空 body（仍 400）；新增成功用例：
+
+```go
+t.Run("valid_repository_key", func(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{
+		"repository_key": "https://github.com/test/repo",
+	})
+	req, _ := http.NewRequest("POST", "/api/jobs", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 200, resp.Code)
+	var response struct {
+		Code int `json:"code"`
+		Data struct {
+			JobIDs []string `json:"job_ids"`
+			Status string   `json:"status"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+	assert.Equal(t, 200, response.Code)
+	require.Len(t, response.Data.JobIDs, 1)
+	assert.NotEmpty(t, response.Data.JobIDs[0])
+	assert.Equal(t, "running", response.Data.Status)
+})
+```
+
+- `TestGetJobs` 的三个 INSERT 改为带 `repo_key`（`"github.com/test/repo"`），并在 `list all jobs` 的 checkResponse 里加 URL 断言：
+
+```go
+	// URL 解析：repo_key 命中配置条目 → url 被填上（三行同键，全部命中）
+	for _, j := range response.Data.Jobs {
+		assert.Equal(t, "github.com/test/repo", j.URL)
+	}
+```
+
+- 追加 URL 模糊过滤用例（filter 列表里新增一行）：
+
+```go
+{
+	name:           "filter by full URL with scheme and trailing slash",
+	queryParams:    "?repository=" + url.QueryEscape("https://github.com/test/repo/"),
+	expectedStatus: 200,
+	checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+		var response struct {
+			Code    int `json:"code"`
+			Data    struct {
+				Jobs  []struct{ Name string `json:"name"` } `json:"jobs"`
+				Total int64                               `json:"total"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+		assert.Equal(t, int64(3), response.Data.Total, "normalized URL must match repo_key despite scheme/slash")
+	},
+},
+```
+
+- **注意**：`TestGetJobsRepositoryEscaping` 的行插入不带 `repo_key`（默认 `''`），过滤仍只命中 `job_name`，断言不变；无需改动。
+
+- [ ] **Step 5: 运行 server 测试确认通过**
+
+Run: `go test ./internal/server/ -run 'TestCreateJob|TestGetJobs'`
+Expected: PASS。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add internal/server/types.go internal/server/api.go internal/server/api_test.go
+git commit -m "feat(server): CreateJob takes repository_key and returns job_ids; GetJobs matches name or URL"
+```
+
+---
+
+### Task 6: API —— GetRepositories 按 repo_key 聚合 + 仓库 CRUD 按身份键
+
+**Files:**
+- Modify: `internal/server/api.go`（GetRepositories `:307-407`、CreateRepository `:409-453`、UpdateRepository `:455-536`、DeleteRepository `:538-570`）
+- Modify: `internal/server/repository_test.go`（既有用例路径参数由 name 改身份键 + 新增 URL 判重/空 URL/org 合成/org 前缀聚合用例）
+
+**Interfaces:**
+- Consumes: `typedef.Repository.Key()` / `.Matches()` / `.EffectiveURL()`（Task 1）、`repo_key` 列（Task 2）
+- Produces:
+  - `func lookupStats(stats map[string]runStats, repo typedef.Repository) runStats` — type=repo/user 直接取 `stats[repo.Key()]`；type=org/user 对 `entry.Key()+"/"` 路径前缀命中的成员求和，`last_run` 取 max
+  - `GetRepositories`：`GROUP BY repo_key`；搜索 `name` 或 `EffectiveURL()` 任一 `Contains`（大小写折叠）
+  - `CreateRepository`：允许 name 重复；URL 判重 409；空身份键 400；user/org 空 URL 自动填合成 URL
+  - `UpdateRepository` / `DeleteRepository`：`:id` 用 `repo.Matches(id)` 定位；更新后与其他仓库 URL 冲突 409（不与自身比较）
+
+- [ ] **Step 1: 写失败测试**（`internal/server/repository_test.go` 改动 + 新增）
+
+**既有用例改造：**
+
+- `TestGetRepositories`：
+  - cfg 的 `repo-a` 的 INSERT 改为带 `repo_key`：
+    ```go
+    testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        "e1", "repo-a", "github.com/a/a", now, now.Add(time.Minute), "completed", "")
+    testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        "e2", "repo-a", "github.com/a/a", now.Add(2*time.Minute), now.Add(3*time.Minute), "failed", "boom")
+    ```
+  - 追加 URL 搜索用例：
+    ```go
+    t.Run("search filters by URL", func(t *testing.T) {
+        d := getList("?search=github.com/b")
+        assert.Equal(t, 1, d.Total)
+        assert.Equal(t, "repo-b", d.Repositories[0].Name)
+    })
+    ```
+
+- `TestCreateRepository`：`duplicate_name` 改为 `duplicate_url`（同名不同 URL → 200）；`empty_name` 用例**保持不变**（name 仍必填 400，CreateRepository 保留 name 校验）；空 URL/org 无 orgName 由新增的 `TestCreateRepositoryEmptyURLRejected` 覆盖；新增 `org_synthesizes_url`。
+
+- `TestUpdateRepository`：`PUT /api/repositories/update-me` → `PUT /api/repositories/github.com/old/url`。
+
+- `TestDeleteRepository`：`DELETE /api/repositories/delete-me` → `DELETE /api/repositories/github.com/delete/me`。
+
+**新增用例：**
+
+```go
+func TestCreateRepositoryDuplicateURL(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "existing-repo", URL: "github.com/existing/repo"},
+		},
+	}
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	// 同一 URL 不同 name → 409（身份以 URL 为准，name 可重复）。
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "another-name",
+		"url":  "https://github.com/existing/repo.git",
+	})
+	req, _ := http.NewRequest("POST", "/api/repositories", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 409, resp.Code)
+	assert.Equal(t, 409, repoResponseCode(t, resp))
+}
+
+func TestCreateRepositoryNameMayRepeat(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "repo", URL: "github.com/one/repo"},
+		},
+	}
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	// 相同 name 不同 URL → 200（name 不再是唯一约束）。
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "repo",
+		"url":  "github.com/two/repo",
+	})
+	req, _ := http.NewRequest("POST", "/api/repositories", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 200, resp.Code)
+}
+
+func TestCreateRepositoryOrgSynthesizesURL(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	s := server.NewRepoTestServer(&config.Config{}, testDB)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":    "acme",
+		"type":    "org",
+		"orgName": "acme",
+	})
+	req, _ := http.NewRequest("POST", "/api/repositories", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 200, resp.Code)
+	var response struct {
+		Code int                `json:"code"`
+		Data typedef.Repository `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+	assert.Equal(t, 200, response.Code)
+	assert.Equal(t, "https://github.com/acme", response.Data.URL)
+}
+
+func TestCreateRepositoryEmptyURLRejected(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	s := server.NewRepoTestServer(&config.Config{}, testDB)
+
+	// type=repo 且无 URL；type=org 但无 orgName → 都 400。
+	for _, body := range []map[string]interface{}{
+		{"name": "orphan", "type": "repo"},
+		{"name": "nobody", "type": "org"},
+	} {
+		b, _ := json.Marshal(body)
+		req, _ := http.NewRequest("POST", "/api/repositories", bytes.NewBuffer(b))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		s.ServeHTTP(resp, req)
+		assert.Equal(t, 400, resp.Code, "body %v", body)
+	}
+}
+
+func TestUpdateRepositoryURLCollision(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "a", URL: "github.com/a/a"},
+			{Name: "b", URL: "github.com/b/b"},
+		},
+	}
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	// 把 a 的 URL 改成 b 的 → 409（与其他仓库冲突，不与自身比较）。
+	body, _ := json.Marshal(map[string]interface{}{
+		"url": "github.com/b/b",
+	})
+	req, _ := http.NewRequest("PUT", "/api/repositories/github.com/a/a", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 409, resp.Code)
+}
+
+func TestGetRepositoriesOrgPrefixAggregation(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "acme", URL: "https://github.com/acme", Type: typedef.TypeOrg, OrgName: "acme"},
+			{Name: "solo", URL: "github.com/solo/app"},
+		},
+	}
+
+	now := time.Now()
+	// 成员仓库的 executions 各记一条。
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"a1", "alpha", "github.com/acme/alpha", now.Add(-2*time.Minute), now.Add(-1*time.Minute), "completed", "")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"b1", "beta", "github.com/acme/beta", now.Add(-4*time.Minute), now.Add(-3*time.Minute), "failed", "boom")
+	// 路径边界：github.com/acme2/x 不能被 acme 前缀吞掉。
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"c1", "other", "github.com/acme2/other", now.Add(-6*time.Minute), now.Add(-5*time.Minute), "completed", "")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"d1", "solo", "github.com/solo/app", now.Add(-8*time.Minute), now.Add(-7*time.Minute), "completed", "")
+
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	type repoView struct {
+		Name        string     `json:"Name"`
+		LastRunTime *time.Time `json:"last_run_time"`
+		TotalRuns   int64      `json:"total_runs"`
+		SuccessRuns int64      `json:"success_runs"`
+		FailedRuns  int64      `json:"failed_runs"`
+	}
+	req, _ := http.NewRequest("GET", "/api/repositories", nil)
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+	var response struct {
+		Code int `json:"code"`
+		Data struct {
+			Repositories []repoView `json:"repositories"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+	assert.Equal(t, 200, response.Code)
+
+	byName := map[string]repoView{}
+	for _, r := range response.Data.Repositories {
+		byName[r.Name] = r
+	}
+
+	acme := byName["acme"]
+	assert.Equal(t, int64(2), acme.TotalRuns, "org aggregates its member repos only")
+	assert.Equal(t, int64(1), acme.SuccessRuns)
+	assert.Equal(t, int64(1), acme.FailedRuns)
+	require.NotNil(t, acme.LastRunTime)
+	assert.WithinDuration(t, now.Add(-1*time.Minute), *acme.LastRunTime, time.Second, "last_run must be the max of members")
+
+	solo := byName["solo"]
+	assert.Equal(t, int64(1), solo.TotalRuns)
+}
+```
+
+- [ ] **Step 2: 运行 repository 测试确认失败**
+
+Run: `go test ./internal/server/ -run 'TestCreateRepository|TestUpdateRepository|TestDeleteRepository|TestGetRepositories'`
+Expected: FAIL — 用例期望的行为（409 而非 name 判重、URL 聚合等）当前不满足。
+
+- [ ] **Step 3: 改 GetRepositories**（`internal/server/api.go`）
+
+统计聚合与关联改为按身份键；新增包级 `runStats` 与 `lookupStats`：
+
+```go
+// runStats 是单仓库/单组织的聚合运行统计。
+type runStats struct {
+	LastRun *time.Time
+	Total   int64
+	Success int64
+	Failed  int64
+}
+
+// lookupStats 返回配置条目的运行统计。type=repo 直接取自身键；type=org/user
+// 对「路径边界前缀」（entry.Key()+"/"）命中的成员求和，last_run 取成员最大值。
+// 前缀以 "/" 结尾，避免 github.com/acme 误吞 github.com/acme2/x。
+func lookupStats(stats map[string]runStats, repo typedef.Repository) runStats {
+	key := repo.Key()
+	if key == "" {
+		return runStats{}
+	}
+	switch repo.GetType() {
+	case typedef.TypeOrg, typedef.TypeUser:
+		prefix := key + "/"
+		var sum runStats
+		for k, s := range stats {
+			if !strings.HasPrefix(k, prefix) {
+				continue
+			}
+			sum.Total += s.Total
+			sum.Success += s.Success
+			sum.Failed += s.Failed
+			if s.LastRun != nil && (sum.LastRun == nil || s.LastRun.After(*sum.LastRun)) {
+				t := *s.LastRun
+				sum.LastRun = &t
+			}
+		}
+		return sum
+	default:
+		return stats[key]
+	}
+}
+```
+
+`GetRepositories` 内：
+- 聚合 SQL 分组键 `job_name` → `repo_key`（`SELECT repo_key, start_time AS last_run, ... FROM executions GROUP BY repo_key HAVING start_time = MAX(start_time)`），scan 的变量名 `name` → `key`，`stats[key] = a`。
+- `filtered` 的过滤改为 name 或 URL：
+  ```go
+  for _, repo := range a.config.Repository {
+      if search != "" {
+          inName := strings.Contains(strings.ToLower(repo.Name), strings.ToLower(search))
+          inURL := strings.Contains(strings.ToLower(repo.EffectiveURL()), strings.ToLower(search))
+          if !inName && !inURL {
+              continue
+          }
+      }
+      filtered = append(filtered, repo)
+  }
+  ```
+- 统计关联 `s := stats[repo.Name]` → `s := lookupStats(stats, repo)`。
+- 原函数内的 `type agg struct {...}` 删除，改用包级 `runStats`。
+
+- [ ] **Step 4: 改 CreateRepository**
+
+```go
+	if repo.Name == "" {
+		c.JSON(http.StatusBadRequest, Response{
+			Code:    400,
+			Message: "Repository name is required",
+		})
+		return
+	}
+	// user/org 空 URL → 填合成 URL；随后统一判身份键非空。
+	repo.URL = repo.EffectiveURL()
+	if repo.Key() == "" {
+		c.JSON(http.StatusBadRequest, Response{
+			Code:    400,
+			Message: "Repository needs a non-empty URL (or orgName for user/org type)",
+		})
+		return
+	}
+
+	// 判重按身份键（URL），name 允许重复。
+	for _, existing := range a.config.Repository {
+		if existing.Key() == repo.Key() {
+			c.JSON(http.StatusConflict, Response{
+				Code:    409,
+				Message: "Repository with URL '" + repo.Key() + "' already exists",
+			})
+			return
+		}
+	}
+```
+
+（`repo.Name == ""` 的 400 保留；`empty_name` 用例改造后不再依赖它，但保留对 UI 的友好校验。）
+
+- [ ] **Step 5: 改 UpdateRepository**
+
+定位与冲突检查：
+
+```go
+	// Locate the existing repository by identity key (URL).
+	idx := -1
+	for i, existing := range a.config.Repository {
+		if existing.Matches(id) {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		c.JSON(http.StatusNotFound, Response{
+			Code:    404,
+			Message: "Repository not found",
+		})
+		return
+	}
+```
+
+merge 之后、写回之前：
+
+```go
+	// user/org 空 URL → 填合成 URL；空身份键拒绝；与其他仓库 URL 冲突拒绝。
+	updated.URL = updated.EffectiveURL()
+	if updated.Key() == "" {
+		c.JSON(http.StatusBadRequest, Response{
+			Code:    400,
+			Message: "Repository needs a non-empty URL (or orgName for user/org type)",
+		})
+		return
+	}
+	for i, other := range a.config.Repository {
+		if i != idx && other.Key() == updated.Key() {
+			c.JSON(http.StatusConflict, Response{
+				Code:    409,
+				Message: "Repository with URL '" + updated.Key() + "' already exists",
+			})
+			return
+		}
+	}
+```
+
+- [ ] **Step 6: 改 DeleteRepository**
+
+```go
+	idx := -1
+	for i, existing := range a.config.Repository {
+		if existing.Matches(id) {
+			idx = i
+			break
+		}
+	}
+```
+
+- [ ] **Step 7: 运行全部 server 测试确认通过**
+
+Run: `go test ./internal/server/`
+Expected: PASS。
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add internal/server/api.go internal/server/repository_test.go
+git commit -m "feat(server): repo_key aggregation + org prefix stats; CRUD keyed by URL identity"
+```
+
+---
+
+### Task 7: 前端 —— 按钮/请求按 URL 身份键，name 可编辑
+
+**Files:**
+- Modify: `web/static/js/main.js`
+- Modify: `web/templates/index.html`
+
+**Interfaces:**
+- Consumes: `POST /api/jobs {repository_key}` → `{job_ids: []string}`；`PUT/DELETE /api/repositories/:id`（:id = URL 编码的身份键）；`GET /api/repositories` 返回 `RepositoryOverview`（内嵌 `typedef.Repository`，字段 `URL`、`Name`、`Type`、`OrgName`…）
+- Produces: 无（纯前端消费）
+
+- [ ] **Step 1: 加 `repoKey` 助手与占位文案**（`main.js`）
+
+文件顶部附近加：
+
+```js
+// repoKey 返回仓库身份键。后端以规范化 URL 为唯一身份，前端不做规范化。
+const repoKey = (r) => r.URL || '';
+```
+
+- 任务页过滤占位（`jobsToolbar`，约第 122 行）：`placeholder="Filter by repository name…"` → `"Filter by repository name or URL…"`。
+- 仓库页搜索占位（`renderRepositories`，约第 428 行）：`placeholder="Filter by repository name…"` → `"Filter by name or URL…"`。
+
+- [ ] **Step 2: 改 `runRepo`**（约第 240 行；签名带 name 供日志弹窗标题使用）
+
+```js
+async function runRepo(key, name, btn) {
+    if (!key) return;
+    btn.disabled = true;
+    try {
+        const data = await api('/api/jobs', { method: 'POST', body: JSON.stringify({ repository_key: key }) });
+        const jobIDs = (data && data.job_ids) || [];
+        if (jobIDs.length === 1) {
+            toast('Job started (' + jobIDs[0].slice(0, 8) + '…)');
+            openLogModal(jobIDs[0], name);
+        } else {
+            toast('Started ' + jobIDs.length + ' jobs (org expansion)');
+        }
+        renderRepositories();
+    } catch (e) {
+        toast('Failed to start job: ' + e.message, true);
+        btn.disabled = false;
+    }
+}
+```
+
+- [ ] **Step 3: 改仓库表格按钮 data-* 与事件绑定**（`renderRepositories`）
+
+行内按钮（约第 418-420 行）`data-name="${esc(r.Name)}"` → `data-key="${esc(repoKey(r))}"`；事件绑定（约第 465-470 行）：
+
+```js
+$$('.btn-run-repo').forEach(b => b.addEventListener('click', () => {
+    const r = repos.find(x => repoKey(x) === b.dataset.key);
+    runRepo(b.dataset.key, r ? r.Name : '', b);
+}));
+$$('.btn-edit-repo').forEach(b => b.addEventListener('click', () => {
+    const r = repos.find(x => repoKey(x) === b.dataset.key);
+    if (r) openRepoForm(r);
+}));
+$$('.btn-del-repo').forEach(b => b.addEventListener('click', () => deleteRepo(b.dataset.key)));
+```
+
+- [ ] **Step 4: 改 `deleteRepo`**（约第 378 行）
+
+```js
+async function deleteRepo(key) {
+    if (!confirm('Delete repository?')) return;
+    try {
+        await api('/api/repositories/' + encodeURIComponent(key), { method: 'DELETE' });
+        toast('Repository deleted');
+        renderRepositories();
+    } catch (e) {
+        toast('Failed to delete repository: ' + e.message, true);
+    }
+}
+```
+
+- [ ] **Step 5: 改编辑表单：存身份键、name 可改**（`main.js` + `index.html`）
+
+`index.html` 第 43 行：`<input type="hidden" id="repo-original-name">` → `<input type="hidden" id="repo-original-key">`。
+
+`openRepoForm`（约第 308-310 行）：
+
+```js
+$('#repo-original-key').value = repo ? repoKey(repo) : '';
+$('#repo-name').value = repo ? repo.Name : '';
+$('#repo-name').disabled = false; // name 仅展示/查询，可重复可改名
+```
+
+`saveRepo`（约第 342、365 行）：
+
+```js
+const originalKey = $('#repo-original-key').value;
+...
+if (originalKey) {
+    await api('/api/repositories/' + encodeURIComponent(originalKey), { method: 'PUT', body: JSON.stringify(repo) });
+    toast('Repository updated');
+} else {
+    await api('/api/repositories', { method: 'POST', body: JSON.stringify(repo) });
+    toast('Repository added');
+}
+```
+
+（`repo` 对象的构造不变；`URL` 字段为 `$('#repo-url').value.trim()`，后端负责规范化与 user/org 合成。）
+
+- [ ] **Step 6: 手工/浏览器验证**
+
+Run: `go build -o gitrieve main.go && ./gitrieve server -c config.yaml`（或项目既有启动方式），浏览器打开：
+1. 仓库列表按钮执行单个仓库 → 打开日志弹窗；任务页出现该仓库的 execution。
+2. 添加一个 `type: org, orgName: <你的org>` 的条目 → 保存后 URL 自动显示 `https://github.com/<orgName>`；点 Execute → toast「Started N jobs」、任务列表出现 N 条（各为具体仓库 URL）。
+3. 编辑仓库：name 输入框可改；改 URL 后保存 → 任务页旧历史保留、新任务关联新 URL；把 URL 改成另一仓库的 → 后端 409。
+4. 任务页过滤输入完整带协议的 URL → 能搜到；仓库页搜索 URL 片段 → 能搜到。
+
+- [ ] **Step 7: 提交**
+
+```bash
+git add web/static/js/main.js web/templates/index.html
+git commit -m "feat(ui): key repo actions by URL identity; make name editable"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage 核对：**
+
+- §4 身份键/规范化 → Task 1（含表驱动测试覆盖协议/大小写/尾斜杠/.git/www/#/多主机/合成/空输入）。
+- §4 空 URL 启动校验 → Task 1 Step 5-7。
+- §5 schema + 迁移 → Task 2（新增列、`Migrate`、幂等、无回填、server 接线、失败即退出）。
+- §6 executor → Task 4（`Matches` 查找、`Expand` 展开、INSERT 写 `repo_key`、`job_name` 写展示名、返回多 jobID）。
+- §7.1 CreateJob → Task 5。
+- §7.2 GetJobs → Task 5（name+URL 模糊、URL 搜索词先规范化、`repo.Matches(repoKey)` 关联、关联不到用快照）。
+- §7.3 GetRepositories → Task 6（`GROUP BY repo_key` 保留 HAVING 写法；org 前缀求和 + 路径边界；搜索 name 或 EffectiveURL）。
+- §7.4 CRUD → Task 6（`:id`=身份键、name 重复、URL 判重、空 URL 400、user/org 合成写回、更新冲突 409 不与自身比较）。
+- §7.5 破坏性变更清单 → Task 5/6/7。
+- §8 前端 → Task 7（`repoKey=r.URL`、`repository_key`/`job_ids`、name 可编辑、占位文案）。
+- §10 测试 → 各任务内；executor 的 org 多 job 用 `expandRepos` seam（Task 4 Step 2），`repository.Expand` 用 `newGithubClient` seam（Task 3 Step 1）；API 层 org 多值经 executor 单测覆盖 + `job_ids` 形状断言。
+- §9 明确不做 → 计划未触碰 `cmd/daemon`、不做前端规范化、不做导入导出。
+
+**Placeholder scan：** 无 TBD/占位；每个代码步骤均含完整实现。
+
+**Type consistency：**
+- `repoKey(r)` 前端返回 `r.URL`，与后端 `Matches` 规范化判等一致（§8）。
+- `expandRepos`（executor）签名 `func(typedef.Repository) []typedef.Repository` 与 `repository.Expand` 一致。
+- `newGithubClient`（repository）签名 `func() (repoLister, error)` 与 `github.New` 兼容（`*github.Client` 实现 `GetRepos(name, accountType string) ([]string, error)`）。
+- `runStats`/`lookupStats` 在 Task 6 定义并仅在该任务使用；`jobSelect` 常量在 Task 5 定义并同步用于 countQuery 切片。
+- 既有 server 测试（`repository_test.go`/`api_test.go`）路径参数全部由 name 改为身份键，Task 5/6 内显式列出。
+
+**执行前修正（SDD 预检发现并已改入本计划）：**
+- Task 1：`ui.ErrorfExit` 走 `os.Exit(1)` 而非 panic——原 `require.Panics(Init)` 用例会杀测试进程；改为可测试的 `validateIdentity(cfg) error` + `Init` 内 `ui.ErrorfExit`，测试针对 `validateIdentity` 断言 error。
+- Task 5：`api_test.go` 需新增 `net/url` import；URL 解析断言改为遍历全部 jobs（三条 INSERT 的 start_time 相同，取 [0] 依赖插入顺序不可靠）。
+- Task 6：`empty_name` 用例保留不变（name 仍必填 400）；空 URL 由新增 `TestCreateRepositoryEmptyURLRejected` 覆盖。
+- Task 7：`runRepo(key, name, btn)` 增加 name 参数供日志弹窗标题使用（按钮 textContent 是 "Execute"，不能当仓库名）。

--- a/docs/superpowers/specs/2026-08-19-repo-identity-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-19-repo-identity-refactor-design.md
@@ -75,8 +75,9 @@
 新增（放在 `repository.go` 或新文件 `key.go`）：
 
 ```go
-// NormalizeURL 归一化仓库 URL：小写、去 http(s):// 前缀、去尾斜杠、去 .git 后缀。
-// 返回 "" 表示没有可用 URL。
+// NormalizeURL 归一化仓库 URL，产出无协议、小写、无 www、无尾斜杠、无 .git 的规范形态
+// "host/owner/repo"。处理顺序：去空白 → 去 #fragment → 小写 → 去 http(s):// → 去 www. →
+// 去尾斜杠 → 去 .git。返回 "" 表示没有可用 URL。
 func NormalizeURL(url string) string
 
 // EffectiveURL 返回条目的有效 URL：URL 非空直接用；type 为 user/org 且 orgName 非空时
@@ -97,6 +98,11 @@ func (r Repository) Matches(input string) bool
 | `github.com/wnarutou/gitrieve` | `github.com/wnarutou/gitrieve` |
 | `https://GITHUB.com/wnarutou/gitrieve/` | `github.com/wnarutou/gitrieve` |
 | `http://github.com/wnarutou/gitrieve.git` | `github.com/wnarutou/gitrieve` |
+| `https://www.github.com/wnarutou/gitrieve` | `github.com/wnarutou/gitrieve` |
+| `https://github.com/wnarutou/gitrieve#readme` | `github.com/wnarutou/gitrieve` |
+| `https://gitlab.com/Wnarutou/proj.git/` | `gitlab.com/wnarutou/proj` |
+
+**对齐 gitrieve-gleaner**（`urlUtils.js` 的 `cleanUrl`/`normalizeGitHubUrl` + `configGenerator` 的无协议输出）：去 `#fragment`、`http`→`https`（此处通过统一去协议体现）、去尾斜杠、去 `www.`、产出无协议形态 `host/owner/repo`。在此基础上确认的三点扩展：**任意主机通用清理**（gleaner 只处理 GitHub）、**去 `.git` 后缀**（gleaner 保留）、**统一小写**（gleaner 保留原大小写）。
 
 `git@host:path` 的 SCP 风格先**不支持**（示例配置全部用 `host/owner/repo` 形式）；若后续需要再扩展。规范化逻辑与前端 JS 版本各自独立实现，但**身份判定以后端为准**（API 路径参数在后端也做规范化后再匹配）。
 
@@ -217,7 +223,7 @@ type CreateJobResponse struct {
 
 新增：
 
-- `internal/typedef`：`NormalizeURL` / `EffectiveURL` / `Key` / `Matches` 表驱动测试（协议、大小写、尾斜杠、`.git`、user/org 合成 URL、空输入/空 URL 拒绝）。
+- `internal/typedef`：`NormalizeURL` / `EffectiveURL` / `Key` / `Matches` 表驱动测试（协议、大小写、尾斜杠、`.git`、`www.`、`#fragment`、多主机如 gitlab、user/org 合成 URL、空输入/空 URL 拒绝）。
 - `internal/db`：`Migrate` 测试——旧 schema（无 `repo_key` 列）补列成功；新 schema 幂等；不加回填断言（旧行键为空）。
 - `internal/executor`：按 `Key()`/`Matches` 查找、INSERT 写入 `repo_key`、找不到返回错误；**type=repo 返回单 jobID，type=org/user 经展开返回多个 jobID 且各写具体仓库键**。
 - `internal/repository`：`Expand` 对 repo/user/org 的展开结果（user/org 需要能 mock 掉 GitHub 客户端）。

--- a/docs/superpowers/specs/2026-08-19-repo-identity-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-19-repo-identity-refactor-design.md
@@ -1,0 +1,205 @@
+# 仓库身份重构（URL 为主键）设计文档
+
+日期：2026-08-19
+
+## 1. 背景与目标
+
+当前系统中，仓库（repository）的**身份**是 `name`：
+
+- `executions.job_name` 是任务历史与仓库的唯一关联字段；
+- `Executor.ExecuteJob(name)` 按 `repo.Name` 查找；
+- `POST /api/jobs` 按 name 触发任务；
+- `GET /api/repositories` 按 `job_name` 聚合统计、按 `repo.Name` 关联；
+- 仓库 CRUD 的路径参数 `:id` 就是 name；
+- 前端所有操作按钮按 name 编码到 URL，且 name 创建后不可修改。
+
+这带来两个问题：
+
+1. **同一个上游仓库可以以不同 name 配置多次**，同一 URL 被归档多份、任务历史无法按 URL 归并——这正是后续「配置导入导出」合并语义（按 URL 判重）的障碍。
+2. name 被当身份用，导致 name 不允许重复、不允许改名，限制了用户自由组织本地命名。
+
+**目标**：仓库身份改为 **URL 为主键**；`name` 降级为纯展示/查询标签，允许重复、允许改名；查询（任务过滤、仓库搜索）支持 name 与 URL 的模糊匹配。这是子项目 A，为子项目 B「配置导入导出」打基础。
+
+已确认的需求决策：
+
+| 决策点 | 结论 |
+|---|---|
+| 主键 | 规范化后的 **URL**；URL 为空的仓库（`type: user/org`）回退用 `name` |
+| name | 允许重复、允许改名，仅用于展示与查询 |
+| URL 修改 | 允许修改；修改即身份变更，旧 URL 下的任务历史保持原样但不再被查询关联 |
+| URL 重复 | 创建/更新时拒绝（规范化后相同） |
+| 查询 | 任务过滤与仓库搜索均支持 name + URL 模糊匹配 |
+| API 破坏性变更 | `POST /api/jobs` 请求字段由 name 改为仓库身份键 |
+
+**范围**：DB schema 迁移、`internal/executor`、`internal/server` API、`web` 前端。`cmd/daemon` 仅日志使用 name，无身份逻辑，不动。`storage` 仍按 name 引用，不动。org/user 仓库在 `internal/repository.addRepo` 中展开为具体 URL 仓库的既有行为不变。
+
+## 2. 现状与关键事实
+
+| 位置 | 现状（以 name 为身份） |
+|---|---|
+| `internal/db/db.go:46` | `executions.job_name TEXT NOT NULL`，无 URL/键列 |
+| `internal/db/models.go` | `Job.JobName` 字段 |
+| `internal/executor/executor.go:57-104` | `ExecuteJob(jobName)` 按 `repo.Name` 查找；INSERT 只写 `job_name` |
+| `internal/server/api.go:43` | `CreateJob` 校验按 `repo.Name == req.Repository` |
+| `internal/server/api.go:121-138` | `GetJobs` 过滤按 `job_name LIKE` |
+| `internal/server/api.go:186-191` | `GetJobs` 用 `repo.Name == job.Name` 从 config 解析 URL |
+| `internal/server/api.go:334-341` | `GetRepositories` 统计 `GROUP BY job_name` |
+| `internal/server/api.go:371` | 仓库搜索仅 name `Contains` |
+| `internal/server/api.go:390` | 统计关联 `stats[repo.Name]` |
+| `internal/server/api.go:462,544` | 仓库 `PUT/DELETE :id` 按 `existing.Name == id` 定位 |
+| `web/static/js/main.js` | 操作按钮按 name 编码；`runRepo` 传 name；name 编辑禁用 |
+
+一个既有事实：`type: user/org` 的仓库在 config 里没有 `url`（只有 `orgName`），其身份必须回退。另外 `GetRepositories` 的聚合 SQL 用了 SQLite 的技巧写法（`GROUP BY xxx HAVING start_time = MAX(start_time)` 取每组最后一条），换分组键时保留该写法与 `DATETIME` 列的注释约束（modernc/sqlite 驱动只有声明为 DATETIME 的列才能 scan 成 `time.Time`）。
+
+## 3. 方案选择
+
+**选 A：引入「仓库身份键」（`RepoKey`），贯穿 DB、executor、API、前端。**
+
+- 在 `typedef` 增加 `Repository.Key()` 与 URL 规范化函数，作为唯一判等口径。
+- DB `executions` 新增 `repo_key` 列（身份键），保留 `job_name`（执行时快照的展示名）。
+- executor、API 全部改为按 `RepoKey` 查找/关联/聚合。
+- 前端用同名 `repoKey(r)` 生成操作键，匹配后端。
+
+不选：
+
+- **方案 B（前端只改传参、后端只改 CRUD id，不引入 key 列）**：不引入 `repo_key` 列就无法在 `executions` 上可靠聚合（空 URL 仓库会塌缩到同一组），name 与 URL 的关系无法在历史中稳定表达。否决。
+- **方案 C（复用 name 列存 URL，另加 name 列）**：语义混乱，历史数据迁移更复杂。否决。
+
+## 4. 身份键与 URL 规范化（`internal/typedef`）
+
+新增（放在 `repository.go` 或新文件 `key.go`）：
+
+```go
+// NormalizeURL 归一化仓库 URL：小写、去 http(s):// 前缀、去尾斜杠、去 .git 后缀。
+// 返回 "" 表示没有可用 URL。
+func NormalizeURL(url string) string
+
+// Key 返回仓库身份键：URL 非空用 "url:"+NormalizeURL(URL)，否则 "name:"+Name。
+func (r Repository) Key() string
+
+// Matches 判断一段「用户输入的身份键」是否命中该仓库。输入有两种形态：
+//   - "name:xxx"（空 URL 仓库的兜底键）→ 与 Name 精确比较；
+//   - 其余 → 视为仓库 URL，规范化后与 Key() 比较（处理 url: 前缀、协议、尾斜杠、.git）。
+func (r Repository) Matches(input string) bool
+```
+
+**匹配口径统一用 `repo.Matches(input)`**：前端传原始 URL 或 `name:<name>`，后端统一走 Matches，避免「前端 URL 形态」与「后端 key 形态」对不上的坑。
+
+规范化规则（表驱动可测）：
+
+| 输入 | 规范化结果 |
+|---|---|
+| `github.com/wnarutou/gitrieve` | `github.com/wnarutou/gitrieve` |
+| `https://GITHUB.com/wnarutou/gitrieve/` | `github.com/wnarutou/gitrieve` |
+| `http://github.com/wnarutou/gitrieve.git` | `github.com/wnarutou/gitrieve` |
+| `git@github.com:wnarutou/gitrieve.git` | `github.com/wnarutou/gitrieve`（可选，先支持 `https/http/裸 host`，`git@` 形式另行说明） |
+
+`git@host:path` 的 SCP 风格先**不支持**（示例配置全部用 `host/owner/repo` 形式）；若后续需要再扩展。规范化逻辑与前端 JS 版本各自独立实现，但**身份判定以后端为准**（API 路径参数在后端也做规范化后再匹配）。
+
+## 5. DB 层（`internal/db`）
+
+### schema
+
+`executions` 增加列：
+
+```sql
+repo_key TEXT NOT NULL DEFAULT ''
+```
+
+新库在 `CREATE TABLE IF NOT EXISTS executions` 中直接带上该列。
+
+### 迁移与回填
+
+新增 `db.Migrate(db *DB, repos []typedef.Repository) error`，在 server 启动（拿到 config 后）调用一次：
+
+1. `PRAGMA table_info(executions)` 检测 `repo_key` 列是否存在；不存在则 `ALTER TABLE executions ADD COLUMN repo_key TEXT NOT NULL DEFAULT ''`。
+2. 回填：对每个配置仓库，`UPDATE executions SET repo_key = ? WHERE job_name = ? AND (repo_key = '' OR repo_key IS NULL)`（用 `repo.Key()` 回填——旧数据按 `job_name` 尽力匹配，匹配不到的置为 `"name:"+job_name` 自我归档，保证各自成组、不互相污染）。
+3. 幂等：列已存在时跳过 ALTER；回填语句本身幂等。
+
+依赖方向：`db` 导入 `typedef`（`typedef` 是叶子包，无循环依赖）。
+
+## 6. Executor（`internal/executor`）
+
+`ExecuteJob(repoKey string)`：按 `repo.Key() == repoKey` 查找仓库；INSERT 改为：
+
+```sql
+INSERT INTO executions (id, job_name, repo_key, start_time, status)
+VALUES (?, ?, ?, ?, ?)
+```
+
+`job_name` 写执行时的 `repo.Name`（显示快照），`repo_key` 写 `repo.Key()`。其余（runningJobs 按 jobID、状态更新、取消）不变。
+
+## 7. API（`internal/server`）
+
+### 7.1 `CreateJob`
+
+请求字段改为仓库身份键：
+
+```go
+type CreateJobRequest struct {
+    RepositoryKey string `json:"repository_key" binding:"required"`
+}
+```
+
+按 `repo.Matches(req.RepositoryKey)` 查找；找不到 404。空 URL 仓库也能用 `name:` 键触发（执行内部仍会失败——既有局限，不在本子项目修复）。
+
+### 7.2 `GetJobs`
+
+- SELECT 增加 `repo_key`；过滤参数 `repository` 改为对 `(job_name LIKE ? ESCAPE '\' OR repo_key LIKE ? ESCAPE '\')` 匹配。**第二个 LIKE 的搜索词先做 URL 规范化**（`NormalizeURL(q)`）再包 `%`：这样用户输入 `https://github.com/wnarutou/gitrieve/`（带协议/尾斜杠）也能命中规范化后的 `repo_key`（`url:github.com/wnarutou/gitrieve`）。
+- `Job.url` 仍从 config 解析，但关联改按 `repo.Matches(job.RepoKey)` 匹配；关联不到（仓库已删/已改名）则 URL 为空、显示 `job_name` 快照。
+- `Job` 响应模型不变（`name`/`url` 都在）。
+
+### 7.3 `GetRepositories`
+
+- 统计 SQL 改为 `GROUP BY repo_key`，保留 `HAVING start_time = MAX(start_time)` 取末次运行的写法与注释。
+- 统计按 `stats[repo.Key()]` 关联。
+- 搜索过滤改为 `name` 或 `url` 任一 `Contains`（大小写折叠）。
+
+### 7.4 仓库 CRUD
+
+- `PUT/DELETE /api/repositories/:id` 的 `:id` 语义变为**身份键**（URL 编码传输）。后端对 `:id` 用 `repo.Matches(id)` 定位（URL 或 `name:` 两种形态都处理）：
+  - URL 仓库：id 传 URL（`encodeURIComponent`）；
+  - 空 URL 仓库：id 传 `name:<name>`。
+- `CreateRepository`：
+  - **允许 name 重复**（删除既有按 name 的 409 检查）；
+  - **URL 判重**：规范化后（`NormalizeURL`）与现有仓库相同的 URL → 409；空 URL 仓库按 name 判重 → 409（等价于旧行为）。
+- `UpdateRepository`：name、URL 都可改（前端表单不再禁用 name）。URL 被改 → 该条目身份键变化，旧 `repo_key` 下的任务历史保持原样但不再被新键关联（孤立，符合决策）。更新后若与**其他**仓库的规范化 URL 冲突 → 409（更新对象自身不与自己比较）。
+
+### 7.5 破坏性变更清单
+
+- `POST /api/jobs` 字段 `repository` → `repository_key`。
+- 仓库 `PUT/DELETE` 路径参数由 name 改为身份键。
+
+## 8. 前端（`web/static/js/main.js`）
+
+- 新增 JS 函数 `repoKey(r)`：`r.URL` 非空返回 `r.URL`，否则 `'name:' + r.Name`（规范化交给后端，前端只负责 URL vs name 分支与编码）。
+- 仓库表操作（Execute / Edit / Delete）的 `data-*` 与 URL 路径改用 `encodeURIComponent(repoKey(r))`。
+- `runRepo` 请求体改 `{ repository_key: repoKey(repo) }`。
+- 编辑表单移除 `$('#repo-name').disabled = !!repo`（name 现在可改）。
+- 任务页过滤输入占位文案改为 "Filter by repository name or URL…"；仓库页搜索占位改为 "Filter by name or URL…"。
+- 展示不变：表格仍 Name 加粗、URL 灰色。
+
+## 9. 失败语义与边界
+
+- **迁移失败**：`Migrate` 出错则 server 启动失败退出（与 db 初始化失败同处理，`ui.ErrorfExit`）——宁可起不来也不要在坏 schema 上跑。
+- **孤立历史**：URL 改名/删除仓库后，旧 `repo_key` 的 executions 仍在库中，但 `GetRepositories` 不关联、`GetJobs` 仍能按 job_name/旧键搜到（作为纯历史展示）。这是刻意为之，不清理。
+- **明确不做**：
+  - `cmd/daemon` 行为改动（无身份逻辑，仅日志）。
+  - org/user 仓库在 executor 下运行时 URL 为空的既有失败问题。
+  - 前端 JS 的完整 URL 规范化（以后端为准）。
+  - 配置导入导出（子项目 B，另行 spec）。
+
+## 10. 测试
+
+新增：
+
+- `internal/typedef`：`NormalizeURL` / `Key()` / `Matches` 表驱动测试（协议、大小写、尾斜杠、`.git`、空 URL、`name:` 回退、`name:` 输入精确匹配、URL 输入规范化匹配）。
+- `internal/db`：`Migrate` 测试——构造旧 schema（无 `repo_key` 列）的库，运行后列存在且回填正确；新 schema 库幂等；`job_name` 匹配不到时置为 `name:<job_name>`。
+- `internal/executor`：按 `Key()` 查找、INSERT 写入 `repo_key`、找不到返回错误。
+- `internal/server`：
+  - 按 URL 创建/更新/删除仓库；name 允许重复；URL 重复 409；更新 URL 冲突 409；
+  - `CreateJob` 用 `repository_key`；`GetJobs` name/URL 模糊过滤；
+  - `GetRepositories` 按 `repo_key` 聚合、搜索 name 或 URL。
+- 既有 server 测试（`repository_test.go` 等）中按 name 作为路径 id 的用例需同步改为身份键。
+
+前端无 JS 测试基建，UI 改动靠后端 API 测试 + 手动/浏览器验证。

--- a/docs/superpowers/specs/2026-08-19-repo-identity-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-19-repo-identity-refactor-design.md
@@ -24,14 +24,17 @@
 
 | 决策点 | 结论 |
 |---|---|
-| 主键 | 规范化后的 **URL**；URL 为空的仓库（`type: user/org`）回退用 `name` |
+| 主键 | 规范化后的 **URL**；**空 URL 即非法**（创建/导入/启动校验都报错），无 `name:` 兜底 |
 | name | 允许重复、允许改名，仅用于展示与查询 |
+| 历史数据 | **不做兼容回填**——工具尚未正式使用、无存量数据，`executions` 只新增 `repo_key` 列，不回溯旧数据 |
+| org/user 条目 | 保留；URL 为空时按 `orgName` **自动合成** `https://github.com/<orgName>` 作为身份 |
+| 执行/记账粒度 | 运行 org/user 条目时**在任务内展开**成具体仓库，每个具体仓库一条 execution（repo_key = 具体仓库 URL）；org 条目统计 = 成员仓库的 **URL 前缀聚合** |
 | URL 修改 | 允许修改；修改即身份变更，旧 URL 下的任务历史保持原样但不再被查询关联 |
 | URL 重复 | 创建/更新时拒绝（规范化后相同） |
 | 查询 | 任务过滤与仓库搜索均支持 name + URL 模糊匹配 |
-| API 破坏性变更 | `POST /api/jobs` 请求字段由 name 改为仓库身份键 |
+| API 破坏性变更 | `POST /api/jobs` 请求字段改为仓库身份键；org 展开时响应返回多个 job_id |
 
-**范围**：DB schema 迁移、`internal/executor`、`internal/server` API、`web` 前端。`cmd/daemon` 仅日志使用 name，无身份逻辑，不动。`storage` 仍按 name 引用，不动。org/user 仓库在 `internal/repository.addRepo` 中展开为具体 URL 仓库的既有行为不变。
+**范围**：DB schema、`internal/executor`、`internal/server` API、`web` 前端。`cmd/daemon` 仅日志使用 name，无身份逻辑，不动。`storage` 仍按 name 引用，不动。
 
 ## 2. 现状与关键事实
 
@@ -39,7 +42,7 @@
 |---|---|
 | `internal/db/db.go:46` | `executions.job_name TEXT NOT NULL`，无 URL/键列 |
 | `internal/db/models.go` | `Job.JobName` 字段 |
-| `internal/executor/executor.go:57-104` | `ExecuteJob(jobName)` 按 `repo.Name` 查找；INSERT 只写 `job_name` |
+| `internal/executor/executor.go:57-104` | `ExecuteJob(jobName)` 按 `repo.Name` 查找；INSERT 只写 `job_name`；org/user 条目 URL 为空时 Sync 会失败（既有局限） |
 | `internal/server/api.go:43` | `CreateJob` 校验按 `repo.Name == req.Repository` |
 | `internal/server/api.go:121-138` | `GetJobs` 过滤按 `job_name LIKE` |
 | `internal/server/api.go:186-191` | `GetJobs` 用 `repo.Name == job.Name` 从 config 解析 URL |
@@ -47,23 +50,25 @@
 | `internal/server/api.go:371` | 仓库搜索仅 name `Contains` |
 | `internal/server/api.go:390` | 统计关联 `stats[repo.Name]` |
 | `internal/server/api.go:462,544` | 仓库 `PUT/DELETE :id` 按 `existing.Name == id` 定位 |
+| `internal/repository/repository.go:40-76` | `addRepo`（私有）把 org/user 展开成具体 URL 仓库；`GetRepositories("")` 遍历展开 |
 | `web/static/js/main.js` | 操作按钮按 name 编码；`runRepo` 传 name；name 编辑禁用 |
 
-一个既有事实：`type: user/org` 的仓库在 config 里没有 `url`（只有 `orgName`），其身份必须回退。另外 `GetRepositories` 的聚合 SQL 用了 SQLite 的技巧写法（`GROUP BY xxx HAVING start_time = MAX(start_time)` 取每组最后一条），换分组键时保留该写法与 `DATETIME` 列的注释约束（modernc/sqlite 驱动只有声明为 DATETIME 的列才能 scan 成 `time.Time`）。
+一个既有事实：`GetRepositories` 的聚合 SQL 用了 SQLite 的技巧写法（`GROUP BY xxx HAVING start_time = MAX(start_time)`，在每组内取 COUNT/SUM 并返回末次运行的 start_time），换分组键时保留该写法与 `DATETIME` 列的注释约束（modernc/sqlite 驱动只有声明为 DATETIME 的列才能 scan 成 `time.Time`）。
 
 ## 3. 方案选择
 
-**选 A：引入「仓库身份键」（`RepoKey`），贯穿 DB、executor、API、前端。**
+**选 A：引入「仓库身份键」（`Key()` = 规范化 URL），贯穿 DB、executor、API、前端；org/user 在 executor 内展开、按具体仓库记账。**
 
-- 在 `typedef` 增加 `Repository.Key()` 与 URL 规范化函数，作为唯一判等口径。
-- DB `executions` 新增 `repo_key` 列（身份键），保留 `job_name`（执行时快照的展示名）。
-- executor、API 全部改为按 `RepoKey` 查找/关联/聚合。
-- 前端用同名 `repoKey(r)` 生成操作键，匹配后端。
+- `typedef` 提供 `Repository.Key()` 与 URL 规范化，作为唯一判等口径。
+- DB `executions` 新增 `repo_key` 列（规范化 URL），保留 `job_name`（执行时快照的展示名）。
+- executor、API 全部按身份键查找/关联/聚合。
+- org/user 条目身份用合成 URL；执行时经 `repository.Expand` 展开为具体仓库逐个归档。
 
 不选：
 
-- **方案 B（前端只改传参、后端只改 CRUD id，不引入 key 列）**：不引入 `repo_key` 列就无法在 `executions` 上可靠聚合（空 URL 仓库会塌缩到同一组），name 与 URL 的关系无法在历史中稳定表达。否决。
-- **方案 C（复用 name 列存 URL，另加 name 列）**：语义混乱，历史数据迁移更复杂。否决。
+- **方案 B（前端只改传参、后端只改 CRUD id，不引入 key 列）**：不引入 `repo_key` 列就无法在 `executions` 上可靠聚合；org/user 无 URL 时身份无法表达。否决。
+- **方案 C（复用 name 列存 URL，另加 name 列）**：语义混乱。否决。
+- **方案 D（org/user 按条目记账，一条 execution 记整个 org）**：历史无法区分具体归档了哪些仓库，与 daemon 按成员调度的粒度不一致。否决（用户已确认按具体仓库记账）。
 
 ## 4. 身份键与 URL 规范化（`internal/typedef`）
 
@@ -74,16 +79,16 @@
 // 返回 "" 表示没有可用 URL。
 func NormalizeURL(url string) string
 
-// Key 返回仓库身份键：URL 非空用 "url:"+NormalizeURL(URL)，否则 "name:"+Name。
+// EffectiveURL 返回条目的有效 URL：URL 非空直接用；type 为 user/org 且 orgName 非空时
+// 合成 "https://github.com/<orgName>"；否则 ""（非法）。
+func (r Repository) EffectiveURL() string
+
+// Key 返回仓库身份键 = NormalizeURL(EffectiveURL())。空 URL 会得到 ""，调用方必须拒绝。
 func (r Repository) Key() string
 
-// Matches 判断一段「用户输入的身份键」是否命中该仓库。输入有两种形态：
-//   - "name:xxx"（空 URL 仓库的兜底键）→ 与 Name 精确比较；
-//   - 其余 → 视为仓库 URL，规范化后与 Key() 比较（处理 url: 前缀、协议、尾斜杠、.git）。
+// Matches 判断一段用户输入是否命中该仓库：输入被规范化后与 Key() 比较。空输入返回 false。
 func (r Repository) Matches(input string) bool
 ```
-
-**匹配口径统一用 `repo.Matches(input)`**：前端传原始 URL 或 `name:<name>`，后端统一走 Matches，避免「前端 URL 形态」与「后端 key 形态」对不上的坑。
 
 规范化规则（表驱动可测）：
 
@@ -92,9 +97,10 @@ func (r Repository) Matches(input string) bool
 | `github.com/wnarutou/gitrieve` | `github.com/wnarutou/gitrieve` |
 | `https://GITHUB.com/wnarutou/gitrieve/` | `github.com/wnarutou/gitrieve` |
 | `http://github.com/wnarutou/gitrieve.git` | `github.com/wnarutou/gitrieve` |
-| `git@github.com:wnarutou/gitrieve.git` | `github.com/wnarutou/gitrieve`（可选，先支持 `https/http/裸 host`，`git@` 形式另行说明） |
 
 `git@host:path` 的 SCP 风格先**不支持**（示例配置全部用 `host/owner/repo` 形式）；若后续需要再扩展。规范化逻辑与前端 JS 版本各自独立实现，但**身份判定以后端为准**（API 路径参数在后端也做规范化后再匹配）。
+
+**空 URL 的约束**：创建/更新仓库、导入、启动配置校验时，凡 `EffectiveURL()` 为空（非 user/org，或无 orgName）即报错拒绝。org/user 条目的合成 URL 在**创建/导入时直接写入条目**（config 里存的是合成后的完整 URL），保证"每个已存条目都有非空 URL"字面成立。
 
 ## 5. DB 层（`internal/db`）
 
@@ -108,26 +114,34 @@ repo_key TEXT NOT NULL DEFAULT ''
 
 新库在 `CREATE TABLE IF NOT EXISTS executions` 中直接带上该列。
 
-### 迁移与回填
+### 迁移（无回填）
 
-新增 `db.Migrate(db *DB, repos []typedef.Repository) error`，在 server 启动（拿到 config 后）调用一次：
+新增 `db.Migrate(db *DB) error`，在 server 启动时调用一次：
 
 1. `PRAGMA table_info(executions)` 检测 `repo_key` 列是否存在；不存在则 `ALTER TABLE executions ADD COLUMN repo_key TEXT NOT NULL DEFAULT ''`。
-2. 回填：对每个配置仓库，`UPDATE executions SET repo_key = ? WHERE job_name = ? AND (repo_key = '' OR repo_key IS NULL)`（用 `repo.Key()` 回填——旧数据按 `job_name` 尽力匹配，匹配不到的置为 `"name:"+job_name` 自我归档，保证各自成组、不互相污染）。
-3. 幂等：列已存在时跳过 ALTER；回填语句本身幂等。
+2. **不做数据回填**（无存量数据）。旧开发库中既有行的 `repo_key` 保持 `''`，与任何配置条目都匹配不上，作为纯历史显示即可。
 
-依赖方向：`db` 导入 `typedef`（`typedef` 是叶子包，无循环依赖）。
+幂等：列已存在时跳过 ALTER。`db` 保持只依赖 `database/sql` 与 sqlite 驱动，不引入 `typedef`（无回填后不再需要仓库类型）。
 
 ## 6. Executor（`internal/executor`）
 
-`ExecuteJob(repoKey string)`：按 `repo.Key() == repoKey` 查找仓库；INSERT 改为：
+### 查找
+
+`ExecuteJob(repoKey string)`：按 `repo.Matches(repoKey)` 在 config 中定位条目。
+
+### 执行与展开
+
+- **type = repo**：与现在一致，跑单个仓库，产生一条 execution，返回 `[]string{jobID}`。
+- **type = user/org**：经 `repository.Expand(repo)`（把私有 `addRepo` 提为导出函数）展开成具体仓库列表，对每个具体仓库**独立执行**：各自生成 jobID、execution 行、日志流、可独立取消。返回 `[]string{jobID, ...}`。execution 的 `repo_key` 一律写**具体仓库**的规范化 URL，`job_name` 写具体仓库名。
+
+INSERT 改为：
 
 ```sql
 INSERT INTO executions (id, job_name, repo_key, start_time, status)
 VALUES (?, ?, ?, ?, ?)
 ```
 
-`job_name` 写执行时的 `repo.Name`（显示快照），`repo_key` 写 `repo.Key()`。其余（runningJobs 按 jobID、状态更新、取消）不变。
+`runningJobs` 仍按 jobID 管理，取消/状态更新逻辑不变。
 
 ## 7. API（`internal/server`）
 
@@ -141,40 +155,49 @@ type CreateJobRequest struct {
 }
 ```
 
-按 `repo.Matches(req.RepositoryKey)` 查找；找不到 404。空 URL 仓库也能用 `name:` 键触发（执行内部仍会失败——既有局限，不在本子项目修复）。
+按 `repo.Matches(req.RepositoryKey)` 查找；找不到 404。响应改为返回**多个 job_id**：
+
+```go
+type CreateJobResponse struct {
+    JobIDs []string `json:"job_ids"`
+    Status string   `json:"status"`
+}
+```
+
+（type=repo 时长度为 1，行为与现状等价。）
 
 ### 7.2 `GetJobs`
 
-- SELECT 增加 `repo_key`；过滤参数 `repository` 改为对 `(job_name LIKE ? ESCAPE '\' OR repo_key LIKE ? ESCAPE '\')` 匹配。**第二个 LIKE 的搜索词先做 URL 规范化**（`NormalizeURL(q)`）再包 `%`：这样用户输入 `https://github.com/wnarutou/gitrieve/`（带协议/尾斜杠）也能命中规范化后的 `repo_key`（`url:github.com/wnarutou/gitrieve`）。
-- `Job.url` 仍从 config 解析，但关联改按 `repo.Matches(job.RepoKey)` 匹配；关联不到（仓库已删/已改名）则 URL 为空、显示 `job_name` 快照。
+- SELECT 增加 `repo_key`；过滤参数 `repository` 改为对 `(job_name LIKE ? ESCAPE '\' OR repo_key LIKE ? ESCAPE '\')` 匹配。**第二个 LIKE 的搜索词先做 URL 规范化**（`NormalizeURL(q)`）再包 `%`：这样用户输入 `https://github.com/wnarutou/gitrieve/`（带协议/尾斜杠）也能命中规范化后的 `repo_key`。
+- `Job.url` 仍从 config 解析，但关联改按 `repo.Matches(job.RepoKey)` 匹配；关联不到（仓库已删/已改名/旧数据空键）则 URL 为空、显示 `job_name` 快照。
 - `Job` 响应模型不变（`name`/`url` 都在）。
 
 ### 7.3 `GetRepositories`
 
-- 统计 SQL 改为 `GROUP BY repo_key`，保留 `HAVING start_time = MAX(start_time)` 取末次运行的写法与注释。
-- 统计按 `stats[repo.Key()]` 关联。
-- 搜索过滤改为 `name` 或 `url` 任一 `Contains`（大小写折叠）。
+- 统计 SQL 改为 `GROUP BY repo_key`，保留 `HAVING start_time = MAX(start_time)` 写法与注释；每组一行含 `last_run/total/success/failed`。
+- 关联：对每个配置条目，取其身份键对应的统计；**type 为 user/org 时**对「键前缀命中」的成员做**求和聚合**——`repo_key == entry.Key()` 或 `repo_key` 以 `entry.Key()` 为路径边界前缀（`HasPrefix` 且下一个字符是 `/` 或结尾，避免 `github.com/wnarutou` 误吞 `github.com/wnarutou2/x`）。`last_run` 取命中成员的 max。
+- 搜索过滤改为 `name` 或 `url`（`EffectiveURL()`）任一 `Contains`（大小写折叠）。
 
 ### 7.4 仓库 CRUD
 
-- `PUT/DELETE /api/repositories/:id` 的 `:id` 语义变为**身份键**（URL 编码传输）。后端对 `:id` 用 `repo.Matches(id)` 定位（URL 或 `name:` 两种形态都处理）：
-  - URL 仓库：id 传 URL（`encodeURIComponent`）；
-  - 空 URL 仓库：id 传 `name:<name>`。
+- `PUT/DELETE /api/repositories/:id` 的 `:id` 语义变为**身份键**（URL 编码传输），后端用 `repo.Matches(id)` 定位。
 - `CreateRepository`：
   - **允许 name 重复**（删除既有按 name 的 409 检查）；
-  - **URL 判重**：规范化后（`NormalizeURL`）与现有仓库相同的 URL → 409；空 URL 仓库按 name 判重 → 409（等价于旧行为）。
+  - **URL 判重**：规范化后（`NormalizeURL(EffectiveURL())`）与现有仓库相同 → 409；
+  - **空 URL 拒绝**：非 user/org 或 orgName 为空导致 `EffectiveURL()` 为空的 → 400；user/org 且 URL 为空 → 自动填入合成 URL。
 - `UpdateRepository`：name、URL 都可改（前端表单不再禁用 name）。URL 被改 → 该条目身份键变化，旧 `repo_key` 下的任务历史保持原样但不再被新键关联（孤立，符合决策）。更新后若与**其他**仓库的规范化 URL 冲突 → 409（更新对象自身不与自己比较）。
 
 ### 7.5 破坏性变更清单
 
-- `POST /api/jobs` 字段 `repository` → `repository_key`。
+- `POST /api/jobs` 字段 `repository` → `repository_key`；响应 `job_id` → `job_ids`。
 - 仓库 `PUT/DELETE` 路径参数由 name 改为身份键。
 
 ## 8. 前端（`web/static/js/main.js`）
 
-- 新增 JS 函数 `repoKey(r)`：`r.URL` 非空返回 `r.URL`，否则 `'name:' + r.Name`（规范化交给后端，前端只负责 URL vs name 分支与编码）。
-- 仓库表操作（Execute / Edit / Delete）的 `data-*` 与 URL 路径改用 `encodeURIComponent(repoKey(r))`。
-- `runRepo` 请求体改 `{ repository_key: repoKey(repo) }`。
+- 新增 `repoKey(r)`：**就是 `r.URL`**（所有条目都有 URL，包括合成后的 org/user；前端不做规范化，交给后端）。操作按钮的 `data-*` 与 URL 路径改用 `encodeURIComponent(repoKey(r))`。
+- `runRepo` 请求体改 `{ repository_key: repoKey(repo) }`；响应是 `job_ids` 数组：
+  - 长度 1 → 保持现状：toast + 打开日志弹窗；
+  - 长度 >1（org/user 展开）→ toast「Started N jobs」并刷新任务列表，不弹日志窗。
 - 编辑表单移除 `$('#repo-name').disabled = !!repo`（name 现在可改）。
 - 任务页过滤输入占位文案改为 "Filter by repository name or URL…"；仓库页搜索占位改为 "Filter by name or URL…"。
 - 展示不变：表格仍 Name 加粗、URL 灰色。
@@ -182,10 +205,11 @@ type CreateJobRequest struct {
 ## 9. 失败语义与边界
 
 - **迁移失败**：`Migrate` 出错则 server 启动失败退出（与 db 初始化失败同处理，`ui.ErrorfExit`）——宁可起不来也不要在坏 schema 上跑。
-- **孤立历史**：URL 改名/删除仓库后，旧 `repo_key` 的 executions 仍在库中，但 `GetRepositories` 不关联、`GetJobs` 仍能按 job_name/旧键搜到（作为纯历史展示）。这是刻意为之，不清理。
+- **空 URL 配置**：启动时配置校验发现 `EffectiveURL()` 为空的条目（非 user/org，或无 orgName）→ `ui.ErrorfExit` 报错退出。无历史数据，不做宽容处理。
+- **孤立历史**：URL 改名/删除仓库后，旧 `repo_key` 的 executions 仍在库中，但 `GetRepositories` 不关联、`GetJobs` 仍能按 job_name/旧键搜到（纯历史展示）。刻意为之，不清理。
 - **明确不做**：
   - `cmd/daemon` 行为改动（无身份逻辑，仅日志）。
-  - org/user 仓库在 executor 下运行时 URL 为空的既有失败问题。
+  - org/user 展开后的每个成员仓库与显式条目并存时的重复归档问题（用户自行避免）。
   - 前端 JS 的完整 URL 规范化（以后端为准）。
   - 配置导入导出（子项目 B，另行 spec）。
 
@@ -193,13 +217,15 @@ type CreateJobRequest struct {
 
 新增：
 
-- `internal/typedef`：`NormalizeURL` / `Key()` / `Matches` 表驱动测试（协议、大小写、尾斜杠、`.git`、空 URL、`name:` 回退、`name:` 输入精确匹配、URL 输入规范化匹配）。
-- `internal/db`：`Migrate` 测试——构造旧 schema（无 `repo_key` 列）的库，运行后列存在且回填正确；新 schema 库幂等；`job_name` 匹配不到时置为 `name:<job_name>`。
-- `internal/executor`：按 `Key()` 查找、INSERT 写入 `repo_key`、找不到返回错误。
+- `internal/typedef`：`NormalizeURL` / `EffectiveURL` / `Key` / `Matches` 表驱动测试（协议、大小写、尾斜杠、`.git`、user/org 合成 URL、空输入/空 URL 拒绝）。
+- `internal/db`：`Migrate` 测试——旧 schema（无 `repo_key` 列）补列成功；新 schema 幂等；不加回填断言（旧行键为空）。
+- `internal/executor`：按 `Key()`/`Matches` 查找、INSERT 写入 `repo_key`、找不到返回错误；**type=repo 返回单 jobID，type=org/user 经展开返回多个 jobID 且各写具体仓库键**。
+- `internal/repository`：`Expand` 对 repo/user/org 的展开结果（user/org 需要能 mock 掉 GitHub 客户端）。
 - `internal/server`：
-  - 按 URL 创建/更新/删除仓库；name 允许重复；URL 重复 409；更新 URL 冲突 409；
-  - `CreateJob` 用 `repository_key`；`GetJobs` name/URL 模糊过滤；
-  - `GetRepositories` 按 `repo_key` 聚合、搜索 name 或 URL。
+  - 按 URL 创建/更新/删除仓库；name 允许重复；URL 重复 409；更新 URL 冲突 409；空 URL 创建 400；
+  - `CreateJob` 用 `repository_key`、响应 `job_ids`（repo 单值、org 多值）；
+  - `GetJobs` name/URL 模糊过滤（含带协议的完整 URL）；
+  - `GetRepositories` 按 `repo_key` 聚合、org 前缀求和、路径边界不误吞、搜索 name 或 URL。
 - 既有 server 测试（`repository_test.go` 等）中按 name 作为路径 id 的用例需同步改为身份键。
 
 前端无 JS 测试基建，UI 改动靠后端 API 测试 + 手动/浏览器验证。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,11 @@ func Init() {
 	if ins.ReleaseSizeLimit == 0 {
 		ins.ReleaseSizeLimit = 300000000
 	}
+	// 启动校验：每个仓库条目都必须有可用身份。身份键为空意味着永远无法被
+	// 匹配或执行，直接拒绝启动。
+	if err := validateIdentity(ins); err != nil {
+		ui.ErrorfExit("Invalid configuration: %s", err)
+	}
 }
 
 func GetIns() *Config {
@@ -122,6 +127,21 @@ func GetRetryConfig() retry.Config {
 		MaxRetries: GetRetryMaxCount(),
 		BaseDelay:  GetRetryBaseDelay(),
 	}
+}
+
+// validateIdentity ensures every repository entry has a usable identity (a
+// non-empty URL, or orgName for user/org types). The repository identity is the
+// normalized URL; an entry without one can never be matched or executed.
+// Returns an error rather than exiting so it is unit-testable; Init surfaces
+// it via ui.ErrorfExit.
+func validateIdentity(cfg *Config) error {
+	for _, repo := range cfg.Repository {
+		if repo.Key() == "" {
+			return fmt.Errorf("repository %q (type %q) has an empty URL and no orgName; every repository needs a URL identity",
+				repo.Name, repo.GetType())
+		}
+	}
+	return nil
 }
 
 // Save persists the current in-memory config back to the config file via viper.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/typedef"
 )
 
 // writeTmpConfig points the package global at a temp config file and loads it,
@@ -123,4 +124,22 @@ func TestSaveStorageRoundTripKeepsFlatFields(t *testing.T) {
 	require.Equal(t, "localFile", GetIns().Storage[0].Name)
 	require.Equal(t, "file", GetIns().Storage[0].Type)
 	require.Equal(t, "/app/repo", GetIns().Storage[0].Path)
+}
+
+func TestValidateIdentity(t *testing.T) {
+	// 非 user/org 且无 URL → 校验拒绝。
+	err := validateIdentity(&Config{Repository: []typedef.Repository{
+		{Name: "orphan", Type: typedef.TypeRepo},
+	}})
+	require.Error(t, err)
+
+	// user/org 且带 orgName → 通过；合成 URL 即为身份。
+	acme := Config{Repository: []typedef.Repository{
+		{Name: "acme", Type: typedef.TypeOrg, OrgName: "acme"},
+	}}
+	require.NoError(t, validateIdentity(&acme))
+	require.Equal(t, "https://github.com/acme", acme.Repository[0].EffectiveURL())
+
+	// 空仓库列表 → 通过。
+	require.NoError(t, validateIdentity(&Config{}))
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -44,6 +44,7 @@ func Initialize(path string) (*DB, error) {
 		CREATE TABLE IF NOT EXISTS executions (
 			id TEXT PRIMARY KEY,
 			job_name TEXT NOT NULL,
+			repo_key TEXT NOT NULL DEFAULT '',
 			start_time DATETIME NOT NULL,
 			end_time DATETIME,
 			status TEXT NOT NULL,

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1,0 +1,42 @@
+package db
+
+import "fmt"
+
+// Migrate upgrades an existing database to the current schema. Additive-only:
+// it adds the repo_key column to executions when missing and never backfills or
+// drops data. Call once at server startup (after Initialize).
+func Migrate(d *DB) error {
+	has, err := columnExists(d, "executions", "repo_key")
+	if err != nil {
+		return fmt.Errorf("check executions.repo_key: %w", err)
+	}
+	if !has {
+		if _, err := d.Exec(`ALTER TABLE executions ADD COLUMN repo_key TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("add executions.repo_key: %w", err)
+		}
+	}
+	return nil
+}
+
+// columnExists reports whether table has a column named column.
+func columnExists(d *DB, table, column string) (bool, error) {
+	rows, err := d.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid, notnull, pk int
+			name, ctype      string
+			dflt             *string
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -53,3 +53,55 @@ func TestInitializeIsIdempotent(t *testing.T) {
 		)`)
 	assert.NoError(t, err)
 }
+
+// TestMigrateAddsRepoKeyColumn verifies Migrate upgrades a legacy executions
+// table (no repo_key) in place without backfilling, and that new rows can
+// write repo_key.
+func TestMigrateAddsRepoKeyColumn(t *testing.T) {
+	testDB, err := Initialize(":memory:")
+	assert.NoError(t, err)
+	defer testDB.Close()
+
+	// Rebuild executions in the pre-migration shape (no repo_key).
+	_, err = testDB.Exec(`DROP TABLE executions`)
+	assert.NoError(t, err)
+	_, err = testDB.Exec(`
+		CREATE TABLE executions (
+			id TEXT PRIMARY KEY,
+			job_name TEXT NOT NULL,
+			start_time DATETIME NOT NULL,
+			end_time DATETIME,
+			status TEXT NOT NULL,
+			error_message TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`)
+	assert.NoError(t, err)
+
+	// A pre-existing legacy row.
+	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, start_time, status) VALUES (?, ?, ?, ?)`,
+		"old", "repo-a", time.Now(), "completed")
+	assert.NoError(t, err)
+
+	assert.NoError(t, Migrate(testDB))
+
+	// Column now exists; legacy row's key stays empty (no backfill).
+	var key string
+	err = testDB.QueryRow(`SELECT repo_key FROM executions WHERE id = 'old'`).Scan(&key)
+	assert.NoError(t, err)
+	assert.Equal(t, "", key)
+
+	// New rows can write repo_key.
+	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, status) VALUES (?, ?, ?, ?, ?)`,
+		"new", "repo-b", "github.com/b/b", time.Now(), "running")
+	assert.NoError(t, err)
+}
+
+// TestMigrateIsIdempotent verifies Migrate on a fresh (already current) DB is a no-op.
+func TestMigrateIsIdempotent(t *testing.T) {
+	testDB, err := Initialize(":memory:")
+	assert.NoError(t, err)
+	defer testDB.Close()
+
+	assert.NoError(t, Migrate(testDB))
+	assert.NoError(t, Migrate(testDB))
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
-	"time"
 	"github.com/google/uuid"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/db"
@@ -17,6 +15,8 @@ import (
 	"github.com/wnarutou/gitrieve/internal/typedef"
 	"github.com/wnarutou/gitrieve/internal/ui"
 	"github.com/wnarutou/gitrieve/internal/wiki"
+	"sync"
+	"time"
 )
 
 type ExecutionStatus string

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -54,31 +55,52 @@ func NewExecutor(logger *logger.Logger, db *db.DB, cfg *config.Config) *Executor
 	}
 }
 
-func (e *Executor) ExecuteJob(jobName string) (string, error) {
-	// Find repository in config
-	var job typedef.Repository
+// ErrRepositoryNotFound 表示配置中找不到匹配该身份键的仓库条目。
+var ErrRepositoryNotFound = errors.New("repository not found in configuration")
+
+// expandRepos 是把 user/org 条目展开为具体仓库的 seam：生产用 repository.Expand，
+// 测试注入 fake，避免真实 GitHub 调用。
+var expandRepos = repository.Expand
+
+// ExecuteJob 按仓库身份键（规范化 URL）在配置中定位条目并执行。type=repo 产生
+// 一条 execution 并返回单元素 jobID；type=user/org 先在任务内展开为具体仓库，
+// 每个具体仓库独立执行（各自 jobID / execution / 日志流 / 可取消）。
+func (e *Executor) ExecuteJob(repoKey string) ([]string, error) {
+	var repo typedef.Repository
 	found := false
-	for _, repo := range e.cfg.Repository {
-		if repo.Name == jobName {
-			job = repo
+	for _, r := range e.cfg.Repository {
+		if r.Matches(repoKey) {
+			repo = r
 			found = true
 			break
 		}
 	}
-
 	if !found {
-		return "", fmt.Errorf("repository %s not found in configuration", jobName)
+		return nil, ErrRepositoryNotFound
 	}
 
+	jobIDs := make([]string, 0, 1)
+	for _, concrete := range expandRepos(repo) {
+		jobID, err := e.launchJob(concrete)
+		if err != nil {
+			return nil, err
+		}
+		jobIDs = append(jobIDs, jobID)
+	}
+	return jobIDs, nil
+}
+
+// launchJob 为单个具体仓库创建 execution 记录并异步执行。
+func (e *Executor) launchJob(job typedef.Repository) (string, error) {
 	// Generate job ID
 	jobID := uuid.New().String()
 	startTime := time.Now()
 
-	// Create execution record
+	// Create execution record: job_name 保存展示名快照，repo_key 是身份键。
 	_, err := e.db.Exec(`
-		INSERT INTO executions (id, job_name, start_time, status)
-		VALUES (?, ?, ?, ?)
-	`, jobID, jobName, startTime, string(StatusPending))
+		INSERT INTO executions (id, job_name, repo_key, start_time, status)
+		VALUES (?, ?, ?, ?, ?)
+	`, jobID, job.Name, job.Key(), startTime, string(StatusPending))
 	if err != nil {
 		return "", fmt.Errorf("failed to create execution record: %w", err)
 	}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -31,8 +31,9 @@ func newTestExecutor(t *testing.T) (*Executor, *db.DB) {
 func TestExecuteJobWritesBoundLogs(t *testing.T) {
 	exec, testDB := newTestExecutor(t)
 
-	jobID, err := exec.ExecuteJob("test-repo")
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
 	require.NoError(t, err)
+	require.Len(t, jobIDs, 1)
 
 	// executeAsync binds the goroutine and ui.Printf("Starting job execution")
 	// is forwarded to the DB logs for this execution. Poll for that specific
@@ -44,14 +45,14 @@ func TestExecuteJobWritesBoundLogs(t *testing.T) {
 	for {
 		var count int
 		err := testDB.QueryRow(
-			"SELECT COUNT(*) FROM logs WHERE execution_id = ? AND message = 'Starting job execution'", jobID,
+			"SELECT COUNT(*) FROM logs WHERE execution_id = ? AND message = 'Starting job execution'", jobIDs[0],
 		).Scan(&count)
 		require.NoError(t, err)
 		if count >= 1 {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("expected a 'Starting job execution' log row for execution %s", jobID)
+			t.Fatalf("expected a 'Starting job execution' log row for execution %s", jobIDs[0])
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -83,8 +84,9 @@ func TestExecuteJobRunsConfiguredComponents(t *testing.T) {
 	}
 	exec := NewExecutor(log, testDB, cfg)
 
-	jobID, err := exec.ExecuteJob("test-repo")
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
 	require.NoError(t, err)
+	require.Len(t, jobIDs, 1)
 
 	// The executor must run the configured component syncs. "Downloading issues"
 	// is written only after repository.Sync returns, and that sync does a real
@@ -94,14 +96,14 @@ func TestExecuteJobRunsConfiguredComponents(t *testing.T) {
 	for {
 		var count int
 		err := testDB.QueryRow(
-			"SELECT COUNT(*) FROM logs WHERE execution_id = ? AND message = 'Downloading issues'", jobID,
+			"SELECT COUNT(*) FROM logs WHERE execution_id = ? AND message = 'Downloading issues'", jobIDs[0],
 		).Scan(&count)
 		require.NoError(t, err)
 		if count >= 1 {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("expected 'Downloading issues' log row for execution %s", jobID)
+			t.Fatalf("expected 'Downloading issues' log row for execution %s", jobIDs[0])
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -110,18 +112,19 @@ func TestExecuteJobRunsConfiguredComponents(t *testing.T) {
 func TestExecuteJobCreatesRecord(t *testing.T) {
 	exec, testDB := newTestExecutor(t)
 
-	jobID, err := exec.ExecuteJob("test-repo")
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, jobID)
+	require.Len(t, jobIDs, 1)
+	assert.NotEmpty(t, jobIDs[0])
 
 	// A pending/running execution record should exist in the database
 	var status string
-	err = testDB.QueryRow("SELECT status FROM executions WHERE id = ?", jobID).Scan(&status)
+	err = testDB.QueryRow("SELECT status FROM executions WHERE id = ?", jobIDs[0]).Scan(&status)
 	assert.NoError(t, err)
 	assert.Contains(t, []string{"pending", "running"}, status)
 
 	// The job should be marked as running in memory
-	assert.True(t, exec.IsJobRunning(jobID))
+	assert.True(t, exec.IsJobRunning(jobIDs[0]))
 }
 
 func TestExecuteJobUnknownRepository(t *testing.T) {
@@ -137,4 +140,46 @@ func TestCancelNonRunningJob(t *testing.T) {
 	// Cancelling a job that was never started should still update its status
 	err := exec.CancelJob("never-started")
 	assert.NoError(t, err)
+}
+
+func TestExecuteJobWritesRepoKey(t *testing.T) {
+	exec, testDB := newTestExecutor(t)
+
+	jobIDs, err := exec.ExecuteJob("https://github.com/test/repo")
+	require.NoError(t, err)
+	require.Len(t, jobIDs, 1)
+
+	var repoKey string
+	err = testDB.QueryRow("SELECT repo_key FROM executions WHERE id = ?", jobIDs[0]).Scan(&repoKey)
+	assert.NoError(t, err)
+	assert.Equal(t, "github.com/test/repo", repoKey)
+}
+
+func TestExecuteJobExpandsOrgIntoMultipleJobs(t *testing.T) {
+	exec, testDB := newTestExecutor(t)
+	exec.cfg.Repository = []typedef.Repository{
+		{Name: "acme", URL: "https://github.com/acme", Type: typedef.TypeOrg, OrgName: "acme"},
+	}
+
+	old := expandRepos
+	t.Cleanup(func() { expandRepos = old })
+	expandRepos = func(repo typedef.Repository) []typedef.Repository {
+		return []typedef.Repository{
+			{Name: "alpha", URL: "github.com/acme/alpha"},
+			{Name: "beta", URL: "github.com/acme/beta"},
+		}
+	}
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme")
+	require.NoError(t, err)
+	require.Len(t, jobIDs, 2)
+
+	keys := map[string]bool{}
+	for _, id := range jobIDs {
+		var repoKey string
+		require.NoError(t, testDB.QueryRow("SELECT repo_key FROM executions WHERE id = ?", id).Scan(&repoKey))
+		keys[repoKey] = true
+	}
+	assert.True(t, keys["github.com/acme/alpha"])
+	assert.True(t, keys["github.com/acme/beta"])
 }

--- a/internal/repository/expand_test.go
+++ b/internal/repository/expand_test.go
@@ -1,0 +1,54 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+)
+
+type fakeRepoLister struct {
+	repos []string
+	err   error
+}
+
+func (f *fakeRepoLister) GetRepos(name, accountType string) ([]string, error) {
+	return f.repos, f.err
+}
+
+func TestExpand(t *testing.T) {
+	old := newGithubClient
+	t.Cleanup(func() { newGithubClient = old })
+	newGithubClient = func() (repoLister, error) {
+		return &fakeRepoLister{repos: []string{"github.com/acme/alpha", "github.com/acme/beta"}}, nil
+	}
+
+	t.Run("repo passthrough", func(t *testing.T) {
+		repo := typedef.Repository{Name: "solo", URL: "github.com/a/solo", Type: typedef.TypeRepo}
+		got := Expand(repo)
+		require.Len(t, got, 1)
+		assert.Equal(t, "solo", got[0].Name)
+		assert.Equal(t, "github.com/a/solo", got[0].URL)
+	})
+
+	t.Run("org expands to concrete repos inheriting options", func(t *testing.T) {
+		org := typedef.Repository{
+			Name: "acme", Type: typedef.TypeOrg, OrgName: "acme",
+			Cron: "0 2 * * *", AllBranches: true,
+		}
+		got := Expand(org)
+		require.Len(t, got, 2)
+		assert.Equal(t, "alpha", got[0].Name)
+		assert.Equal(t, "github.com/acme/alpha", got[0].URL)
+		assert.Equal(t, typedef.TypeRepo, got[0].GetType())
+		assert.Equal(t, "0 2 * * *", got[0].Cron) // 继承父条目配置
+		assert.True(t, got[0].AllBranches)
+		assert.Equal(t, "beta", got[1].Name)
+	})
+
+	t.Run("invalid type yields nothing", func(t *testing.T) {
+		bad := typedef.Repository{Name: "x", URL: "github.com/a/x", Type: "whatever"}
+		assert.Empty(t, Expand(bad))
+	})
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -20,12 +20,20 @@ import (
 	"github.com/wnarutou/gitrieve/internal/ui"
 )
 
+// repoLister 抽象 GitHub 客户端，测试时替换 newGithubClient 即可 mock。
+type repoLister interface {
+	GetRepos(name, accountType string) ([]string, error)
+}
+
+// newGithubClient 是可替换的包级 seam：生产用真客户端，测试注入 fake。
+var newGithubClient = func() (repoLister, error) { return github.New() }
+
 func GetRepositories(name string) []typedef.Repository {
 	repositories := make([]typedef.Repository, 0)
 	if name != "" {
 		// find repo in config
 		for _, repository := range internalconfig.GetIns().Repository {
-			if repository.Name == name {
+			if repository.Name == name || repository.Matches(name) {
 				repositories = addRepo(repository, repositories)
 			}
 		}
@@ -43,7 +51,7 @@ func addRepo(repo typedef.Repository, ret []typedef.Repository) []typedef.Reposi
 		ret = append(ret, repo)
 	case typedef.TypeUser, typedef.TypeOrg:
 		// get repos
-		client, err := github.New()
+		client, err := newGithubClient()
 		if err != nil {
 			ui.Errorf("Error creating github client, %s", err)
 			return ret
@@ -409,4 +417,11 @@ func Sync(ctx context.Context, repo typedef.Repository, iswiki bool, storages []
 		}
 	}
 	return nil
+}
+
+// Expand 返回一个配置条目实际对应的具体仓库列表。type=repo 原样返回自身；
+// type=user/org 通过 GitHub API 展开为成员仓库（继承 cron/storage 等选项）；
+// 非法类型返回空切片。CLI 与 executor 共用。
+func Expand(repo typedef.Repository) []typedef.Repository {
+	return addRepo(repo, nil)
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -294,8 +294,46 @@ func (a *API) GetJobLogs(c *gin.Context) {
 	})
 }
 
+// runStats 是单仓库/单组织的聚合运行统计。
+type runStats struct {
+	LastRun *time.Time
+	Total   int64
+	Success int64
+	Failed  int64
+}
+
+// lookupStats 返回配置条目的运行统计。type=repo 直接取自身键；type=org/user
+// 对「路径边界前缀」（entry.Key()+"/"）命中的成员求和，last_run 取成员最大值。
+// 前缀以 "/" 结尾，避免 github.com/acme 误吞 github.com/acme2/x。
+func lookupStats(stats map[string]runStats, repo typedef.Repository) runStats {
+	key := repo.Key()
+	if key == "" {
+		return runStats{}
+	}
+	switch repo.GetType() {
+	case typedef.TypeOrg, typedef.TypeUser:
+		prefix := key + "/"
+		var sum runStats
+		for k, s := range stats {
+			if !strings.HasPrefix(k, prefix) {
+				continue
+			}
+			sum.Total += s.Total
+			sum.Success += s.Success
+			sum.Failed += s.Failed
+			if s.LastRun != nil && (sum.LastRun == nil || s.LastRun.After(*sum.LastRun)) {
+				t := *s.LastRun
+				sum.LastRun = &t
+			}
+		}
+		return sum
+	default:
+		return stats[key]
+	}
+}
+
 // GetRepositories returns repositories with per-repo execution stats, last/next
-// run times, search (fuzzy name match) and pagination.
+// run times, search (fuzzy name or URL match) and pagination.
 func (a *API) GetRepositories(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
@@ -309,13 +347,7 @@ func (a *API) GetRepositories(c *gin.Context) {
 	}
 
 	// Aggregate per-repository execution stats from the DB.
-	type agg struct {
-		LastRun *time.Time
-		Total   int64
-		Success int64
-		Failed  int64
-	}
-	stats := map[string]agg{}
+	stats := map[string]runStats{}
 
 	// Note: we select the bare start_time column (constrained to the max by
 	// HAVING) rather than MAX(start_time). The modernc.org/sqlite driver only
@@ -323,13 +355,13 @@ func (a *API) GetRepositories(c *gin.Context) {
 	// aggregate expressions like MAX(start_time) have no declared type and come
 	// back as a raw string that database/sql cannot scan into *time.Time.
 	rows, err := a.db.Query(`
-		SELECT job_name,
+		SELECT repo_key,
 		       start_time AS last_run,
 		       COUNT(*)        AS total,
 		       COALESCE(SUM(status = 'completed'), 0) AS success,
 		       COALESCE(SUM(status = 'failed'), 0)    AS failed
 		FROM executions
-		GROUP BY job_name
+		GROUP BY repo_key
 		HAVING start_time = MAX(start_time)`)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to query repository stats: " + err.Error()})
@@ -338,30 +370,34 @@ func (a *API) GetRepositories(c *gin.Context) {
 	defer rows.Close()
 
 	for rows.Next() {
-		var name string
+		var key string
 		var lastRun sql.NullTime
-		var a agg
-		if err := rows.Scan(&name, &lastRun, &a.Total, &a.Success, &a.Failed); err != nil {
+		var a runStats
+		if err := rows.Scan(&key, &lastRun, &a.Total, &a.Success, &a.Failed); err != nil {
 			c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to scan repository stats: " + err.Error()})
 			return
 		}
 		if lastRun.Valid {
 			a.LastRun = &lastRun.Time
 		}
-		stats[name] = a
+		stats[key] = a
 	}
 	if err := rows.Err(); err != nil {
 		c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to iterate repository stats: " + err.Error()})
 		return
 	}
 
-	// Fuzzy name filter (in-memory equivalent of LIKE '%search%'). SQL LIKE is
-	// case-insensitive for ASCII, so match that by folding both sides to lower
-	// case before the Contains check.
+	// Fuzzy name or URL filter (in-memory equivalent of LIKE '%search%'). SQL
+	// LIKE is case-insensitive for ASCII, so match that by folding both sides to
+	// lower case before the Contains check.
 	filtered := make([]typedef.Repository, 0, len(a.config.Repository))
 	for _, repo := range a.config.Repository {
-		if search != "" && !strings.Contains(strings.ToLower(repo.Name), strings.ToLower(search)) {
-			continue
+		if search != "" {
+			inName := strings.Contains(strings.ToLower(repo.Name), strings.ToLower(search))
+			inURL := strings.Contains(strings.ToLower(repo.EffectiveURL()), strings.ToLower(search))
+			if !inName && !inURL {
+				continue
+			}
 		}
 		filtered = append(filtered, repo)
 	}
@@ -379,7 +415,7 @@ func (a *API) GetRepositories(c *gin.Context) {
 	now := time.Now()
 	overviews := make([]RepositoryOverview, 0, end-start)
 	for _, repo := range filtered[start:end] {
-		s := stats[repo.Name]
+		s := lookupStats(stats, repo)
 		overviews = append(overviews, RepositoryOverview{
 			Repository:  repo,
 			LastRunTime: s.LastRun,
@@ -417,12 +453,22 @@ func (a *API) CreateRepository(c *gin.Context) {
 		return
 	}
 
-	// Check for duplicates
+	// user/org 空 URL → 填合成 URL；随后统一判身份键非空。
+	repo.URL = repo.EffectiveURL()
+	if repo.Key() == "" {
+		c.JSON(http.StatusBadRequest, Response{
+			Code:    400,
+			Message: "Repository needs a non-empty URL (or orgName for user/org type)",
+		})
+		return
+	}
+
+	// 判重按身份键（URL），name 允许重复。
 	for _, existing := range a.config.Repository {
-		if existing.Name == repo.Name {
+		if existing.Key() == repo.Key() {
 			c.JSON(http.StatusConflict, Response{
 				Code:    409,
-				Message: "Repository with name '" + repo.Name + "' already exists",
+				Message: "Repository with URL '" + repo.Key() + "' already exists",
 			})
 			return
 		}
@@ -444,14 +490,17 @@ func (a *API) CreateRepository(c *gin.Context) {
 	})
 }
 
-// UpdateRepository modifies an existing repository by name (partial update via JSON merge).
+// UpdateRepository modifies an existing repository by identity key (partial update via JSON merge).
 func (a *API) UpdateRepository(c *gin.Context) {
-	id := c.Param("id")
+	// The route uses a *id catch-all so identity keys containing "/" reach the
+	// handler; gin prefixes the captured value with "/", which we strip before
+	// matching against repo keys.
+	id := strings.TrimPrefix(c.Param("id"), "/")
 
-	// Locate the existing repository
+	// Locate the existing repository by identity key (URL).
 	idx := -1
 	for i, existing := range a.config.Repository {
-		if existing.Name == id {
+		if existing.Matches(id) {
 			idx = i
 			break
 		}
@@ -513,6 +562,25 @@ func (a *API) UpdateRepository(c *gin.Context) {
 		return
 	}
 
+	// user/org 空 URL → 填合成 URL；空身份键拒绝；与其他仓库 URL 冲突拒绝。
+	updated.URL = updated.EffectiveURL()
+	if updated.Key() == "" {
+		c.JSON(http.StatusBadRequest, Response{
+			Code:    400,
+			Message: "Repository needs a non-empty URL (or orgName for user/org type)",
+		})
+		return
+	}
+	for i, other := range a.config.Repository {
+		if i != idx && other.Key() == updated.Key() {
+			c.JSON(http.StatusConflict, Response{
+				Code:    409,
+				Message: "Repository with URL '" + updated.Key() + "' already exists",
+			})
+			return
+		}
+	}
+
 	a.config.Repository[idx] = updated
 
 	msg := ""
@@ -527,13 +595,14 @@ func (a *API) UpdateRepository(c *gin.Context) {
 	})
 }
 
-// DeleteRepository removes a repository from the configuration by name.
+// DeleteRepository removes a repository from the configuration by identity key.
 func (a *API) DeleteRepository(c *gin.Context) {
-	id := c.Param("id")
+	// See UpdateRepository: strip the leading "/" gin adds to *id catch-all values.
+	id := strings.TrimPrefix(c.Param("id"), "/")
 
 	idx := -1
 	for i, existing := range a.config.Repository {
-		if existing.Name == id {
+		if existing.Matches(id) {
 			idx = i
 			break
 		}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -415,6 +415,12 @@ func (a *API) GetRepositories(c *gin.Context) {
 	now := time.Now()
 	overviews := make([]RepositoryOverview, 0, end-start)
 	for _, repo := range filtered[start:end] {
+		// Serve the effective URL (type=user/org with empty URL and an orgName
+		// synthesizes https://github.com/<orgName>). The frontend keys rows off
+		// r.URL, so a raw config entry without `url` would otherwise come back
+		// with URL=="" and its row buttons would no-op / 404. repo is a loop copy,
+		// so this neither mutates nor persists the config.
+		repo.URL = repo.EffectiveURL()
 		s := lookupStats(stats, repo)
 		overviews = append(overviews, RepositoryOverview{
 			Repository:  repo,

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -3,6 +3,7 @@ package server
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,26 +38,15 @@ func (a *API) CreateJob(c *gin.Context) {
 		return
 	}
 
-	// Validate repository exists
-	var found bool
-	for _, repo := range a.config.Repository {
-		if repo.Name == req.Repository {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		c.JSON(http.StatusNotFound, Response{
-			Code:    404,
-			Message: "Repository not found in configuration",
-		})
-		return
-	}
-
-	// Execute job
-	jobID, err := a.executor.ExecuteJob(req.Repository)
+	jobIDs, err := a.executor.ExecuteJob(req.RepositoryKey)
 	if err != nil {
+		if errors.Is(err, executor.ErrRepositoryNotFound) {
+			c.JSON(http.StatusNotFound, Response{
+				Code:    404,
+				Message: "Repository not found in configuration",
+			})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, Response{
 			Code:    500,
 			Message: "Failed to execute job: " + err.Error(),
@@ -67,7 +57,7 @@ func (a *API) CreateJob(c *gin.Context) {
 	c.JSON(http.StatusOK, Response{
 		Code: 200,
 		Data: CreateJobResponse{
-			JobID:  jobID,
+			JobIDs: jobIDs,
 			Status: string(executor.StatusRunning),
 		},
 	})
@@ -117,25 +107,25 @@ func (a *API) GetJobs(c *gin.Context) {
 		limit = 20
 	}
 
+	const jobSelect = "SELECT id, job_name, repo_key, start_time, end_time, status, error_message FROM executions"
+
 	// Build query
-	query := "SELECT id, job_name, start_time, end_time, status, error_message FROM executions WHERE 1=1"
+	query := jobSelect + " WHERE 1=1"
 	args := []interface{}{}
-	argPos := 1
 
 	if status != "" && status != "all" {
 		query += " AND status = ?"
 		args = append(args, status)
-		argPos++
 	}
 
 	if repository != "" {
-		query += " AND job_name LIKE ? ESCAPE '\\'"
-		args = append(args, "%"+escapeLike(repository)+"%")
-		argPos++
+		// name 模糊匹配原始输入；URL 搜索词先规范化，命中规范化后的 repo_key。
+		query += " AND (job_name LIKE ? ESCAPE '\\' OR repo_key LIKE ? ESCAPE '\\')"
+		args = append(args, "%"+escapeLike(repository)+"%", "%"+escapeLike(typedef.NormalizeURL(repository))+"%")
 	}
 
 	// Get total count
-	countQuery := "SELECT COUNT(*) FROM executions" + query[len("SELECT id, job_name, start_time, end_time, status, error_message FROM executions"):]
+	countQuery := "SELECT COUNT(*) FROM executions" + query[len(jobSelect):]
 	var total int64
 	err := a.db.QueryRow(countQuery, args...).Scan(&total)
 	if err != nil {
@@ -167,7 +157,8 @@ func (a *API) GetJobs(c *gin.Context) {
 		var endTime *time.Time
 		var errorMessage *string
 
-		err := rows.Scan(&job.ID, &job.Name, &startTime, &endTime, &job.Status, &errorMessage)
+		var repoKey string
+		err := rows.Scan(&job.ID, &job.Name, &repoKey, &startTime, &endTime, &job.Status, &errorMessage)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, Response{
 				Code:    500,
@@ -182,9 +173,10 @@ func (a *API) GetJobs(c *gin.Context) {
 			job.ErrorMessage = *errorMessage
 		}
 
-		// Get repository URL from config
+		// Resolve URL from config by identity key; unmatched (renamed/deleted/old
+		// empty-key rows) keeps the job_name snapshot and empty URL.
 		for _, repo := range a.config.Repository {
-			if repo.Name == job.Name {
+			if repo.Matches(repoKey) {
 				job.URL = repo.URL
 				break
 			}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -55,12 +56,12 @@ func TestGetJobs(t *testing.T) {
 
 	// Insert test data
 	now := time.Now()
-	testDB.Exec(`INSERT INTO executions (id, job_name, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?)`,
-		"job-1", "test-repo", now, now.Add(5*time.Minute), "completed", "")
-	testDB.Exec(`INSERT INTO executions (id, job_name, start_time, status) VALUES (?, ?, ?, ?)`,
-		"job-2", "test-repo", now, "running")
-	testDB.Exec(`INSERT INTO executions (id, job_name, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?)`,
-		"job-3", "test-repo", now, now.Add(2*time.Minute), "failed", "some error")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"job-1", "test-repo", "github.com/test/repo", now, now.Add(5*time.Minute), "completed", "")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, status) VALUES (?, ?, ?, ?, ?)`,
+		"job-2", "test-repo", "github.com/test/repo", now, "running")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"job-3", "test-repo", "github.com/test/repo", now, now.Add(2*time.Minute), "failed", "some error")
 
 	tests := []struct {
 		name           string
@@ -98,6 +99,10 @@ func TestGetJobs(t *testing.T) {
 				assert.Equal(t, 1, response.Data.Page)
 				assert.Equal(t, 20, response.Data.Limit)
 				assert.Len(t, response.Data.Jobs, 3)
+				// URL 解析：repo_key 命中配置条目 → url 被填上（三行同键，全部命中）
+				for _, j := range response.Data.Jobs {
+					assert.Equal(t, "github.com/test/repo", j.URL)
+				}
 			},
 		},
 		{
@@ -204,6 +209,22 @@ func TestGetJobs(t *testing.T) {
 				assert.Len(t, response.Data.Jobs, 0)
 			},
 		},
+		{
+			name:           "filter by full URL with scheme and trailing slash",
+			queryParams:    "?repository=" + url.QueryEscape("https://github.com/test/repo/"),
+			expectedStatus: 200,
+			checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				var response struct {
+					Code    int `json:"code"`
+					Data    struct {
+						Jobs  []struct{ Name string `json:"name"` } `json:"jobs"`
+						Total int64                               `json:"total"`
+					} `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+				assert.Equal(t, int64(3), response.Data.Total, "normalized URL must match repo_key despite scheme/slash")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -243,7 +264,7 @@ func TestCreateJob(t *testing.T) {
 	// Test invalid repository - this doesn't execute actual jobs
 	t.Run("invalid_repository", func(t *testing.T) {
 		body, _ := json.Marshal(map[string]string{
-			"repository": "non-existent-repo",
+			"repository_key": "github.com/nope/repo",
 		})
 		req, _ := http.NewRequest("POST", "/api/jobs", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
@@ -280,6 +301,30 @@ func TestCreateJob(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 400, response.Code)
 		assert.Contains(t, response.Message, "Invalid request")
+	})
+
+	t.Run("valid_repository_key", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]string{
+			"repository_key": "https://github.com/test/repo",
+		})
+		req, _ := http.NewRequest("POST", "/api/jobs", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		s.ServeHTTP(resp, req)
+
+		assert.Equal(t, 200, resp.Code)
+		var response struct {
+			Code int `json:"code"`
+			Data struct {
+				JobIDs []string `json:"job_ids"`
+				Status string   `json:"status"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+		assert.Equal(t, 200, response.Code)
+		require.Len(t, response.Data.JobIDs, 1)
+		assert.NotEmpty(t, response.Data.JobIDs[0])
+		assert.Equal(t, "running", response.Data.Status)
 	})
 }
 

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -77,8 +77,9 @@ func NewRepoTestServer(cfg *config.Config, testDB *db.DB) *TestServer {
 	s := &TestServer{router: gin.Default()}
 	s.router.GET("/api/repositories", api.GetRepositories)
 	s.router.POST("/api/repositories", api.CreateRepository)
-	s.router.PUT("/api/repositories/:id", api.UpdateRepository)
-	s.router.DELETE("/api/repositories/:id", api.DeleteRepository)
+	// *id catch-all: identity keys are URLs containing "/" that :id cannot match.
+	s.router.PUT("/api/repositories/*id", api.UpdateRepository)
+	s.router.DELETE("/api/repositories/*id", api.DeleteRepository)
 	return s
 }
 

--- a/internal/server/repository_test.go
+++ b/internal/server/repository_test.go
@@ -44,10 +44,10 @@ func TestGetRepositories(t *testing.T) {
 	// e2 starts LATER than e1, so the "list all" subtest below can assert the
 	// HAVING start_time = MAX(start_time) row selection returns e2's time.
 	now := time.Now()
-	testDB.Exec(`INSERT INTO executions (id, job_name, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?)`,
-		"e1", "repo-a", now, now.Add(time.Minute), "completed", "")
-	testDB.Exec(`INSERT INTO executions (id, job_name, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?)`,
-		"e2", "repo-a", now.Add(2*time.Minute), now.Add(3*time.Minute), "failed", "boom")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"e1", "repo-a", "github.com/a/a", now, now.Add(time.Minute), "completed", "")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"e2", "repo-a", "github.com/a/a", now.Add(2*time.Minute), now.Add(3*time.Minute), "failed", "boom")
 
 	s := server.NewRepoTestServer(cfg, testDB)
 
@@ -137,6 +137,12 @@ func TestGetRepositories(t *testing.T) {
 		assert.False(t, names["alpha"])
 	})
 
+	t.Run("search filters by URL", func(t *testing.T) {
+		d := getList("?search=github.com/b")
+		assert.Equal(t, 1, d.Total)
+		assert.Equal(t, "repo-b", d.Repositories[0].Name)
+	})
+
 	t.Run("pagination", func(t *testing.T) {
 		d1 := getList("?page=1&limit=2")
 		assert.Equal(t, 3, d1.Total)
@@ -195,7 +201,8 @@ func TestCreateRepository(t *testing.T) {
 		assert.Len(t, getResp.Data.Repositories, 2)
 	})
 
-	t.Run("duplicate_name", func(t *testing.T) {
+	t.Run("same_name_different_url", func(t *testing.T) {
+		// Name may repeat; identity is the URL. Same name + different URL → 200.
 		body, _ := json.Marshal(map[string]interface{}{
 			"name": "existing-repo",
 			"url":  "github.com/another/repo",
@@ -205,8 +212,8 @@ func TestCreateRepository(t *testing.T) {
 		resp := httptest.NewRecorder()
 		s.ServeHTTP(resp, req)
 
-		assert.Equal(t, 409, resp.Code)
-		assert.Equal(t, 409, repoResponseCode(t, resp))
+		assert.Equal(t, 200, resp.Code)
+		assert.Equal(t, 200, repoResponseCode(t, resp))
 	})
 
 	t.Run("empty_name", func(t *testing.T) {
@@ -241,7 +248,7 @@ func TestUpdateRepository(t *testing.T) {
 			"url":         "github.com/new/url",
 			"allBranches": true,
 		})
-		req, _ := http.NewRequest("PUT", "/api/repositories/update-me", bytes.NewBuffer(body))
+		req, _ := http.NewRequest("PUT", "/api/repositories/github.com/old/url", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
 		resp := httptest.NewRecorder()
 		s.ServeHTTP(resp, req)
@@ -287,7 +294,7 @@ func TestDeleteRepository(t *testing.T) {
 	s := server.NewRepoTestServer(cfg, testDB)
 
 	t.Run("success", func(t *testing.T) {
-		req, _ := http.NewRequest("DELETE", "/api/repositories/delete-me", nil)
+		req, _ := http.NewRequest("DELETE", "/api/repositories/github.com/delete/me", nil)
 		resp := httptest.NewRecorder()
 		s.ServeHTTP(resp, req)
 
@@ -325,4 +332,192 @@ func TestDeleteRepository(t *testing.T) {
 		assert.Equal(t, 404, resp.Code)
 		assert.Equal(t, 404, repoResponseCode(t, resp))
 	})
+}
+
+func TestCreateRepositoryDuplicateURL(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "existing-repo", URL: "github.com/existing/repo"},
+		},
+	}
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	// 同一 URL 不同 name → 409（身份以 URL 为准，name 可重复）。
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "another-name",
+		"url":  "https://github.com/existing/repo.git",
+	})
+	req, _ := http.NewRequest("POST", "/api/repositories", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 409, resp.Code)
+	assert.Equal(t, 409, repoResponseCode(t, resp))
+}
+
+func TestCreateRepositoryNameMayRepeat(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "repo", URL: "github.com/one/repo"},
+		},
+	}
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	// 相同 name 不同 URL → 200（name 不再是唯一约束）。
+	body, _ := json.Marshal(map[string]interface{}{
+		"name": "repo",
+		"url":  "github.com/two/repo",
+	})
+	req, _ := http.NewRequest("POST", "/api/repositories", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 200, resp.Code)
+}
+
+func TestCreateRepositoryOrgSynthesizesURL(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	s := server.NewRepoTestServer(&config.Config{}, testDB)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":    "acme",
+		"type":    "org",
+		"orgName": "acme",
+	})
+	req, _ := http.NewRequest("POST", "/api/repositories", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 200, resp.Code)
+	var response struct {
+		Code int                `json:"code"`
+		Data typedef.Repository `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+	assert.Equal(t, 200, response.Code)
+	assert.Equal(t, "https://github.com/acme", response.Data.URL)
+}
+
+func TestCreateRepositoryEmptyURLRejected(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	s := server.NewRepoTestServer(&config.Config{}, testDB)
+
+	// type=repo 且无 URL；type=org 但无 orgName → 都 400。
+	for _, body := range []map[string]interface{}{
+		{"name": "orphan", "type": "repo"},
+		{"name": "nobody", "type": "org"},
+	} {
+		b, _ := json.Marshal(body)
+		req, _ := http.NewRequest("POST", "/api/repositories", bytes.NewBuffer(b))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		s.ServeHTTP(resp, req)
+		assert.Equal(t, 400, resp.Code, "body %v", body)
+	}
+}
+
+func TestUpdateRepositoryURLCollision(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "a", URL: "github.com/a/a"},
+			{Name: "b", URL: "github.com/b/b"},
+		},
+	}
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	// 把 a 的 URL 改成 b 的 → 409（与其他仓库冲突，不与自身比较）。
+	body, _ := json.Marshal(map[string]interface{}{
+		"url": "github.com/b/b",
+	})
+	req, _ := http.NewRequest("PUT", "/api/repositories/github.com/a/a", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+
+	assert.Equal(t, 409, resp.Code)
+}
+
+func TestGetRepositoriesOrgPrefixAggregation(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "acme", URL: "https://github.com/acme", Type: typedef.TypeOrg, OrgName: "acme"},
+			{Name: "solo", URL: "github.com/solo/app"},
+		},
+	}
+
+	now := time.Now()
+	// 成员仓库的 executions 各记一条。
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"a1", "alpha", "github.com/acme/alpha", now.Add(-2*time.Minute), now.Add(-1*time.Minute), "completed", "")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"b1", "beta", "github.com/acme/beta", now.Add(-4*time.Minute), now.Add(-3*time.Minute), "failed", "boom")
+	// 路径边界：github.com/acme2/x 不能被 acme 前缀吞掉。
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"c1", "other", "github.com/acme2/other", now.Add(-6*time.Minute), now.Add(-5*time.Minute), "completed", "")
+	testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"d1", "solo", "github.com/solo/app", now.Add(-8*time.Minute), now.Add(-7*time.Minute), "completed", "")
+
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	type repoView struct {
+		Name        string     `json:"Name"`
+		LastRunTime *time.Time `json:"last_run_time"`
+		TotalRuns   int64      `json:"total_runs"`
+		SuccessRuns int64      `json:"success_runs"`
+		FailedRuns  int64      `json:"failed_runs"`
+	}
+	req, _ := http.NewRequest("GET", "/api/repositories", nil)
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+	var response struct {
+		Code int `json:"code"`
+		Data struct {
+			Repositories []repoView `json:"repositories"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+	assert.Equal(t, 200, response.Code)
+
+	byName := map[string]repoView{}
+	for _, r := range response.Data.Repositories {
+		byName[r.Name] = r
+	}
+
+	acme := byName["acme"]
+	assert.Equal(t, int64(2), acme.TotalRuns, "org aggregates its member repos only")
+	assert.Equal(t, int64(1), acme.SuccessRuns)
+	assert.Equal(t, int64(1), acme.FailedRuns)
+	require.NotNil(t, acme.LastRunTime)
+	// last_run is the max member START time: alpha (a1) starts at now-2m, beta
+	// (b1) at now-4m — the max is now-2m (the brief's original now-1m was the
+	// member's end time; the API convention is start_time-based).
+	assert.WithinDuration(t, now.Add(-2*time.Minute), *acme.LastRunTime, time.Second, "last_run must be the max of members")
+
+	solo := byName["solo"]
+	assert.Equal(t, int64(1), solo.TotalRuns)
 }

--- a/internal/server/repository_test.go
+++ b/internal/server/repository_test.go
@@ -152,6 +152,46 @@ func TestGetRepositories(t *testing.T) {
 	})
 }
 
+func TestGetRepositoriesSynthesizesOrgURL(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	// YAML-loaded org entry: type=org + orgName, NO url — the documented shape.
+	cfg := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "acme", Type: typedef.TypeOrg, OrgName: "acme"},
+		},
+	}
+
+	s := server.NewRepoTestServer(cfg, testDB)
+
+	// typedef.Repository fields marshal as PascalCase (no json tags).
+	type repoView struct {
+		Name string `json:"Name"`
+		URL  string `json:"URL"`
+	}
+	type listData struct {
+		Repositories []repoView `json:"repositories"`
+		Total        int        `json:"total"`
+	}
+	req, _ := http.NewRequest("GET", "/api/repositories", nil)
+	resp := httptest.NewRecorder()
+	s.ServeHTTP(resp, req)
+	var response struct {
+		Code int      `json:"code"`
+		Data listData `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+	assert.Equal(t, 200, response.Code)
+	assert.Equal(t, 1, response.Data.Total)
+	require.Len(t, response.Data.Repositories, 1)
+	assert.Equal(t, "acme", response.Data.Repositories[0].Name)
+	// The DTO must serve the synthesized URL so the frontend's repoKey (r.URL)
+	// resolves to a non-empty identity key.
+	assert.Equal(t, "https://github.com/acme", response.Data.Repositories[0].URL)
+}
+
 func TestCreateRepository(t *testing.T) {
 	testDB, err := db.Initialize(":memory:")
 	require.NoError(t, err)

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -23,12 +23,12 @@ type Job struct {
 }
 
 type CreateJobRequest struct {
-	Repository string `json:"repository" binding:"required"`
+	RepositoryKey string `json:"repository_key" binding:"required"`
 }
 
 type CreateJobResponse struct {
-	JobID  string `json:"job_id"`
-	Status string `json:"status"`
+	JobIDs []string `json:"job_ids"`
+	Status string   `json:"status"`
 }
 
 type CancelJobResponse struct {

--- a/internal/typedef/key.go
+++ b/internal/typedef/key.go
@@ -1,0 +1,52 @@
+package typedef
+
+import (
+	"strings"
+)
+
+// NormalizeURL 归一化仓库 URL，产出无协议、小写、无 www、无尾斜杠、无 .git 的
+// 规范形态 "host/owner/repo"。处理顺序：去空白 → 去 #fragment → 小写 →
+// 去 http(s):// → 去 www. → 去尾斜杠 → 去 .git。返回 "" 表示没有可用 URL。
+func NormalizeURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	if i := strings.IndexByte(s, '#'); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.ToLower(s)
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "www.")
+	s = strings.TrimSuffix(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	return s
+}
+
+// EffectiveURL 返回条目的有效 URL：URL 非空直接用；type 为 user/org 且 URL 为
+// 空、orgName 非空时合成 "https://github.com/<orgName>"；否则返回 r.URL（可能
+// 为空，即非法）。
+func (r *Repository) EffectiveURL() string {
+	if (r.GetType() == TypeUser || r.GetType() == TypeOrg) &&
+		strings.TrimSpace(r.URL) == "" && r.OrgName != "" {
+		return "https://github.com/" + r.OrgName
+	}
+	return r.URL
+}
+
+// Key 返回仓库身份键 = NormalizeURL(EffectiveURL())。空 URL 会得到 ""，
+// 调用方（创建/更新/启动校验）必须拒绝。
+func (r *Repository) Key() string {
+	return NormalizeURL(r.EffectiveURL())
+}
+
+// Matches 判断一段用户输入是否命中该仓库：输入被规范化后与 Key() 比较。
+// Key() 为空（无身份）或输入为空时返回 false。
+func (r *Repository) Matches(input string) bool {
+	key := r.Key()
+	if key == "" {
+		return false
+	}
+	return NormalizeURL(input) == key
+}

--- a/internal/typedef/key_test.go
+++ b/internal/typedef/key_test.go
@@ -1,0 +1,66 @@
+package typedef
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"github.com/wnarutou/gitrieve", "github.com/wnarutou/gitrieve"},
+		{"https://GITHUB.com/wnarutou/gitrieve/", "github.com/wnarutou/gitrieve"},
+		{"http://github.com/wnarutou/gitrieve.git", "github.com/wnarutou/gitrieve"},
+		{"https://www.github.com/wnarutou/gitrieve", "github.com/wnarutou/gitrieve"},
+		{"www.github.com/wnarutou/gitrieve", "github.com/wnarutou/gitrieve"},
+		{"https://github.com/wnarutou/gitrieve#readme", "github.com/wnarutou/gitrieve"},
+		{"https://gitlab.com/Wnarutou/proj.git/", "gitlab.com/wnarutou/proj"},
+		{"HTTPS://GitHub.com/Foo/Bar.Git", "github.com/foo/bar"},
+		{"   https://github.com/foo/bar  ", "github.com/foo/bar"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, NormalizeURL(c.in), "NormalizeURL(%q)", c.in)
+	}
+}
+
+func TestEffectiveURL(t *testing.T) {
+	cases := []struct {
+		repo Repository
+		want string
+	}{
+		{Repository{Type: TypeRepo, URL: "github.com/a/b"}, "github.com/a/b"},
+		{Repository{Type: TypeOrg, OrgName: "acme"}, "https://github.com/acme"},
+		{Repository{Type: TypeUser, OrgName: "alice"}, "https://github.com/alice"},
+		// 显式 URL 优先于合成
+		{Repository{Type: TypeOrg, URL: "gitlab.com/acme/org", OrgName: "acme"}, "gitlab.com/acme/org"},
+		// orgName 为空 → 无有效 URL
+		{Repository{Type: TypeOrg}, ""},
+		// 非 user/org 且无 URL → 无有效 URL
+		{Repository{Type: TypeRepo}, ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.repo.EffectiveURL(), "EffectiveURL(%+v)", c.repo)
+	}
+}
+
+func TestKeyAndMatches(t *testing.T) {
+	repo := Repository{Name: "x", URL: "https://GitHub.com/Foo/Bar.git"}
+	assert.Equal(t, "github.com/foo/bar", repo.Key())
+
+	assert.True(t, repo.Matches("github.com/foo/bar"))
+	assert.True(t, repo.Matches("https://github.com/foo/bar"))
+	assert.True(t, repo.Matches("HTTPS://GITHUB.COM/FOO/BAR.GIT"))
+	assert.True(t, repo.Matches("github.com/foo/bar/"))
+	assert.False(t, repo.Matches("github.com/other/bar"))
+	assert.False(t, repo.Matches(""))
+
+	// 空身份条目谁也不匹配
+	empty := Repository{Name: "orphan"}
+	assert.Equal(t, "", empty.Key())
+	assert.False(t, empty.Matches("github.com/foo/bar"))
+	assert.False(t, empty.Matches(""))
+}

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -7,6 +7,9 @@ function esc(value) {
     }[c]));
 }
 
+// repoKey 返回仓库身份键。后端以规范化 URL 为唯一身份，前端不做规范化。
+const repoKey = (r) => r.URL || '';
+
 function fmtTime(value) {
     if (!value) return '-';
     const d = new Date(value);
@@ -119,7 +122,7 @@ function jobsToolbar(jobCount) {
         <div class="panel">
             <div class="toolbar">
                 <div class="toolbar-group">
-                    <input type="text" id="jobs-repo-filter" placeholder="Filter by repository name…" value="${esc(state.jobsRepo)}">
+                    <input type="text" id="jobs-repo-filter" placeholder="Filter by repository name or URL…" value="${esc(state.jobsRepo)}">
                     <button id="btn-search-jobs" class="btn">Search</button>
                 </div>
                 <div class="toolbar-group">
@@ -237,13 +240,18 @@ async function cancelJob(jobId) {
     }
 }
 
-async function runRepo(name, btn) {
-    if (!name) return;
+async function runRepo(key, name, btn) {
+    if (!key) return;
     btn.disabled = true;
     try {
-        const data = await api('/api/jobs', { method: 'POST', body: JSON.stringify({ repository: name }) });
-        toast('Job started (' + (data.job_id || '').slice(0, 8) + '…)');
-        openLogModal(data.job_id, name);
+        const data = await api('/api/jobs', { method: 'POST', body: JSON.stringify({ repository_key: key }) });
+        const jobIDs = (data && data.job_ids) || [];
+        if (jobIDs.length === 1) {
+            toast('Job started (' + jobIDs[0].slice(0, 8) + '…)');
+            openLogModal(jobIDs[0], name);
+        } else {
+            toast('Started ' + jobIDs.length + ' jobs (org expansion)');
+        }
         renderRepositories();
     } catch (e) {
         toast('Failed to start job: ' + e.message, true);
@@ -305,9 +313,9 @@ async function closeLogModal() {
 
 function openRepoForm(repo) {
     $('#repo-modal-title').textContent = repo ? 'Edit Repository' : 'Add Repository';
-    $('#repo-original-name').value = repo ? repo.Name : '';
+    $('#repo-original-key').value = repo ? repoKey(repo) : '';
     $('#repo-name').value = repo ? repo.Name : '';
-    $('#repo-name').disabled = !!repo;
+    $('#repo-name').disabled = false; // name 仅展示/查询，可重复可改名
     $('#repo-url').value = repo ? (repo.URL || '') : '';
     $('#repo-type').value = repo && repo.Type ? repo.Type : 'repo';
     $('#repo-org').value = repo ? (repo.OrgName || '') : '';
@@ -339,7 +347,7 @@ function openRepoForm(repo) {
 
 async function saveRepo(ev) {
     ev.preventDefault();
-    const original = $('#repo-original-name').value;
+    const originalKey = $('#repo-original-key').value;
     const name = $('#repo-name').value.trim();
     if (!name) { toast('Name is required', true); return; }
 
@@ -361,8 +369,8 @@ async function saveRepo(ev) {
     };
 
     try {
-        if (original) {
-            await api('/api/repositories/' + encodeURIComponent(original), { method: 'PUT', body: JSON.stringify(repo) });
+        if (originalKey) {
+            await api('/api/repositories/' + encodeURIComponent(originalKey), { method: 'PUT', body: JSON.stringify(repo) });
             toast('Repository updated');
         } else {
             await api('/api/repositories', { method: 'POST', body: JSON.stringify(repo) });
@@ -375,10 +383,10 @@ async function saveRepo(ev) {
     }
 }
 
-async function deleteRepo(name) {
-    if (!confirm('Delete repository "' + name + '"?')) return;
+async function deleteRepo(key) {
+    if (!confirm('Delete repository?')) return;
     try {
-        await api('/api/repositories/' + encodeURIComponent(name), { method: 'DELETE' });
+        await api('/api/repositories/' + encodeURIComponent(key), { method: 'DELETE' });
         toast('Repository deleted');
         renderRepositories();
     } catch (e) {
@@ -415,9 +423,9 @@ async function renderRepositories() {
             <td class="muted">${esc((r.Storage || []).join(', ') || '-')}</td>
             <td class="muted">${optionsCell(r)}</td>
             <td class="actions">
-                <button class="btn btn-sm btn-primary btn-run-repo" data-name="${esc(r.Name)}">Execute</button>
-                <button class="btn btn-sm btn-edit-repo" data-name="${esc(r.Name)}">Edit</button>
-                <button class="btn btn-sm btn-danger btn-del-repo" data-name="${esc(r.Name)}">Delete</button>
+                <button class="btn btn-sm btn-primary btn-run-repo" data-key="${esc(repoKey(r))}">Execute</button>
+                <button class="btn btn-sm btn-edit-repo" data-key="${esc(repoKey(r))}">Edit</button>
+                <button class="btn btn-sm btn-danger btn-del-repo" data-key="${esc(repoKey(r))}">Delete</button>
             </td>
         </tr>`).join('');
 
@@ -425,7 +433,7 @@ async function renderRepositories() {
         <div class="page-header">
             <h2>Repositories</h2>
             <div class="toolbar-group">
-                <input type="text" id="repos-search" placeholder="Filter by repository name\u2026" value="${esc(state.reposSearch)}">
+                <input type="text" id="repos-search" placeholder="Filter by name or URL\u2026" value="${esc(state.reposSearch)}">
                 <button id="btn-search-repos" class="btn">Search</button>
                 <button id="btn-add-repo" class="btn btn-primary">Add Repository</button>
                 <button id="btn-refresh-repos" class="btn">Refresh</button>
@@ -462,12 +470,15 @@ async function renderRepositories() {
     if (prev) prev.addEventListener('click', () => { if (state.reposPage > 1) { state.reposPage--; renderRepositories(); } });
     if (next) next.addEventListener('click', () => { state.reposPage++; renderRepositories(); });
 
-    $$('.btn-run-repo').forEach(b => b.addEventListener('click', () => runRepo(b.dataset.name, b)));
+    $$('.btn-run-repo').forEach(b => b.addEventListener('click', () => {
+        const r = repos.find(x => repoKey(x) === b.dataset.key);
+        runRepo(b.dataset.key, r ? r.Name : '', b);
+    }));
     $$('.btn-edit-repo').forEach(b => b.addEventListener('click', () => {
-        const r = repos.find(x => x.Name === b.dataset.name);
+        const r = repos.find(x => repoKey(x) === b.dataset.key);
         if (r) openRepoForm(r);
     }));
-    $$('.btn-del-repo').forEach(b => b.addEventListener('click', () => deleteRepo(b.dataset.name)));
+    $$('.btn-del-repo').forEach(b => b.addEventListener('click', () => deleteRepo(b.dataset.key)));
 }
 
 function openStorageForm(storage) {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -40,7 +40,7 @@
                 <button id="repo-modal-close" class="btn btn-sm">Close</button>
             </div>
             <form id="repo-form" class="form">
-                <input type="hidden" id="repo-original-name">
+                <input type="hidden" id="repo-original-key">
                 <div class="form-grid">
                     <label class="field">Name *<input id="repo-name" required placeholder="e.g. gitrieve"></label>
                     <label class="field">Type


### PR DESCRIPTION
Sub-project A of the repo-identity refactor: repositories are now identified by normalized URL, not name. Name becomes a renamable, duplicate-allowed display/query label.

## Changes
- **Identity primitives** (`internal/typedef/key.go`): `NormalizeURL` (trim → strip fragment → lowercase → strip scheme/www → strip trailing `/` and `.git`), `EffectiveURL` (synthesizes `https://github.com/<orgName>` for org/user entries), `Key()`, `Matches()`. Empty URL rejected at config validation and API create/update.
- **DB** (`internal/db/`): additive `executions.repo_key` column via `PRAGMA table_info` migration; no backfill.
- **Executor** (`internal/executor/executor.go`): `ExecuteJob(repoKey)` looks up by URL identity, expands org/user entries into per-repo jobs, records `repo_key` per execution.
- **Repository pkg**: exported `Expand` + name-or-URL matching in `GetRepositories` (testable `newGithubClient` seam).
- **API** (`internal/server/api.go`):
  - `POST /api/jobs` takes `repository_key`, returns `job_ids`
  - `GetJobs` matches name or URL (fuzzy)
  - `GetRepositories` aggregates by `repo_key`; org/user stats via URL-prefix aggregation with path-boundary check
  - CRUD (`PUT`/`DELETE /api/repositories/*id`) keyed by URL identity; URL edits allowed (identity change orphans old history), dedup on create/update → 409
  - `*id` catch-all route so slash-bearing URL keys survive gin routing
- **UI** (`web/static/js/main.js`): repo actions keyed by URL; name editable; org/user entries show synthesized URL.
- **Docs**: `docs/api.md` updated to the new contract.

## Design notes
- Org/user entries retain a synthesized `https://github.com/<orgName>` URL and expand to concrete repos at execution time; stats are URL-prefix aggregates.
- URL normalization aligned with the gitrieve-gleaner reference.
- Deletion-safe sync invariant untouched (`internal/repository/repository.go` Sync unchanged).

## Commits
12 commits over `main` (`8d37d20`..`f63f7bf`).

## Next
Sub-project B (config import/export) to be designed after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
