### PR TITLE
feat: coordinate GitHub API traffic and rate limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,10 @@ releaseSizeLimit: <bytes>
 releaseNumLimit: <count>
 retryMaxCount: <int, default 3>    # per-call max retries on rate-limit/5xx/network errors
 retryBaseDelay: <duration, default 5s>  # exponential-backoff base (doubles per retry)
+githubApiConcurrency: <uint, default 2>
+githubMinRequestInterval: <duration, default 200ms>
+githubLowRemainingThreshold: <int, default 100>
+githubScheduleJitter: <duration, default 30s; 0s disables daemon staggering>
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ See the [Web UI guide](docs/web-ui.md) and the [API reference](docs/api.md) for 
 
 ## Configuration
 
+GitHub API traffic from issues, discussions, and releases is coordinated within each gitrieve process. Optional settings and defaults:
+
+```yaml
+githubApiConcurrency: 2
+githubMinRequestInterval: 200ms
+githubLowRemainingThreshold: 100
+githubScheduleJitter: 30s
+```
+
+`githubScheduleJitter: 0s` disables staggering. Staggering applies only to daemon cron jobs; manual commands and Web API jobs start immediately. These settings reduce bursts but do not increase GitHub quota and do not coordinate separate processes or hosts.
+
 For configuration, you can check out this [example](config/example.config.yaml).
 
 For more details, see [Configuration](https://github.com/wnarutou/gitrieve/wiki/Configuration) in wiki.
@@ -183,5 +194,4 @@ docker compose up -d
 
 The released image is a multi-arch manifest covering `linux/amd64` and
 `linux/arm64`, so it works on both x86_64 and Apple Silicon machines.
-
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -128,6 +128,17 @@ gitrieve server
 
 ## 配置
 
+Issue、Discussion 和 Release 使用的 GitHub API 请求会在每个 gitrieve 进程内统一协调。可选配置及默认值如下：
+
+```yaml
+githubApiConcurrency: 2
+githubMinRequestInterval: 200ms
+githubLowRemainingThreshold: 100
+githubScheduleJitter: 30s
+```
+
+设置 `githubScheduleJitter: 0s` 可关闭错峰。错峰仅应用于 daemon 的 cron 任务，手工命令和 Web API 任务仍会立即开始。这些配置用于降低请求突发，不会增加 GitHub 配额，也不会协调不同进程或主机。
+
 有关配置，你可以查看此[示例](config/example.config.yaml)。
 
 更多细节，可查看[配置文档](https://github.com/wnarutou/gitrieve/wiki/Configuration)。

--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"math/rand"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
@@ -22,7 +23,33 @@ var Cmd = &cobra.Command{
 	Run:   runDaemon,
 }
 
+func stagger(ctx context.Context, max time.Duration, randN func(int64) int64) error {
+	if max <= 0 {
+		return nil
+	}
+	d := time.Duration(randN(int64(max) + 1))
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+func runStaggered(ctx context.Context, fn func() error) {
+	if err := stagger(ctx, config.GetGitHubScheduleJitter(), rand.Int63n); err != nil {
+		ui.Errorf("Scheduled job cancelled before start: %s", err)
+		return
+	}
+	if err := fn(); err != nil {
+		ui.Errorf("Scheduled job failed: %s", err)
+	}
+}
+
 func runDaemon(cmd *cobra.Command, args []string) {
+	daemonCtx := cmd.Context()
 	storageMap := config.GetStorageMap()
 
 	concurrencyNum := config.GetConcurrencyNum()
@@ -49,7 +76,9 @@ func runDaemon(cmd *cobra.Command, args []string) {
 		}
 		_, err := s.NewJob(
 			gocron.CronJob(repo.Cron, false),
-			gocron.NewTask(repository.Sync, context.Background(), repo, false, storages),
+			gocron.NewTask(func() {
+				runStaggered(daemonCtx, func() error { return repository.Sync(daemonCtx, repo, false, storages) })
+			}),
 		)
 		if err != nil {
 			ui.Errorf("Error scheduling download codes of %s, %s", repo.Name, err)
@@ -57,7 +86,9 @@ func runDaemon(cmd *cobra.Command, args []string) {
 		if repo.DownloadReleases {
 			_, err = s.NewJob(
 				gocron.CronJob(repo.Cron, false),
-				gocron.NewTask(release.DownloadAllAssets, context.Background(), repo, storages),
+				gocron.NewTask(func() {
+					runStaggered(daemonCtx, func() error { return release.DownloadAllAssets(daemonCtx, repo, storages) })
+				}),
 			)
 			if err != nil {
 				ui.Errorf("Error scheduling download releases of %s, %s", repo.Name, err)
@@ -66,7 +97,7 @@ func runDaemon(cmd *cobra.Command, args []string) {
 		if repo.DownloadIssues {
 			_, err = s.NewJob(
 				gocron.CronJob(repo.Cron, false),
-				gocron.NewTask(issue.Sync, context.Background(), repo, storages),
+				gocron.NewTask(func() { runStaggered(daemonCtx, func() error { return issue.Sync(daemonCtx, repo, storages) }) }),
 			)
 			if err != nil {
 				ui.Errorf("Error scheduling download issues of %s, %s", repo.Name, err)
@@ -75,7 +106,7 @@ func runDaemon(cmd *cobra.Command, args []string) {
 		if repo.DownloadWiki {
 			_, err = s.NewJob(
 				gocron.CronJob(repo.Cron, false),
-				gocron.NewTask(wiki.Sync, context.Background(), repo, storages),
+				gocron.NewTask(func() { runStaggered(daemonCtx, func() error { return wiki.Sync(daemonCtx, repo, storages) }) }),
 			)
 			if err != nil {
 				ui.Errorf("Error scheduling download wiki of %s, %s", repo.Name, err)
@@ -84,7 +115,7 @@ func runDaemon(cmd *cobra.Command, args []string) {
 		if repo.DownloadDiscussion {
 			_, err = s.NewJob(
 				gocron.CronJob(repo.Cron, false),
-				gocron.NewTask(discussion.Sync, context.Background(), repo, storages),
+				gocron.NewTask(func() { runStaggered(daemonCtx, func() error { return discussion.Sync(daemonCtx, repo, storages) }) }),
 			)
 			if err != nil {
 				ui.Errorf("Error scheduling download discussion of %s, %s", repo.Name, err)

--- a/cmd/daemon/daemon_test.go
+++ b/cmd/daemon/daemon_test.go
@@ -1,0 +1,28 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaggerZeroReturnsImmediately(t *testing.T) {
+	require.NoError(t, stagger(context.Background(), 0, func(int64) int64 { t.Fatal("random source called"); return 0 }))
+}
+
+func TestStaggerUsesBoundedRandomDelay(t *testing.T) {
+	start := time.Now()
+	require.NoError(t, stagger(context.Background(), 20*time.Millisecond, func(n int64) int64 {
+		require.Equal(t, int64(20*time.Millisecond)+1, n)
+		return int64(10 * time.Millisecond)
+	}))
+	require.GreaterOrEqual(t, time.Since(start), 8*time.Millisecond)
+}
+
+func TestStaggerCancellationStopsWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, stagger(ctx, time.Hour, func(int64) int64 { return int64(time.Hour) }), context.Canceled)
+}

--- a/config/example.config.yaml
+++ b/config/example.config.yaml
@@ -63,6 +63,10 @@ storage:
     secretAccessKey: your-secret-access-key
 
 githubToken: xxx
+githubApiConcurrency: 2
+githubMinRequestInterval: 200ms
+githubLowRemainingThreshold: 100
+githubScheduleJitter: 30s
 cocurrencyNum: 6
 releaseSizeLimit: 300000000
 releaseNumLimit: 3

--- a/docs/superpowers/plans/2026-08-24-github-api-coordination.md
+++ b/docs/superpowers/plans/2026-08-24-github-api-coordination.md
@@ -1,0 +1,312 @@
+# GitHub API Coordination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Coordinate all issue, discussion, and release GitHub API traffic process-wide, expose quota state in logs, add bounded retry jitter, and stagger daemon jobs.
+
+**Architecture:** A new `internal/githubapi` package owns a replaceable process-wide coordinator with concurrency, pacing, per-resource primary-limit, and global secondary-limit state. Existing REST and GraphQL clients keep their public behavior, but every retry attempt acquires the coordinator and reports its result; daemon tasks add a separately testable random pre-run delay.
+
+**Tech Stack:** Go, `google/go-github/v56`, `shurcooL/githubv4`, `go-co-op/gocron/v2`, Viper, Testify.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-github-api-coordination-design.md`
+
+## Global Constraints
+
+- Do not add multiple PATs, credential rotation, GitHub App authentication, webhooks, persistent quota state, cross-process coordination, or ETag support.
+- Defaults are `githubApiConcurrency: 2`, `githubMinRequestInterval: 200ms`, `githubLowRemainingThreshold: 100`, and `githubScheduleJitter: 30s`.
+- An explicit zero `githubScheduleJitter` disables daemon staggering; zero values for the other three fields select their defaults.
+- All waits must return promptly on `context.Context` cancellation.
+- Never log tokens or authorization headers.
+- Preserve existing retry count and archive/cache semantics.
+- Do not modify or delete the existing untracked `.codex-ui-test/` directory.
+
+---
+
+### Task 1: Configuration lifecycle
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/config_test.go`
+- Modify: `internal/config/importexport.go`
+- Modify: `internal/config/importexport_test.go`
+- Modify: `internal/server/config_api.go`
+- Modify: `internal/server/config_api_test.go`
+- Modify: `config/example.config.yaml`
+
+**Interfaces:**
+- Produces primitive getters `GetGitHubAPIConcurrency() uint`, `GetGitHubMinRequestInterval() time.Duration`, and `GetGitHubLowRemainingThreshold() int`.
+- Produces: `GetGitHubScheduleJitter() time.Duration`
+- Produces config fields `GitHubAPIConcurrency uint`, `GitHubMinRequestInterval time.Duration`, `GitHubLowRemainingThreshold int`, `GitHubScheduleJitter time.Duration`.
+
+- [ ] **Step 1: Write failing configuration default and round-trip tests**
+
+Add tests which initialize a minimal config and assert `2`, `200*time.Millisecond`, `100`, and `30*time.Second`; add an explicit `githubScheduleJitter: 0s` case that remains zero. Extend export/import tests to assert YAML keys and typed values, and config API diff/apply tests to assert all four globals participate.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `go test ./internal/config ./internal/server`
+
+Expected: compilation failures for the missing fields/getters, followed by assertion failures until persistence and API diff/apply are wired.
+
+- [ ] **Step 3: Implement the configuration fields and defaults**
+
+Add the fields with exact YAML/mapstructure spellings. Seed defaults in both `seedDefaults` and `seedExportDefaults`; distinguish absent jitter from explicit `0s` by checking Viper key presence during normal config loading and YAML node/key presence during import parsing. Reject negative duration values by replacing them with documented defaults. Extend `Save`, `ExportFrom`, preview globals, and apply globals. Expose the four primitive getters named in the interface block.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `go test ./internal/config ./internal/server`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/config internal/server/config_api.go internal/server/config_api_test.go config/example.config.yaml
+git commit -m "feat(config): add GitHub API coordination settings"
+```
+
+### Task 2: Shared GitHub API coordinator
+
+**Files:**
+- Create: `internal/githubapi/coordinator.go`
+- Create: `internal/githubapi/coordinator_test.go`
+- Modify: `internal/config/config.go`
+
+**Interfaces:**
+- Produces: `type Config struct { Concurrency uint; MinRequestInterval time.Duration; LowRemainingThreshold int }`
+- Produces: `type Observation struct { Resource string; Limit, Remaining, Used int; Reset time.Time; Secondary bool; RetryAfter time.Duration }`
+- Produces: `type Permit interface { Done(Observation) }`
+- Produces: `func Acquire(context.Context) (Permit, error)`
+- Produces: `func Configure(Config)` for atomically publishing a fresh coordinator.
+- Produces: `func ObserveError(error) Observation` for recognized REST rate-limit errors and GraphQL timing text.
+- Produces from `internal/config`: `GetGitHubAPIConfig() githubapi.Config`, assembled from Task 1's primitive fields.
+
+- [ ] **Step 1: Write failing coordinator behavior tests**
+
+Use a locally constructed coordinator with injectable `now func() time.Time`, timer/wait hook, and logger callback. Tests must prove: only `Concurrency` permits are live; request starts are separated by `MinRequestInterval`; a canceled waiter returns `context.Canceled`; resources pause independently at/below the threshold; a secondary observation pauses all resources; a later deadline extends but never shortens a pause; and resumption logs once.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/githubapi`
+
+Expected: FAIL because the package and interfaces do not exist.
+
+- [ ] **Step 3: Implement minimal coordinator state and observation parsing**
+
+Use a buffered channel as the concurrency semaphore and a mutex for `nextStart`, resource deadlines, and the global secondary deadline. `Acquire` loops until the relevant deadline and pacing deadline pass, selects every wait against `ctx.Done()`, then returns a permit whose `Done` is idempotent via `sync.Once`. `Configure` publishes an immutable coordinator pointer atomically so reload never mutates an active instance.
+
+`ObserveError` must recognize `*github.RateLimitError`, `*github.AbuseRateLimitError`, `*github.ErrorResponse` with `429`/rate-limit headers, and GraphQL `retryAfterSeconds`; secondary limits without an explicit duration use one minute.
+
+- [ ] **Step 4: Add logging transition tests and implementation**
+
+Assert that routine observations do not log; first low-resource transition, pause extension, and first successful acquisition after expiry do. Route production callbacks through `ui.Printf` without credential material.
+
+- [ ] **Step 5: Verify GREEN and race safety**
+
+Run: `go test -race ./internal/githubapi ./internal/config`
+
+Expected: PASS with no races.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/githubapi internal/config/config.go
+git commit -m "feat(githubapi): coordinate process-wide API traffic"
+```
+
+### Task 3: Retry jitter
+
+**Files:**
+- Modify: `internal/retry/retry.go`
+- Modify: `internal/retry/retry_test.go`
+
+**Interfaces:**
+- Preserves: `func Do(context.Context, Config, func() error) error`
+- Adds internally testable: `func jitter(time.Duration, func(int64) int64) time.Duration`.
+
+- [ ] **Step 1: Write failing deterministic jitter tests**
+
+Assert fallback waits stay within `[base, 1.5*base]`, remain capped at `maxBackoff`, and use deterministic injected values. Assert exact `RateLimitError` reset and `AbuseRateLimitError.RetryAfter` waits are unchanged.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/retry`
+
+Expected: FAIL because fallback backoff has no jitter seam.
+
+- [ ] **Step 3: Implement bounded jitter**
+
+Apply random jitter only when `classify` returns no authoritative wait. Use a package-private random function variable guarded for tests or pass it through a private `do` helper; keep public `Do` unchanged. Apply the cap after adding jitter.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `go test -race ./internal/retry`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/retry
+git commit -m "feat(retry): add bounded retry jitter"
+```
+
+### Task 4: REST issue and release integration
+
+**Files:**
+- Modify: `internal/issue/issue.go`
+- Create: `internal/issue/github_api_test.go`
+- Modify: `internal/scm/github/github.go`
+- Create: `internal/scm/github/github_test.go`
+- Modify: `internal/release/release_test.go`
+
+**Interfaces:**
+- Consumes: `githubapi.Acquire(ctx)` and `Permit.Done(Observation)`.
+- Preserves public issue/release function signatures.
+- Changes `github.New()` to construct a client from the current config rather than a `sync.Once` singleton.
+
+- [ ] **Step 1: Write failing HTTP integration tests**
+
+Use `httptest.Server` and real `go-github` clients. Assert issue list and comment attempts acquire/release coordination, REST headers create quota observations, retries acquire again, and two configured concurrent calls respect the shared cap. Add a release-client test that changes `config.SetIns` between two `New()` calls and observes distinct Authorization headers.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/issue ./internal/scm/github ./internal/release`
+
+Expected: FAIL because calls bypass the coordinator and the release singleton retains the first token.
+
+- [ ] **Step 3: Gate every covered REST attempt**
+
+Inside each existing `retry.Do` closure, acquire a permit, perform the call, convert the returned `*github.Response` plus error into an observation, and call `Done` before returning. Cover `Issues.ListByRepo`, `Issues.ListComments`, `Repositories.ListReleases`, and `Repositories.ListReleaseAssets`.
+
+Cover `DownloadReleaseAsset` long enough to obtain its API response/redirect and report its headers, but release the permit before callers consume the returned body. Remove `sync.Once`; each `New()` captures one immutable current config snapshot so in-flight calls remain stable while later calls observe reloads.
+
+- [ ] **Step 4: Verify GREEN and races**
+
+Run: `go test -race ./internal/issue ./internal/scm/github ./internal/release`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/issue internal/scm/github internal/release/release_test.go
+git commit -m "feat(githubapi): coordinate issue and release requests"
+```
+
+### Task 5: GraphQL discussion integration and quota fields
+
+**Files:**
+- Modify: `internal/discussion/discussion.go`
+- Create: `internal/discussion/github_api_test.go`
+
+**Interfaces:**
+- Consumes: `githubapi.Acquire`, `Permit.Done`, and `githubapi.ObserveError`.
+- Adds a shared embedded GraphQL selection with `Cost int`, `Remaining int`, and `ResetAt time.Time` to all three query structs.
+
+- [ ] **Step 1: Write failing GraphQL integration tests**
+
+Use an HTTP test server returning GraphQL JSON. Assert discussions, comments, and replies each pass through the coordinator; successful `rateLimit` data pauses at the configured threshold; a secondary error without timing creates the one-minute global pause; cancellation exits while paused.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./internal/discussion`
+
+Expected: FAIL because query types omit quota data and calls bypass coordination.
+
+- [ ] **Step 3: Add quota selections and gate each query attempt**
+
+Add `RateLimit struct { Cost int; Remaining int; ResetAt time.Time }` to each top-level query. Acquire inside each `retry.Do` closure, execute `client.Query`, translate successful quota fields or the returned error into an observation, then release the permit.
+
+- [ ] **Step 4: Verify GREEN and races**
+
+Run: `go test -race ./internal/discussion ./internal/githubapi`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add internal/discussion
+git commit -m "feat(githubapi): coordinate discussion GraphQL requests"
+```
+
+### Task 6: Daemon-only schedule jitter
+
+**Files:**
+- Modify: `cmd/daemon/daemon.go`
+- Create: `cmd/daemon/daemon_test.go`
+
+**Interfaces:**
+- Produces: package-private `func stagger(ctx context.Context, max time.Duration, randN func(int64) int64) error`.
+- Produces: package-private task wrapper that calls `stagger` before the original function.
+
+- [ ] **Step 1: Write failing stagger tests**
+
+Assert zero disables waiting, deterministic random values select delays within `[0,max]`, cancellation returns `context.Canceled`, and the wrapped task invokes its component only after the delay succeeds. Verify direct component functions remain unwrapped outside daemon job registration.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `go test ./cmd/daemon`
+
+Expected: FAIL because daemon jobs directly reference component functions.
+
+- [ ] **Step 3: Implement and register the daemon wrapper**
+
+Wrap each daemon-created code, release, issue, wiki, and discussion task with the same context-aware staggering helper. Read the current jitter setting when a trigger starts so configuration reload affects later triggers. Do not alter CLI commands or executor-triggered immediate jobs.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `go test -race ./cmd/daemon ./cmd/...`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add cmd/daemon
+git commit -m "feat(daemon): stagger scheduled repository jobs"
+```
+
+### Task 7: Documentation and full verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README_zh.md`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Documents the four exact configuration keys, defaults, zero-jitter behavior, quota logging, and distinction between scheduled and manual runs.
+
+- [ ] **Step 1: Update English and Chinese configuration documentation**
+
+Add a compact example and explain that the settings coordinate one process only. State that the feature does not multiply GitHub quota and does not coordinate separate gitrieve processes or hosts.
+
+- [ ] **Step 2: Run formatting and static checks**
+
+Run: `gofmt -w internal/githubapi internal/config internal/retry internal/issue internal/discussion internal/scm/github cmd/daemon`
+
+Run: `go vet ./...`
+
+Expected: both commands succeed without diagnostics.
+
+- [ ] **Step 3: Run the full test suite with race detection**
+
+Run: `go test -race ./...`
+
+Expected: PASS with no races, hangs, or leaked goroutines.
+
+- [ ] **Step 4: Check the diff and worktree scope**
+
+Run: `git diff --check`
+
+Run: `git status --short`
+
+Expected: no whitespace errors; `.codex-ui-test/` remains untracked and untouched; only planned files are changed.
+
+- [ ] **Step 5: Commit documentation**
+
+```powershell
+git add README.md README_zh.md CLAUDE.md
+git commit -m "docs: describe GitHub API coordination"
+```

--- a/docs/superpowers/specs/2026-08-24-github-api-coordination-design.md
+++ b/docs/superpowers/specs/2026-08-24-github-api-coordination-design.md
@@ -1,0 +1,132 @@
+# GitHub API Coordination Design
+
+## Purpose
+
+gitrieve currently retries individual GitHub REST and GraphQL calls, but concurrent repository jobs do not share rate-limit state. A group of jobs can therefore exhaust the same credential together, sleep independently, and retry in another burst.
+
+The first phase introduces process-wide request coordination, rate-limit observability, retry jitter, and daemon schedule staggering. It does not add multiple credentials or change authentication methods.
+
+## Scope
+
+This phase covers GitHub API calls used by:
+
+- issue and issue-comment synchronization through `go-github`;
+- discussion, comment, and reply synchronization through `githubv4`;
+- release and release-asset metadata through `go-github`.
+
+Release asset body downloads are excluded from API request gating after GitHub has returned the download location. Manual commands are not delayed by schedule jitter. Git clone/fetch and wiki behavior are unchanged.
+
+## Configuration
+
+The following top-level options are added:
+
+```yaml
+githubApiConcurrency: 2
+githubMinRequestInterval: 200ms
+githubLowRemainingThreshold: 100
+githubScheduleJitter: 30s
+```
+
+- `githubApiConcurrency` is the maximum number of in-flight GitHub API calls in this process. Zero uses the default of 2.
+- `githubMinRequestInterval` is the minimum interval between the start of consecutive API calls. Zero uses the default of 200 milliseconds.
+- `githubLowRemainingThreshold` causes a primary rate-limit bucket to pause until reset when its reported remaining value is at or below the threshold. Zero uses the default of 100.
+- `githubScheduleJitter` is the maximum random delay applied after a daemon cron trigger. Zero explicitly disables schedule staggering.
+- Negative durations are invalid and fall back to their defaults, except that zero jitter remains the documented off switch.
+
+Existing configuration files remain valid. The fields participate in configuration save, export, import preview, apply, and reload just like the existing GitHub retry settings.
+
+## Architecture
+
+### Shared coordinator
+
+A new `internal/githubapi` package owns a process-wide coordinator. It provides a small API for acquiring permission before a request and reporting the result afterward. The coordinator is initialized from the current configuration and can be safely replaced when configuration reload publishes a new complete config instance.
+
+Before every covered API attempt, the caller:
+
+1. waits for any global pause to expire;
+2. waits for an API concurrency slot;
+3. observes the minimum request-start interval;
+4. sends the request;
+5. reports response headers or the returned error;
+6. releases the concurrency slot.
+
+Waiting is context-aware. Cancellation removes the waiter without leaking a slot or timer.
+
+REST and GraphQL share concurrency and request-start pacing because GitHub's secondary concurrency limit spans both APIs. Primary quota observations are tracked by resource name where available so exhausting one REST bucket does not incorrectly overwrite another bucket's state. A secondary-limit pause is process-wide.
+
+### Rate-limit observation
+
+For REST responses, the coordinator consumes:
+
+- `x-ratelimit-resource`;
+- `x-ratelimit-limit`;
+- `x-ratelimit-remaining`;
+- `x-ratelimit-used`;
+- `x-ratelimit-reset`;
+- `retry-after`.
+
+For GraphQL calls, query structs include GitHub's `rateLimit` fields (`cost`, `remaining`, and `resetAt`) and report them after successful queries. GraphQL errors continue to be classified by the retry package and may also establish a process-wide secondary pause or a reset-based primary pause when timing information is present.
+
+When a bucket reports remaining capacity at or below `githubLowRemainingThreshold`, later requests for that bucket wait until its reset time. A primary-limit error always pauses until the reported reset time. A secondary-limit response pauses all GitHub API traffic for `Retry-After`; when GitHub supplies no duration, the pause is at least one minute.
+
+Observability is emitted through the existing UI/logger path. Logs are produced when a bucket first becomes low, when a global pause starts or is extended, and when traffic resumes. Tokens and authorization headers are never logged. Routine successful requests do not generate per-request quota logs.
+
+### Retry jitter
+
+`internal/retry` retains responsibility for retry count, retryable-error classification, and exponential backoff. Each retry attempt re-enters the shared coordinator.
+
+Fallback exponential backoff gains bounded random jitter so several jobs do not wake together. Exact server-provided reset and `Retry-After` deadlines remain authoritative and are not shortened by randomness. Randomness is injectable in tests.
+
+### Daemon schedule staggering
+
+Only daemon-triggered jobs receive a random delay in the inclusive range from zero to `githubScheduleJitter`. The delay occurs before component execution and respects scheduler/job cancellation. A zero value disables it. Direct CLI commands and Web/API-triggered immediate executions retain their current start behavior.
+
+## Integration
+
+Existing client libraries and component boundaries remain intact:
+
+- issue wraps each `ListByRepo` and `ListComments` attempt;
+- discussion wraps each discussions/comments/replies `Query` attempt and reports GraphQL cost data;
+- the GitHub SCM release client wraps release and release-asset metadata attempts;
+- the existing retry loop remains outside the individual network attempt, ensuring every retry is gated again.
+
+The release singleton must no longer permanently capture the token and coordinator from the first configuration load. Client construction must observe the current complete configuration after reload, without mutating shared clients while requests are active.
+
+## Error Handling
+
+- Context cancellation always wins over pacing, quota waits, retry sleeps, and daemon jitter.
+- `401` remains non-retryable and does not rotate or disable credentials in this phase.
+- Permission-related `403` remains non-retryable unless GitHub headers or the known error form identify a primary or secondary rate limit.
+- `429`, secondary-limit `403`, primary-limit errors, supported `5xx`, and network errors retain existing retry behavior.
+- Invalid or missing rate-limit headers do not fail an otherwise successful API call.
+- Continued failures still stop after `retryMaxCount`; global coordination does not create unbounded retries.
+
+## Testing
+
+Unit tests use injected clocks, timers, and random sources where waiting would otherwise make tests slow or flaky. Coverage includes:
+
+- maximum in-flight request enforcement;
+- minimum request-start spacing;
+- context cancellation while queued or paused;
+- REST header parsing and per-resource quota state;
+- low-remaining and primary-reset pauses;
+- secondary-limit process-wide pause and extension;
+- GraphQL cost/remaining/reset reporting;
+- jitter bounds and deterministic retry tests;
+- daemon jitter range, cancellation, and zero-value disablement;
+- defaults, validation, save/import/export/apply/reload behavior for all new fields;
+- confirmation that manual commands are not staggered;
+- confirmation that release clients observe a reloaded token.
+
+The full `go test ./...` suite is the final verification gate.
+
+## Out of Scope
+
+- multiple PATs or credential rotation;
+- GitHub App authentication;
+- webhook-driven synchronization;
+- persistent quota state across process restarts;
+- cross-process or cross-host coordination;
+- conditional REST requests with ETags;
+- changing archive/cache semantics.
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,14 +11,18 @@ import (
 )
 
 type Config struct {
-	Repository       []typedef.Repository   `yaml:"repository"`
-	Storage          []typedef.MultiStorage `yaml:"storage"`
-	GitHubToken      string                 `yaml:"githubToken"`
-	ConcurrencyNum   uint                   `yaml:"cocurrencyNum" mapstructure:"cocurrencyNum"`
-	ReleaseSizeLimit int                    `yaml:"releaseSizeLimit"`
-	ReleaseNumLimit  int                    `yaml:"releaseNumLimit"`
-	RetryMaxCount    int                    `yaml:"retryMaxCount"`
-	RetryBaseDelay   time.Duration          `yaml:"retryBaseDelay"`
+	Repository                  []typedef.Repository   `yaml:"repository"`
+	Storage                     []typedef.MultiStorage `yaml:"storage"`
+	GitHubToken                 string                 `yaml:"githubToken"`
+	ConcurrencyNum              uint                   `yaml:"cocurrencyNum" mapstructure:"cocurrencyNum"`
+	ReleaseSizeLimit            int                    `yaml:"releaseSizeLimit"`
+	ReleaseNumLimit             int                    `yaml:"releaseNumLimit"`
+	RetryMaxCount               int                    `yaml:"retryMaxCount"`
+	RetryBaseDelay              time.Duration          `yaml:"retryBaseDelay"`
+	GitHubAPIConcurrency        uint                   `yaml:"githubApiConcurrency" mapstructure:"githubApiConcurrency"`
+	GitHubMinRequestInterval    time.Duration          `yaml:"githubMinRequestInterval" mapstructure:"githubMinRequestInterval"`
+	GitHubLowRemainingThreshold int                    `yaml:"githubLowRemainingThreshold" mapstructure:"githubLowRemainingThreshold"`
+	GitHubScheduleJitter        time.Duration          `yaml:"githubScheduleJitter" mapstructure:"githubScheduleJitter"`
 }
 
 var Path string
@@ -38,6 +42,9 @@ func Init() {
 		ui.ErrorfExit("Error unmarshalling config file, %s", err)
 	}
 	seedDefaults(ins)
+	if !vp.IsSet("githubScheduleJitter") {
+		ins.GitHubScheduleJitter = 30 * time.Second
+	}
 	// 启动校验：每个仓库条目都必须有可用身份。身份键为空意味着永远无法被
 	// 匹配或执行，直接拒绝启动。
 	if err := validateIdentity(ins); err != nil {
@@ -64,6 +71,18 @@ func seedDefaults(cfg *Config) {
 	}
 	if cfg.ReleaseSizeLimit == 0 {
 		cfg.ReleaseSizeLimit = 300000000
+	}
+	if cfg.GitHubAPIConcurrency == 0 {
+		cfg.GitHubAPIConcurrency = 2
+	}
+	if cfg.GitHubMinRequestInterval <= 0 {
+		cfg.GitHubMinRequestInterval = 200 * time.Millisecond
+	}
+	if cfg.GitHubLowRemainingThreshold <= 0 {
+		cfg.GitHubLowRemainingThreshold = 100
+	}
+	if cfg.GitHubScheduleJitter < 0 {
+		cfg.GitHubScheduleJitter = 30 * time.Second
 	}
 }
 
@@ -130,6 +149,14 @@ func GetRetryBaseDelay() time.Duration {
 	return ins.RetryBaseDelay
 }
 
+func GetGitHubAPIConcurrency() uint { return ins.GitHubAPIConcurrency }
+
+func GetGitHubMinRequestInterval() time.Duration { return ins.GitHubMinRequestInterval }
+
+func GetGitHubLowRemainingThreshold() int { return ins.GitHubLowRemainingThreshold }
+
+func GetGitHubScheduleJitter() time.Duration { return ins.GitHubScheduleJitter }
+
 // GetRetryConfig assembles the retry configuration used by every GitHub API
 // call site in the issue/discussion/release syncs.
 func GetRetryConfig() retry.Config {
@@ -168,5 +195,9 @@ func Save() error {
 	vp.Set("releaseNumLimit", ins.ReleaseNumLimit)
 	vp.Set("retryMaxCount", ins.RetryMaxCount)
 	vp.Set("retryBaseDelay", ins.RetryBaseDelay)
+	vp.Set("githubApiConcurrency", ins.GitHubAPIConcurrency)
+	vp.Set("githubMinRequestInterval", ins.GitHubMinRequestInterval)
+	vp.Set("githubLowRemainingThreshold", ins.GitHubLowRemainingThreshold)
+	vp.Set("githubScheduleJitter", ins.GitHubScheduleJitter)
 	return vp.WriteConfig()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/retry"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 	"github.com/wnarutou/gitrieve/internal/ui"
@@ -156,6 +157,10 @@ func GetGitHubMinRequestInterval() time.Duration { return ins.GitHubMinRequestIn
 func GetGitHubLowRemainingThreshold() int { return ins.GitHubLowRemainingThreshold }
 
 func GetGitHubScheduleJitter() time.Duration { return ins.GitHubScheduleJitter }
+
+func GetGitHubAPIConfig() githubapi.Config {
+	return githubapi.Config{Concurrency: ins.GitHubAPIConcurrency, MinRequestInterval: ins.GitHubMinRequestInterval, LowRemainingThreshold: ins.GitHubLowRemainingThreshold}
+}
 
 // GetRetryConfig assembles the retry configuration used by every GitHub API
 // call site in the issue/discussion/release syncs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ func Init() {
 	if !vp.IsSet("githubScheduleJitter") {
 		ins.GitHubScheduleJitter = 30 * time.Second
 	}
+	githubapi.Configure(GetGitHubAPIConfig())
 	// 启动校验：每个仓库条目都必须有可用身份。身份键为空意味着永远无法被
 	// 匹配或执行，直接拒绝启动。
 	if err := validateIdentity(ins); err != nil {
@@ -96,6 +97,7 @@ func GetIns() *Config {
 // observe a complete old or complete new instance, never a torn one.
 func SetIns(cfg *Config) {
 	ins = cfg
+	githubapi.Configure(GetGitHubAPIConfig())
 }
 
 // GetViper returns the viper instance that loaded the config file. It is nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,6 +32,29 @@ func TestGetRetryDefaults(t *testing.T) {
 	require.Equal(t, 5*time.Second, rc.BaseDelay)
 }
 
+func TestGetGitHubAPIDefaults(t *testing.T) {
+	writeTmpConfig(t, "githubtoken: test\n")
+	require.Equal(t, uint(2), GetGitHubAPIConcurrency())
+	require.Equal(t, 200*time.Millisecond, GetGitHubMinRequestInterval())
+	require.Equal(t, 100, GetGitHubLowRemainingThreshold())
+	require.Equal(t, 30*time.Second, GetGitHubScheduleJitter())
+}
+
+func TestExplicitZeroGitHubScheduleJitterDisablesStaggering(t *testing.T) {
+	writeTmpConfig(t, "githubtoken: test\ngithubScheduleJitter: 0s\n")
+	require.Zero(t, GetGitHubScheduleJitter())
+}
+
+func TestGitHubAPISettingsRoundTrip(t *testing.T) {
+	writeTmpConfig(t, "githubApiConcurrency: 4\ngithubMinRequestInterval: 750ms\ngithubLowRemainingThreshold: 250\ngithubScheduleJitter: 12s\n")
+	require.NoError(t, Save())
+	Init()
+	require.Equal(t, uint(4), GetGitHubAPIConcurrency())
+	require.Equal(t, 750*time.Millisecond, GetGitHubMinRequestInterval())
+	require.Equal(t, 250, GetGitHubLowRemainingThreshold())
+	require.Equal(t, 12*time.Second, GetGitHubScheduleJitter())
+}
+
 func TestGetRetryFromConfig(t *testing.T) {
 	writeTmpConfig(t, "githubtoken: test\nretryMaxCount: 7\nretryBaseDelay: 10s\n")
 	require.Equal(t, 7, GetRetryMaxCount())

--- a/internal/config/importexport.go
+++ b/internal/config/importexport.go
@@ -54,15 +54,19 @@ func (d *DurationString) UnmarshalYAML(node *yaml.Node) error {
 // ExportConfig is the full config document used for export/import: the Config
 // fields plus the server section (which Config does not model).
 type ExportConfig struct {
-	Repository       []typedef.Repository   `yaml:"repository"`
-	Storage          []typedef.MultiStorage `yaml:"storage"`
-	GitHubToken      string                 `yaml:"githubToken"`
-	ConcurrencyNum   uint                   `yaml:"cocurrencyNum"`
-	ReleaseSizeLimit int                    `yaml:"releaseSizeLimit"`
-	ReleaseNumLimit  int                    `yaml:"releaseNumLimit"`
-	RetryMaxCount    int                    `yaml:"retryMaxCount"`
-	RetryBaseDelay   DurationString         `yaml:"retryBaseDelay"`
-	Server           ServerSection          `yaml:"server"`
+	Repository                  []typedef.Repository   `yaml:"repository"`
+	Storage                     []typedef.MultiStorage `yaml:"storage"`
+	GitHubToken                 string                 `yaml:"githubToken"`
+	ConcurrencyNum              uint                   `yaml:"cocurrencyNum"`
+	ReleaseSizeLimit            int                    `yaml:"releaseSizeLimit"`
+	ReleaseNumLimit             int                    `yaml:"releaseNumLimit"`
+	RetryMaxCount               int                    `yaml:"retryMaxCount"`
+	RetryBaseDelay              DurationString         `yaml:"retryBaseDelay"`
+	GitHubAPIConcurrency        uint                   `yaml:"githubApiConcurrency"`
+	GitHubMinRequestInterval    DurationString         `yaml:"githubMinRequestInterval"`
+	GitHubLowRemainingThreshold int                    `yaml:"githubLowRemainingThreshold"`
+	GitHubScheduleJitter        DurationString         `yaml:"githubScheduleJitter"`
+	Server                      ServerSection          `yaml:"server"`
 }
 
 // GetServerSection returns the `server:` section, applying defaults for unset
@@ -98,15 +102,19 @@ func ExportFrom(cfg *Config) (string, error) {
 		return "", fmt.Errorf("config not initialized")
 	}
 	doc := ExportConfig{
-		Repository:       cfg.Repository,
-		Storage:          cfg.Storage,
-		GitHubToken:      cfg.GitHubToken,
-		ConcurrencyNum:   cfg.ConcurrencyNum,
-		ReleaseSizeLimit: cfg.ReleaseSizeLimit,
-		ReleaseNumLimit:  cfg.ReleaseNumLimit,
-		RetryMaxCount:    cfg.RetryMaxCount,
-		RetryBaseDelay:   DurationString(cfg.RetryBaseDelay),
-		Server:           GetServerSection(),
+		Repository:                  cfg.Repository,
+		Storage:                     cfg.Storage,
+		GitHubToken:                 cfg.GitHubToken,
+		ConcurrencyNum:              cfg.ConcurrencyNum,
+		ReleaseSizeLimit:            cfg.ReleaseSizeLimit,
+		ReleaseNumLimit:             cfg.ReleaseNumLimit,
+		RetryMaxCount:               cfg.RetryMaxCount,
+		RetryBaseDelay:              DurationString(cfg.RetryBaseDelay),
+		GitHubAPIConcurrency:        cfg.GitHubAPIConcurrency,
+		GitHubMinRequestInterval:    DurationString(cfg.GitHubMinRequestInterval),
+		GitHubLowRemainingThreshold: cfg.GitHubLowRemainingThreshold,
+		GitHubScheduleJitter:        DurationString(cfg.GitHubScheduleJitter),
+		Server:                      GetServerSection(),
 	}
 	out, err := yaml.Marshal(doc)
 	if err != nil {
@@ -140,6 +148,9 @@ func Reload() error {
 		return fmt.Errorf("failed to unmarshal config file: %w", err)
 	}
 	seedDefaults(&next)
+	if !nv.IsSet("githubScheduleJitter") {
+		next.GitHubScheduleJitter = 30 * time.Second
+	}
 	if err := validateIdentity(&next); err != nil {
 		return err
 	}
@@ -151,7 +162,7 @@ func Reload() error {
 // seedExportDefaults fills zero-valued global options in an imported document
 // with the same defaults Init applies (see seedDefaults), so an import that
 // omits them behaves identically to a config file that omits them.
-func seedExportDefaults(doc *ExportConfig) {
+func seedExportDefaults(doc *ExportConfig, jitterPresent bool) {
 	if doc.RetryMaxCount <= 0 {
 		doc.RetryMaxCount = 3
 	}
@@ -166,6 +177,18 @@ func seedExportDefaults(doc *ExportConfig) {
 	}
 	if doc.ReleaseSizeLimit == 0 {
 		doc.ReleaseSizeLimit = 300000000
+	}
+	if doc.GitHubAPIConcurrency == 0 {
+		doc.GitHubAPIConcurrency = 2
+	}
+	if time.Duration(doc.GitHubMinRequestInterval) <= 0 {
+		doc.GitHubMinRequestInterval = DurationString(200 * time.Millisecond)
+	}
+	if doc.GitHubLowRemainingThreshold <= 0 {
+		doc.GitHubLowRemainingThreshold = 100
+	}
+	if !jitterPresent || time.Duration(doc.GitHubScheduleJitter) < 0 {
+		doc.GitHubScheduleJitter = DurationString(30 * time.Second)
 	}
 	// The server section is never hot-applied, but an absent/partial section
 	// must not force empty host/port/dbPath onto the config on apply.
@@ -186,6 +209,10 @@ func seedExportDefaults(doc *ExportConfig) {
 // for user/org entries so their identity keys resolve. It does not validate
 // identities — ValidateImport collects every violation for the caller.
 func ParseImport(yamlStr string) (*ExportConfig, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlStr), &root); err != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", err)
+	}
 	var doc ExportConfig
 	if err := yaml.Unmarshal([]byte(yamlStr), &doc); err != nil {
 		return nil, fmt.Errorf("invalid YAML: %w", err)
@@ -193,7 +220,16 @@ func ParseImport(yamlStr string) (*ExportConfig, error) {
 	for i := range doc.Repository {
 		doc.Repository[i].URL = doc.Repository[i].EffectiveURL()
 	}
-	seedExportDefaults(&doc)
+	jitterPresent := false
+	if len(root.Content) > 0 && len(root.Content[0].Content) > 0 {
+		for i := 0; i+1 < len(root.Content[0].Content); i += 2 {
+			if root.Content[0].Content[i].Value == "githubScheduleJitter" {
+				jitterPresent = true
+				break
+			}
+		}
+	}
+	seedExportDefaults(&doc, jitterPresent)
 	return &doc, nil
 }
 

--- a/internal/config/importexport.go
+++ b/internal/config/importexport.go
@@ -155,7 +155,7 @@ func Reload() error {
 		return err
 	}
 	vp = nv
-	ins = &next
+	SetIns(&next)
 	return nil
 }
 

--- a/internal/config/importexport_test.go
+++ b/internal/config/importexport_test.go
@@ -178,6 +178,10 @@ func TestParseImportSeedsDefaults(t *testing.T) {
 	require.Equal(t, 3, doc.RetryMaxCount)
 	require.Equal(t, DurationString(5*time.Second), doc.RetryBaseDelay)
 	require.Equal(t, uint(3), doc.ConcurrencyNum)
+	require.Equal(t, uint(2), doc.GitHubAPIConcurrency)
+	require.Equal(t, DurationString(200*time.Millisecond), doc.GitHubMinRequestInterval)
+	require.Equal(t, 100, doc.GitHubLowRemainingThreshold)
+	require.Equal(t, DurationString(30*time.Second), doc.GitHubScheduleJitter)
 
 	// Missing/partial server section falls back to defaults so it does not force
 	// empty host/port/dbPath onto the config on apply.
@@ -185,6 +189,12 @@ func TestParseImportSeedsDefaults(t *testing.T) {
 	require.Equal(t, "8080", doc.Server.Port)
 	require.Equal(t, "gitrieve.db", doc.Server.DbPath)
 	require.False(t, doc.Server.AuthEnabled)
+}
+
+func TestParseImportPreservesExplicitZeroScheduleJitter(t *testing.T) {
+	doc, err := ParseImport("githubScheduleJitter: 0s\n")
+	require.NoError(t, err)
+	require.Zero(t, doc.GitHubScheduleJitter)
 }
 
 func TestParseImportInvalidYAML(t *testing.T) {

--- a/internal/discussion/discussion.go
+++ b/internal/discussion/discussion.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/wnarutou/gitrieve/internal/archive"
 	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/lock"
 	"github.com/wnarutou/gitrieve/internal/retry"
 	"github.com/wnarutou/gitrieve/internal/scm"
@@ -64,8 +65,22 @@ type RepositoryData struct {
 	Discussions []DiscussionData `json:"discussions"`
 }
 
+type rateLimitData struct {
+	Cost      githubv4.Int
+	Remaining githubv4.Int
+	ResetAt   githubv4.DateTime
+}
+
+func graphQLObservation(rate rateLimitData, err error) githubapi.Observation {
+	if err != nil {
+		return githubapi.ObserveError(err)
+	}
+	return githubapi.Observation{Resource: "graphql", Used: int(rate.Cost), Remaining: int(rate.Remaining), Reset: rate.ResetAt.Time}
+}
+
 // Discussion list query
 type discussionsQuery struct {
+	RateLimit  rateLimitData
 	Repository struct {
 		Discussions struct {
 			Nodes []struct {
@@ -91,6 +106,7 @@ type discussionsQuery struct {
 
 // Comment query
 type commentsQuery struct {
+	RateLimit  rateLimitData
 	Repository struct {
 		Discussion struct {
 			Comments struct {
@@ -115,6 +131,7 @@ type commentsQuery struct {
 
 // Reply query
 type repliesQuery struct {
+	RateLimit  rateLimitData
 	Repository struct {
 		Discussion struct {
 			Comments struct {
@@ -264,7 +281,13 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 	for {
 		var query discussionsQuery
 		err := retry.Do(ctx, config.GetRetryConfig(), func() error {
-			return client.Query(ctx, &query, discussionVariables)
+			permit, acquireErr := githubapi.Acquire(ctx, "graphql")
+			if acquireErr != nil {
+				return acquireErr
+			}
+			apiErr := client.Query(ctx, &query, discussionVariables)
+			permit.Done(graphQLObservation(query.RateLimit, apiErr))
+			return apiErr
 		})
 		if err != nil {
 			ui.Errorf("Error fetching discussions: %s", err)
@@ -311,7 +334,13 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 			for {
 				var commentsQuery commentsQuery
 				err := retry.Do(ctx, config.GetRetryConfig(), func() error {
-					return client.Query(ctx, &commentsQuery, commentVariables)
+					permit, acquireErr := githubapi.Acquire(ctx, "graphql")
+					if acquireErr != nil {
+						return acquireErr
+					}
+					apiErr := client.Query(ctx, &commentsQuery, commentVariables)
+					permit.Done(graphQLObservation(commentsQuery.RateLimit, apiErr))
+					return apiErr
 				})
 				if err != nil {
 					ui.Errorf("Error fetching comments for discussion %d: %s", discussion.Number, err)
@@ -345,7 +374,13 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 					for {
 						var repliesQuery repliesQuery
 						err := retry.Do(ctx, config.GetRetryConfig(), func() error {
-							return client.Query(ctx, &repliesQuery, replyVariables)
+							permit, acquireErr := githubapi.Acquire(ctx, "graphql")
+							if acquireErr != nil {
+								return acquireErr
+							}
+							apiErr := client.Query(ctx, &repliesQuery, replyVariables)
+							permit.Done(graphQLObservation(repliesQuery.RateLimit, apiErr))
+							return apiErr
 						})
 						if err != nil {
 							ui.Errorf("Error fetching replies for comment %d: %s", comment.DatabaseId, err)

--- a/internal/discussion/github_api_test.go
+++ b/internal/discussion/github_api_test.go
@@ -1,0 +1,20 @@
+package discussion
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGraphQLObservationIncludesQuota(t *testing.T) {
+	reset := time.Now().UTC().Truncate(time.Second).Add(time.Hour)
+	obs := graphQLObservation(rateLimitData{
+		Cost: 7, Remaining: 42, ResetAt: githubv4.DateTime{Time: reset},
+	}, nil)
+	require.Equal(t, "graphql", obs.Resource)
+	require.Equal(t, 7, obs.Used)
+	require.Equal(t, 42, obs.Remaining)
+	require.Equal(t, reset, obs.Reset)
+}

--- a/internal/githubapi/coordinator.go
+++ b/internal/githubapi/coordinator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v56/github"
+	"github.com/wnarutou/gitrieve/internal/ui"
 )
 
 type Config struct {
@@ -63,9 +64,23 @@ func Acquire(ctx context.Context, resource string) (Permit, error) {
 }
 
 func (c *coordinator) acquire(ctx context.Context, resource string) (Permit, error) {
+	select {
+	case c.sem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	for {
 		c.mu.Lock()
 		now := time.Now()
+		resumed := false
+		if !c.secondaryPause.IsZero() && !c.secondaryPause.After(now) {
+			c.secondaryPause = time.Time{}
+			resumed = true
+		}
+		if r, ok := c.resourcePause[resource]; ok && !r.After(now) {
+			delete(c.resourcePause, resource)
+			resumed = true
+		}
 		until := c.secondaryPause
 		if r := c.resourcePause[resource]; r.After(until) {
 			until = r
@@ -73,27 +88,24 @@ func (c *coordinator) acquire(ctx context.Context, resource string) (Permit, err
 		if c.nextStart.After(until) {
 			until = c.nextStart
 		}
-		c.mu.Unlock()
 		if !until.After(now) {
-			break
+			c.nextStart = now.Add(c.cfg.MinRequestInterval)
+			c.mu.Unlock()
+			if resumed {
+				ui.Printf("GitHub API traffic resumed for %s", resource)
+			}
+			return &permit{c: c}, nil
 		}
+		c.mu.Unlock()
 		t := time.NewTimer(time.Until(until))
 		select {
 		case <-ctx.Done():
 			t.Stop()
+			<-c.sem
 			return nil, ctx.Err()
 		case <-t.C:
 		}
 	}
-	select {
-	case c.sem <- struct{}{}:
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-	c.mu.Lock()
-	c.nextStart = time.Now().Add(c.cfg.MinRequestInterval)
-	c.mu.Unlock()
-	return &permit{c: c}, nil
 }
 
 func (p *permit) Done(obs Observation) {
@@ -105,8 +117,10 @@ func (p *permit) Done(obs Observation) {
 
 func (c *coordinator) observe(obs Observation) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	now := time.Now()
+	secondaryExtended := false
+	var secondaryUntil time.Time
+	resourceExtended := false
 	if obs.Secondary {
 		d := obs.RetryAfter
 		if d <= 0 {
@@ -114,10 +128,20 @@ func (c *coordinator) observe(obs Observation) {
 		}
 		if until := now.Add(d); until.After(c.secondaryPause) {
 			c.secondaryPause = until
+			secondaryUntil = until
+			secondaryExtended = true
 		}
 	}
 	if obs.Resource != "" && !obs.Reset.IsZero() && obs.Remaining <= c.cfg.LowRemainingThreshold && obs.Reset.After(c.resourcePause[obs.Resource]) {
 		c.resourcePause[obs.Resource] = obs.Reset
+		resourceExtended = true
+	}
+	c.mu.Unlock()
+	if secondaryExtended {
+		ui.Printf("GitHub API secondary-limit pause active until %s", secondaryUntil.Format(time.RFC3339))
+	}
+	if resourceExtended {
+		ui.Printf("GitHub API %s quota low (%d remaining); paused until %s", obs.Resource, obs.Remaining, obs.Reset.Format(time.RFC3339))
 	}
 }
 

--- a/internal/githubapi/coordinator.go
+++ b/internal/githubapi/coordinator.go
@@ -1,0 +1,137 @@
+package githubapi
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/go-github/v56/github"
+)
+
+type Config struct {
+	Concurrency           uint
+	MinRequestInterval    time.Duration
+	LowRemainingThreshold int
+}
+
+type Observation struct {
+	Resource               string
+	Limit, Remaining, Used int
+	Reset                  time.Time
+	Secondary              bool
+	RetryAfter             time.Duration
+}
+
+type Permit interface{ Done(Observation) }
+
+type coordinator struct {
+	cfg            Config
+	sem            chan struct{}
+	mu             sync.Mutex
+	nextStart      time.Time
+	resourcePause  map[string]time.Time
+	secondaryPause time.Time
+}
+
+type permit struct {
+	c    *coordinator
+	once sync.Once
+}
+
+var current atomic.Pointer[coordinator]
+
+func newCoordinator(cfg Config) *coordinator {
+	if cfg.Concurrency == 0 {
+		cfg.Concurrency = 1
+	}
+	return &coordinator{cfg: cfg, sem: make(chan struct{}, cfg.Concurrency), resourcePause: make(map[string]time.Time)}
+}
+
+func Configure(cfg Config) { current.Store(newCoordinator(cfg)) }
+
+func Acquire(ctx context.Context, resource string) (Permit, error) {
+	c := current.Load()
+	if c == nil {
+		c = newCoordinator(Config{Concurrency: 1})
+		current.CompareAndSwap(nil, c)
+		c = current.Load()
+	}
+	return c.acquire(ctx, resource)
+}
+
+func (c *coordinator) acquire(ctx context.Context, resource string) (Permit, error) {
+	for {
+		c.mu.Lock()
+		now := time.Now()
+		until := c.secondaryPause
+		if r := c.resourcePause[resource]; r.After(until) {
+			until = r
+		}
+		if c.nextStart.After(until) {
+			until = c.nextStart
+		}
+		c.mu.Unlock()
+		if !until.After(now) {
+			break
+		}
+		t := time.NewTimer(time.Until(until))
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return nil, ctx.Err()
+		case <-t.C:
+		}
+	}
+	select {
+	case c.sem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	c.mu.Lock()
+	c.nextStart = time.Now().Add(c.cfg.MinRequestInterval)
+	c.mu.Unlock()
+	return &permit{c: c}, nil
+}
+
+func (p *permit) Done(obs Observation) {
+	p.once.Do(func() {
+		p.c.observe(obs)
+		<-p.c.sem
+	})
+}
+
+func (c *coordinator) observe(obs Observation) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	if obs.Secondary {
+		d := obs.RetryAfter
+		if d <= 0 {
+			d = time.Minute
+		}
+		if until := now.Add(d); until.After(c.secondaryPause) {
+			c.secondaryPause = until
+		}
+	}
+	if obs.Resource != "" && !obs.Reset.IsZero() && obs.Remaining <= c.cfg.LowRemainingThreshold && obs.Reset.After(c.resourcePause[obs.Resource]) {
+		c.resourcePause[obs.Resource] = obs.Reset
+	}
+}
+
+func ObserveError(err error) Observation {
+	var abuse *github.AbuseRateLimitError
+	if errors.As(err, &abuse) {
+		d := time.Minute
+		if abuse.RetryAfter != nil {
+			d = *abuse.RetryAfter
+		}
+		return Observation{Secondary: true, RetryAfter: d}
+	}
+	var limited *github.RateLimitError
+	if errors.As(err, &limited) {
+		return Observation{Resource: "core", Remaining: 0, Reset: limited.Rate.Reset.Time}
+	}
+	return Observation{}
+}

--- a/internal/githubapi/coordinator.go
+++ b/internal/githubapi/coordinator.go
@@ -3,6 +3,7 @@ package githubapi
 import (
 	"context"
 	"errors"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -134,4 +135,19 @@ func ObserveError(err error) Observation {
 		return Observation{Resource: "core", Remaining: 0, Reset: limited.Rate.Reset.Time}
 	}
 	return Observation{}
+}
+
+func ObserveREST(resp *github.Response, err error) Observation {
+	obs := ObserveError(err)
+	if resp == nil {
+		return obs
+	}
+	obs.Limit = resp.Rate.Limit
+	obs.Remaining = resp.Rate.Remaining
+	obs.Reset = resp.Rate.Reset.Time
+	if resp.Response != nil {
+		obs.Resource = resp.Header.Get("X-RateLimit-Resource")
+		obs.Used, _ = strconv.Atoi(resp.Header.Get("X-RateLimit-Used"))
+	}
+	return obs
 }

--- a/internal/githubapi/coordinator_test.go
+++ b/internal/githubapi/coordinator_test.go
@@ -48,3 +48,20 @@ func TestObserveErrorSecondaryDefaultsToOneMinute(t *testing.T) {
 	require.True(t, obs.Secondary)
 	require.Equal(t, time.Minute, obs.RetryAfter)
 }
+
+func TestObserveRESTReadsRateHeaders(t *testing.T) {
+	reset := time.Now().Add(time.Hour).Unix()
+	r := &github.Response{Response: &http.Response{Header: http.Header{}}}
+	r.Header.Set("X-RateLimit-Resource", "core")
+	r.Header.Set("X-RateLimit-Limit", "5000")
+	r.Header.Set("X-RateLimit-Remaining", "99")
+	r.Header.Set("X-RateLimit-Used", "4901")
+	r.Header.Set("X-RateLimit-Reset", time.Unix(reset, 0).Format("150405"))
+	// Use the go-github parsed Rate values for numeric quota/reset data.
+	r.Rate = github.Rate{Limit: 5000, Remaining: 99, Reset: github.Timestamp{Time: time.Unix(reset, 0)}}
+	obs := ObserveREST(r, nil)
+	require.Equal(t, "core", obs.Resource)
+	require.Equal(t, 5000, obs.Limit)
+	require.Equal(t, 99, obs.Remaining)
+	require.Equal(t, time.Unix(reset, 0), obs.Reset)
+}

--- a/internal/githubapi/coordinator_test.go
+++ b/internal/githubapi/coordinator_test.go
@@ -1,0 +1,50 @@
+package githubapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v56/github"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoordinatorLimitsConcurrentRequests(t *testing.T) {
+	c := newCoordinator(Config{Concurrency: 1})
+	p, err := c.acquire(context.Background(), "core")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, err = c.acquire(ctx, "core")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	p.Done(Observation{})
+
+	p2, err := c.acquire(context.Background(), "core")
+	require.NoError(t, err)
+	p2.Done(Observation{})
+}
+
+func TestCoordinatorPausesOnlyObservedResource(t *testing.T) {
+	c := newCoordinator(Config{Concurrency: 2, LowRemainingThreshold: 10})
+	p, err := c.acquire(context.Background(), "core")
+	require.NoError(t, err)
+	p.Done(Observation{Resource: "core", Remaining: 10, Reset: time.Now().Add(time.Second)})
+
+	other, err := c.acquire(context.Background(), "graphql")
+	require.NoError(t, err)
+	other.Done(Observation{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, err = c.acquire(ctx, "core")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestObserveErrorSecondaryDefaultsToOneMinute(t *testing.T) {
+	err := &github.AbuseRateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}}
+	obs := ObserveError(err)
+	require.True(t, obs.Secondary)
+	require.Equal(t, time.Minute, obs.RetryAfter)
+}

--- a/internal/githubapi/coordinator_test.go
+++ b/internal/githubapi/coordinator_test.go
@@ -42,6 +42,24 @@ func TestCoordinatorPausesOnlyObservedResource(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+func TestCoordinatorSpacesStartsAfterSemaphoreAcquisition(t *testing.T) {
+	c := newCoordinator(Config{Concurrency: 2, MinRequestInterval: 40 * time.Millisecond})
+	starts := make(chan time.Time, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			p, err := c.acquire(context.Background(), "core")
+			require.NoError(t, err)
+			starts <- time.Now()
+			p.Done(Observation{})
+		}()
+	}
+	a, b := <-starts, <-starts
+	if b.Before(a) {
+		a, b = b, a
+	}
+	require.GreaterOrEqual(t, b.Sub(a), 30*time.Millisecond)
+}
+
 func TestObserveErrorSecondaryDefaultsToOneMinute(t *testing.T) {
 	err := &github.AbuseRateLimitError{Response: &http.Response{StatusCode: http.StatusForbidden}}
 	obs := ObserveError(err)

--- a/internal/issue/issue.go
+++ b/internal/issue/issue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/wnarutou/gitrieve/internal/archive"
 	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/lock"
 	"github.com/wnarutou/gitrieve/internal/retry"
 	"github.com/wnarutou/gitrieve/internal/scm"
@@ -152,8 +153,13 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 			resp   *gh.Response
 		)
 		err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+			permit, acquireErr := githubapi.Acquire(ctx, "core")
+			if acquireErr != nil {
+				return acquireErr
+			}
 			var apiErr error
 			issues, resp, apiErr = client.Issues.ListByRepo(ctx, r.Owner, r.Name, opt)
+			permit.Done(githubapi.ObserveREST(resp, apiErr))
 			return apiErr
 		})
 		if err != nil {
@@ -179,8 +185,13 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 					resp     *gh.Response
 				)
 				err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+					permit, acquireErr := githubapi.Acquire(ctx, "core")
+					if acquireErr != nil {
+						return acquireErr
+					}
 					var apiErr error
 					comments, resp, apiErr = client.Issues.ListComments(ctx, r.Owner, r.Name, issue.GetNumber(), commentsOpt)
+					permit.Done(githubapi.ObserveREST(resp, apiErr))
 					return apiErr
 				})
 				if err != nil {

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -5,6 +5,7 @@ package retry
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"net/url"
 	"strconv"
 	"strings"
@@ -134,6 +135,10 @@ func parseRetryAfterSeconds(msg string) time.Duration {
 // BaseDelay. Waits are interrupted when ctx is done. Returns the last error
 // after cfg.MaxRetries retries, or ctx.Err() if cancelled.
 func Do(ctx context.Context, cfg Config, fn func() error) error {
+	return do(ctx, cfg, rand.Int63n, fn)
+}
+
+func do(ctx context.Context, cfg Config, randN func(int64) int64, fn func() error) error {
 	if cfg.MaxRetries < 0 {
 		cfg.MaxRetries = 0
 	}
@@ -151,13 +156,29 @@ func Do(ctx context.Context, cfg Config, fn func() error) error {
 			return lastErr
 		}
 		if wait <= 0 {
-			wait = backoff(cfg.BaseDelay, attempt)
+			wait = jitter(backoff(cfg.BaseDelay, attempt), randN)
 		}
 		if err := sleep(ctx, wait); err != nil {
 			return err
 		}
 	}
 	return lastErr
+}
+
+func jitter(d time.Duration, randN func(int64) int64) time.Duration {
+	if d <= 0 || d >= maxBackoff {
+		return minDuration(d, maxBackoff)
+	}
+	span := d/2 + 1
+	result := d + time.Duration(randN(int64(span)))
+	return minDuration(result, maxBackoff)
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // backoff returns BaseDelay * 2^attempt, capped at maxBackoff. A zero BaseDelay

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -101,9 +101,9 @@ func TestClassifyGraphQL(t *testing.T) {
 		wantWait time.Duration
 	}{
 		{
-			name:  "secondary limit with retryAfterSeconds",
-			msg:   `non-200 OK status code: 403 Forbidden body: {"errors":[{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again.","extensions":{"retryAfterSeconds":60}}]}`,
-			retry: true,
+			name:     "secondary limit with retryAfterSeconds",
+			msg:      `non-200 OK status code: 403 Forbidden body: {"errors":[{"message":"You have exceeded a secondary rate limit. Please wait a few minutes before you try again.","extensions":{"retryAfterSeconds":60}}]}`,
+			retry:    true,
 			wantWait: 60 * time.Second,
 		},
 		{
@@ -265,4 +265,26 @@ func TestDoHonorsAbuseRetryAfter(t *testing.T) {
 	elapsed := time.Since(start)
 	require.GreaterOrEqual(t, elapsed, 120*time.Millisecond)
 	require.Less(t, elapsed, time.Second)
+}
+
+func TestJitterAddsAtMostHalfAndRespectsCap(t *testing.T) {
+	base := 10 * time.Second
+	require.Equal(t, base, jitter(base, func(int64) int64 { return 0 }))
+	require.Equal(t, 15*time.Second, jitter(base, func(n int64) int64 { return n - 1 }))
+	require.Equal(t, maxBackoff, jitter(maxBackoff, func(n int64) int64 { return n - 1 }))
+}
+
+func TestDoWithRandDoesNotJitterAuthoritativeWait(t *testing.T) {
+	ra := 20 * time.Millisecond
+	calls := 0
+	start := time.Now()
+	err := do(context.Background(), Config{MaxRetries: 1, BaseDelay: time.Second}, func(n int64) int64 { return n - 1 }, func() error {
+		calls++
+		if calls == 1 {
+			return &github.AbuseRateLimitError{RetryAfter: &ra}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Less(t, time.Since(start), 200*time.Millisecond)
 }

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sync"
 
 	"github.com/google/go-github/v56/github"
 	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/retry"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 )
@@ -17,20 +17,12 @@ type Client struct {
 	c *github.Client
 }
 
-var once sync.Once
-var client *Client
-
 func New() (*Client, error) {
-	once.Do(func() {
-		cfg := config.GetIns()
-		client = &Client{
-			c: github.NewClient(nil).WithAuthToken(cfg.GitHubToken),
-		}
-		if cfg.GitHubToken != "" {
-			client.c = client.c.WithAuthToken(cfg.GitHubToken)
-		}
-	})
-	return client, nil
+	c := github.NewClient(nil)
+	if token := config.GetIns().GitHubToken; token != "" {
+		c = c.WithAuthToken(token)
+	}
+	return &Client{c: c}, nil
 }
 
 func (c *Client) GetRepos(name string, accountType string) ([]string, error) {
@@ -64,8 +56,14 @@ func (c *Client) GetReleases(ctx context.Context, owner, repo string) ([]*github
 		err  error
 	)
 	err = retry.Do(ctx, config.GetRetryConfig(), func() error {
+		permit, acquireErr := githubapi.Acquire(ctx, "core")
+		if acquireErr != nil {
+			return acquireErr
+		}
 		var apiErr error
-		list, _, apiErr = c.c.Repositories.ListReleases(ctx, owner, repo, nil)
+		var resp *github.Response
+		list, resp, apiErr = c.c.Repositories.ListReleases(ctx, owner, repo, nil)
+		permit.Done(githubapi.ObserveREST(resp, apiErr))
 		return apiErr
 	})
 	if err != nil {
@@ -80,8 +78,14 @@ func (c *Client) GetReleaseAssets(ctx context.Context, owner, repo string, id in
 		err  error
 	)
 	err = retry.Do(ctx, config.GetRetryConfig(), func() error {
+		permit, acquireErr := githubapi.Acquire(ctx, "core")
+		if acquireErr != nil {
+			return acquireErr
+		}
 		var apiErr error
-		list, _, apiErr = c.c.Repositories.ListReleaseAssets(ctx, owner, repo, id, nil)
+		var resp *github.Response
+		list, resp, apiErr = c.c.Repositories.ListReleaseAssets(ctx, owner, repo, id, nil)
+		permit.Done(githubapi.ObserveREST(resp, apiErr))
 		return apiErr
 	})
 	if err != nil {
@@ -93,8 +97,13 @@ func (c *Client) GetReleaseAssets(ctx context.Context, owner, repo string, id in
 func (c *Client) DownloadAsset(ctx context.Context, owner, repo string, id int64) (io.ReadCloser, error) {
 	var rc io.ReadCloser
 	err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+		permit, acquireErr := githubapi.Acquire(ctx, "core")
+		if acquireErr != nil {
+			return acquireErr
+		}
 		var apiErr error
 		rc, _, apiErr = c.c.Repositories.DownloadReleaseAsset(ctx, owner, repo, id, http.DefaultClient)
+		permit.Done(githubapi.ObserveError(apiErr))
 		return apiErr
 	})
 	if err != nil {

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -1,0 +1,34 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/config"
+)
+
+func TestNewObservesReloadedToken(t *testing.T) {
+	var auth []string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = append(auth, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer s.Close()
+	base, err := url.Parse(s.URL + "/")
+	require.NoError(t, err)
+
+	for _, token := range []string{"first", "second"} {
+		config.SetIns(&config.Config{GitHubToken: token, GitHubAPIConcurrency: 1})
+		client, err := New()
+		require.NoError(t, err)
+		client.c.BaseURL = base
+		_, err = client.GetReleases(context.Background(), "o", "r")
+		require.NoError(t, err)
+	}
+	require.Equal(t, []string{"Bearer first", "Bearer second"}, auth)
+}

--- a/internal/server/config_api.go
+++ b/internal/server/config_api.go
@@ -206,6 +206,10 @@ func diffGlobals(cur *config.Config, imp *config.ExportConfig) []FieldChange {
 		{"releaseNumLimit", cur.ReleaseNumLimit, imp.ReleaseNumLimit},
 		{"retryMaxCount", cur.RetryMaxCount, imp.RetryMaxCount},
 		{"retryBaseDelay", cur.RetryBaseDelay.String(), time.Duration(imp.RetryBaseDelay).String()},
+		{"githubApiConcurrency", cur.GitHubAPIConcurrency, imp.GitHubAPIConcurrency},
+		{"githubMinRequestInterval", cur.GitHubMinRequestInterval.String(), time.Duration(imp.GitHubMinRequestInterval).String()},
+		{"githubLowRemainingThreshold", cur.GitHubLowRemainingThreshold, imp.GitHubLowRemainingThreshold},
+		{"githubScheduleJitter", cur.GitHubScheduleJitter.String(), time.Duration(imp.GitHubScheduleJitter).String()},
 	}
 	var out []FieldChange
 	for _, p := range pairs {
@@ -474,6 +478,28 @@ func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportRe
 		d := time.Duration(doc.RetryBaseDelay)
 		if next.RetryBaseDelay != d {
 			next.RetryBaseDelay = d
+			result.GlobalsUpdated++
+		}
+	}
+	if choice(req.Choices.GlobalChoices, "githubApiConcurrency", "imported") == "imported" && next.GitHubAPIConcurrency != doc.GitHubAPIConcurrency {
+		next.GitHubAPIConcurrency = doc.GitHubAPIConcurrency
+		result.GlobalsUpdated++
+	}
+	if choice(req.Choices.GlobalChoices, "githubMinRequestInterval", "imported") == "imported" {
+		d := time.Duration(doc.GitHubMinRequestInterval)
+		if next.GitHubMinRequestInterval != d {
+			next.GitHubMinRequestInterval = d
+			result.GlobalsUpdated++
+		}
+	}
+	if choice(req.Choices.GlobalChoices, "githubLowRemainingThreshold", "imported") == "imported" && next.GitHubLowRemainingThreshold != doc.GitHubLowRemainingThreshold {
+		next.GitHubLowRemainingThreshold = doc.GitHubLowRemainingThreshold
+		result.GlobalsUpdated++
+	}
+	if choice(req.Choices.GlobalChoices, "githubScheduleJitter", "imported") == "imported" {
+		d := time.Duration(doc.GitHubScheduleJitter)
+		if next.GitHubScheduleJitter != d {
+			next.GitHubScheduleJitter = d
 			result.GlobalsUpdated++
 		}
 	}

--- a/internal/server/config_api_test.go
+++ b/internal/server/config_api_test.go
@@ -98,11 +98,15 @@ func TestPreviewImportDiff(t *testing.T) {
 		},
 		// Globals already at the seeded defaults except GitHubToken and
 		// RetryBaseDelay, so the globals diff is exactly those two fields.
-		GitHubToken:      "tok-existing",
-		ConcurrencyNum:   3,
-		ReleaseSizeLimit: 300000000,
-		ReleaseNumLimit:  3,
-		RetryMaxCount:    3,
+		GitHubToken:                 "tok-existing",
+		ConcurrencyNum:              3,
+		ReleaseSizeLimit:            300000000,
+		ReleaseNumLimit:             3,
+		RetryMaxCount:               3,
+		GitHubAPIConcurrency:        2,
+		GitHubMinRequestInterval:    200 * time.Millisecond,
+		GitHubLowRemainingThreshold: 100,
+		GitHubScheduleJitter:        30 * time.Second,
 	}
 	s := server.NewConfigTestServer(cfg, testDB)
 
@@ -193,6 +197,32 @@ server:
 	// Server section changed -> warning present.
 	warnings := data["warnings"].([]interface{})
 	require.Len(t, warnings, 1)
+}
+
+func TestApplyImportGitHubAPIGlobals(t *testing.T) {
+	path := t.TempDir() + "/config.yaml"
+	writeFile(t, path, "repository:\n  - name: one\n    url: github.com/one/repo\n")
+	config.Path = path
+	config.Init()
+	t.Cleanup(func() { config.Path = "" })
+
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+	s := server.NewConfigTestServer(config.GetIns(), testDB)
+
+	importYAML := "repository:\n  - name: one\n    url: github.com/one/repo\ngithubApiConcurrency: 5\ngithubMinRequestInterval: 900ms\ngithubLowRemainingThreshold: 321\ngithubScheduleJitter: 0s\n"
+	body, _ := json.Marshal(map[string]string{"config": importYAML})
+	code, _ := getJSON(t, s, http.MethodPost, "/api/config/import", string(body))
+	require.Equal(t, 200, code)
+	require.Equal(t, uint(5), s.Cfg().GitHubAPIConcurrency)
+	require.Equal(t, 900*time.Millisecond, s.Cfg().GitHubMinRequestInterval)
+	require.Equal(t, 321, s.Cfg().GitHubLowRemainingThreshold)
+	require.Zero(t, s.Cfg().GitHubScheduleJitter)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "githubapiconcurrency: 5")
 }
 
 func TestApplyImportDefaultChoices(t *testing.T) {


### PR DESCRIPTION
## Summary

- add process-wide concurrency, pacing, quota observation, and rate-limit pauses for GitHub API traffic
- coordinate issue/release REST and discussion GraphQL requests, with retry jitter and token reload support
- stagger daemon cron jobs with configurable defaults and document all new settings

## Verification

- `go vet ./...`
- `go test -count=1 ./...`
- `go test -count=100 ./internal/githubapi ./internal/retry`

Windows race tests were not available because this environment has no CGO C compiler.