### PR TITLE
fix(ui): move repository actions before name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,4 +93,4 @@ retryBaseDelay: <duration, default 5s>  # exponential-backoff base (doubles per 
 
 ## Testing
 
-Tests live alongside the code they test as `_test.go` files (e.g. `internal/retry/retry_test.go`, `internal/lock/lock_test.go`), following Go conventions. Run the full suite with `go test ./...`.
+Go tests live alongside the code they test as `_test.go` files (e.g. `internal/retry/retry_test.go`, `internal/lock/lock_test.go`), following Go conventions. Run the full Go and web suite with `make test`; the underlying commands are `go test ./...` and `node --test web/main.test.cjs`.

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ docker-run:
 # Run all tests
 test:
 	go test ./...
+	node --test web/main.test.cjs
 
 # Quick build sanity check (builds then removes the binary)
 dry-build:

--- a/web/main.test.cjs
+++ b/web/main.test.cjs
@@ -1,0 +1,69 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+test('renders repository actions before the repository name', async () => {
+    const app = { innerHTML: '' };
+    const control = () => ({
+        addEventListener() {},
+        value: '',
+    });
+    const controls = {
+        '#btn-add-repo': control(),
+        '#btn-refresh-repos': control(),
+        '#repos-search': control(),
+        '#btn-search-repos': control(),
+    };
+    const document = {
+        addEventListener() {},
+        querySelector(selector) {
+            if (selector === '#app') return app;
+            return controls[selector] || null;
+        },
+        querySelectorAll() {
+            return [];
+        },
+    };
+    const context = vm.createContext({
+        document,
+        fetch: async () => ({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                data: {
+                    repositories: [{
+                        Name: 'gitrieve',
+                        URL: 'github.com/wnarutou/gitrieve',
+                        Type: 'repo',
+                        Storage: [],
+                        total_runs: 0,
+                        success_runs: 0,
+                        failed_runs: 0,
+                    }],
+                    total: 1,
+                },
+            }),
+        }),
+        location: { hash: '#/repositories' },
+        setInterval() {},
+        URLSearchParams,
+        window: { addEventListener() {} },
+    });
+
+    const scriptPath = path.join(__dirname, 'static', 'js', 'main.js');
+    vm.runInContext(fs.readFileSync(scriptPath, 'utf8'), context);
+    await vm.runInContext('renderRepositories()', context);
+
+    const headerCells = [...app.innerHTML.matchAll(/<th(?:\s[^>]*)?>([\s\S]*?)<\/th>/g)]
+        .map((match) => match[1].trim());
+    const firstRow = app.innerHTML.match(/<tbody>\s*<tr>([\s\S]*?)<\/tr>/);
+    assert.ok(firstRow, 'expected a rendered repository row');
+    const bodyCells = [...firstRow[1].matchAll(/<td(?:\s+class="([^"]*)")?[^>]*>([\s\S]*?)<\/td>/g)];
+
+    assert.deepEqual(headerCells.slice(0, 2), ['', 'Name']);
+    assert.equal(bodyCells[0][1], 'actions');
+    assert.match(bodyCells[0][2], /btn-run-repo/);
+    assert.match(bodyCells[1][2], /<strong>gitrieve<\/strong>/);
+});

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -416,6 +416,11 @@ async function renderRepositories() {
 
     const rows = repos.map(r => `
         <tr>
+            <td class="actions">
+                <button class="btn btn-sm btn-primary btn-run-repo" data-key="${esc(repoKey(r))}">Execute</button>
+                <button class="btn btn-sm btn-edit-repo" data-key="${esc(repoKey(r))}">Edit</button>
+                <button class="btn btn-sm btn-danger btn-del-repo" data-key="${esc(repoKey(r))}">Delete</button>
+            </td>
             <td><strong>${esc(r.Name)}</strong></td>
             <td class="muted">${esc(r.URL || '-')}</td>
             <td>${esc(r.Type || 'repo')}</td>
@@ -425,11 +430,6 @@ async function renderRepositories() {
             <td class="muted">${r.total_runs} total \u00b7 ${r.success_runs} ok \u00b7 ${r.failed_runs} fail</td>
             <td class="muted">${esc((r.Storage || []).join(', ') || '-')}</td>
             <td class="muted">${optionsCell(r)}</td>
-            <td class="actions">
-                <button class="btn btn-sm btn-primary btn-run-repo" data-key="${esc(repoKey(r))}">Execute</button>
-                <button class="btn btn-sm btn-edit-repo" data-key="${esc(repoKey(r))}">Edit</button>
-                <button class="btn btn-sm btn-danger btn-del-repo" data-key="${esc(repoKey(r))}">Delete</button>
-            </td>
         </tr>`).join('');
 
     $('#app').innerHTML = `
@@ -444,7 +444,7 @@ async function renderRepositories() {
         </div>
         <div class="panel">
             ${repos.length
-                ? '<div class="table-wrap"><table class="table"><thead><tr><th>Name</th><th>URL</th><th>Type</th><th>Cron</th><th>Next Run</th><th>Last Run</th><th>Stats</th><th>Storage</th><th>Options</th><th></th></tr></thead><tbody>' + rows + '</tbody></table></div>'
+                ? '<div class="table-wrap"><table class="table"><thead><tr><th></th><th>Name</th><th>URL</th><th>Type</th><th>Cron</th><th>Next Run</th><th>Last Run</th><th>Stats</th><th>Storage</th><th>Options</th></tr></thead><tbody>' + rows + '</tbody></table></div>'
                 : (state.reposSearch
                     ? '<div class="empty">No repositories match your search.</div>'
                     : '<div class="empty">No repositories configured. Click <strong>Add Repository</strong>.</div>')}


### PR DESCRIPTION
## Summary

- move the Execute/Edit/Delete action column before the repository name
- preserve existing action markup, ordering, keys, and event handlers
- add a regression test for repository table column ordering
- include the web regression test in the standard `make test` workflow

## Testing

- `node --check web/static/js/main.js`
- `node --test web/main.test.cjs`
- `go test ./...` (using `golang:1.23-alpine`)