### PR TITLE
feat: add repository sync health observability

### DIFF
--- a/.superpowers/sdd/2026-09-03-repository-sync-health/final-fix-1-report.md
+++ b/.superpowers/sdd/2026-09-03-repository-sync-health/final-fix-1-report.md
@@ -1,0 +1,194 @@
+# Final branch review - Fix round 1 report
+
+Date: 2026-09-04
+
+## Result
+
+All six findings in `final-fix-1-brief.md` are resolved. Repository data remains
+explicit-refresh-only; the only periodic browser refresh is the metrics timer.
+
+## Implementation decisions
+
+### One immutable execution generation per job
+
+- `RuntimeConfigSnapshot` now owns a cloned `config.ExecutionSnapshot` and one
+  generation-local `githubapi.Scope`.
+- Every admitted job binds both objects to its execution context. Repository
+  expansion uses that context too. Existing non-executor CLI/daemon callers
+  retain their package-global fallback behavior.
+- Code/repository expansion, release, issue, wiki, discussion, SCM GitHub,
+  retry, release-limit, GitHub-token/API-coordination, repository, and storage
+  paths were audited. Executor component paths now read job-bound values;
+  resolved storage values were already copied into `JobContext` and remain
+  frozen there.
+- Jobs in one generation share pacing/quota state through the generation-local
+  GitHub coordinator. Publishing a new config creates a new scope; old jobs do
+  not switch scopes. No package global is swapped per job, and no global lock
+  is held across network work.
+- The only remaining production `config.GetIns()` calls under the audited
+  component directories are the legacy `repository.GetRepositories` CLI
+  lookup path. Executor expansion uses `repository.ExpandContext` instead.
+
+### Reload is read/publish-only
+
+`POST /api/config/reload` now uses a publication-and-schedule-refresh helper
+that never calls `SaveSnapshot`. Mutating config endpoints retain the original
+publish, persist, refresh order. The regression preserves comments and
+operator formatting byte-for-byte.
+
+### Repository health and cards
+
+Primary health precedence is now:
+
+`never_synced`, `stuck`, active `pending`/`running`, terminal
+`failed`/`cancelled`, `overdue`, `healthy`.
+
+Attention sorting remains independent. `overdue` and `stuck` remain independent
+diagnostic totals. `summary.healthy` counts only primary `healthy` rows, so it
+equals the same search with `health=healthy`, including when completed rows are
+overdue.
+
+### Bulk eligibility admission
+
+The bulk-only executor entry point prepares and reserves the complete concrete
+batch, validates active/generation state, runs the API eligibility callback
+while reservation ownership is held, and persists/publishes only when accepted.
+Rejection returns `RepositoryNoLongerEligibleError`; the API accounts it in
+`no_longer_eligible`. Cancellation/error paths release every reservation and
+persist no pending rows. Existing ordinary `ExecuteJob` behavior is unchanged.
+
+### API documentation and refresh invariant
+
+`docs/api.md` now states that repository limits outside 1-100 return HTTP 400,
+includes 400 in the status table, and documents healthy-card/filter parity.
+The browser audit found one `setInterval`, calling only `refreshMetrics`; job
+log SSE does not render or reload repository data.
+
+## TDD evidence
+
+Regressions were added before their implementations and failed for the intended
+reasons:
+
+1. Complete job snapshot: RED failed to compile on the deliberately missing
+   `config.GetExecutionConfig` and `githubapi.ConfigFromContext` APIs. After
+   context/scope propagation, the test pauses a worker, publishes process and
+   executor globals from the new generation, and proves all five component
+   runners observe the complete old generation and old storage credentials.
+2. Reload bytes: RED reported the operator-formatted 133-byte input had become
+   a normalized 607-byte file. The strengthened regression deterministically
+   writes another operator edit after the read; GREEN preserves those exact
+   later bytes while publishing the generation that was read and refreshing
+   executor/schedule state.
+3. Health precedence/card parity: RED classified cancelled-plus-overdue as
+   `overdue` and counted one completed-overdue row as healthy. GREEN classifies
+   it as `cancelled` and reports healthy count zero, equal to the filter total.
+4. Bulk completion race: RED queued one redundant execution after the seam
+   inserted a successful completion between the API recheck and admission.
+   The new reserved callback produces queued=0, no_longer_eligible=1, and no
+   pending row. Separate RED tests required the missing typed error/admission
+   method; GREEN proves typed accounting plus cancellation/reservation cleanup.
+
+Repeated GREEN output:
+
+```text
+> go test ./internal/executor -run '^(TestQueuedJobUsesOneCompleteAcceptedConfigGeneration|TestReservedEligibilityRejectionIsTypedAndReleasesAdmission|TestReservedEligibilityCancellationReleasesAdmissionWithoutPersistence)$' -count=10
+ok  github.com/wnarutou/gitrieve/internal/executor  1.800s
+
+> go test ./internal/server -run '^(TestReloadConfig|TestRepositoryHealthUsesAttentionPrecedenceAndSafeDurations|TestRepositoryHealthSearchFilterSummaryAndSortAreDeterministic|TestGetRepositoriesHealthFiltersSortsAndSummarizesSearchMatches|TestBulkCompletionBetweenAPIRecheckAndReservedAdmissionIsNotQueued)$' -count=10
+ok  github.com/wnarutou/gitrieve/internal/server  2.379s
+```
+
+## Exact final verification output
+
+### Full tests
+
+```text
+> go test ./... -count=1
+?    github.com/wnarutou/gitrieve [no test files]
+ok   github.com/wnarutou/gitrieve/cmd 3.455s
+ok   github.com/wnarutou/gitrieve/cmd/daemon 1.904s
+?    github.com/wnarutou/gitrieve/cmd/discussion [no test files]
+?    github.com/wnarutou/gitrieve/cmd/issue [no test files]
+?    github.com/wnarutou/gitrieve/cmd/release [no test files]
+?    github.com/wnarutou/gitrieve/cmd/repository [no test files]
+?    github.com/wnarutou/gitrieve/cmd/run [no test files]
+ok   github.com/wnarutou/gitrieve/cmd/server 9.314s
+?    github.com/wnarutou/gitrieve/cmd/wiki [no test files]
+ok   github.com/wnarutou/gitrieve/internal/archive 6.556s
+ok   github.com/wnarutou/gitrieve/internal/auth 1.226s
+ok   github.com/wnarutou/gitrieve/internal/config 6.708s
+ok   github.com/wnarutou/gitrieve/internal/db 6.601s
+ok   github.com/wnarutou/gitrieve/internal/discussion 6.423s
+ok   github.com/wnarutou/gitrieve/internal/executor 7.427s
+ok   github.com/wnarutou/gitrieve/internal/githubapi 5.435s
+ok   github.com/wnarutou/gitrieve/internal/issue 3.418s
+ok   github.com/wnarutou/gitrieve/internal/lock 2.251s
+ok   github.com/wnarutou/gitrieve/internal/logger 3.571s
+ok   github.com/wnarutou/gitrieve/internal/monitoring 2.289s
+ok   github.com/wnarutou/gitrieve/internal/release 5.531s
+ok   github.com/wnarutou/gitrieve/internal/repository 1.830s
+ok   github.com/wnarutou/gitrieve/internal/retry 1.981s
+?    github.com/wnarutou/gitrieve/internal/scm [no test files]
+ok   github.com/wnarutou/gitrieve/internal/scm/github 1.168s
+ok   github.com/wnarutou/gitrieve/internal/server 9.820s
+?    github.com/wnarutou/gitrieve/internal/storage [no test files]
+ok   github.com/wnarutou/gitrieve/internal/syncresult 0.828s
+ok   github.com/wnarutou/gitrieve/internal/typedef 2.234s
+ok   github.com/wnarutou/gitrieve/internal/ui 1.746s
+ok   github.com/wnarutou/gitrieve/internal/wiki 1.096s
+?    github.com/wnarutou/gitrieve/web [no test files]
+```
+
+### Vet
+
+```text
+> go vet ./...
+(no output; exit 0)
+```
+
+### Race detector
+
+```text
+> $env:PATH='C:\Program Files\Vagrant\embedded\mingw64\bin;'+$env:PATH; $env:CGO_ENABLED='1'; go test -race ./internal/config ./internal/db ./internal/executor ./internal/server ./cmd/server -count=1
+ok   github.com/wnarutou/gitrieve/internal/config 4.459s
+ok   github.com/wnarutou/gitrieve/internal/db 5.455s
+ok   github.com/wnarutou/gitrieve/internal/executor 6.519s
+ok   github.com/wnarutou/gitrieve/internal/server 11.911s
+ok   github.com/wnarutou/gitrieve/cmd/server 7.472s
+```
+
+### Repository benchmark
+
+```text
+> go test ./internal/server -run '^$' -bench BenchmarkGetRepositories6000 -benchtime=1x -count=1
+goos: windows
+goarch: amd64
+pkg: github.com/wnarutou/gitrieve/internal/server
+cpu: AMD Ryzen 5 6600H with Radeon Graphics
+BenchmarkGetRepositories6000/attention-12          1  430908600 ns/op  16327616 B/op  331211 allocs/op
+BenchmarkGetRepositories6000/failed-12             1  429474100 ns/op  16260384 B/op  330199 allocs/op
+BenchmarkGetRepositories6000/overdue-12            1  428968200 ns/op  16260400 B/op  330200 allocs/op
+BenchmarkGetRepositories6000/last_success-12       1  421091400 ns/op  16260016 B/op  330194 allocs/op
+PASS
+ok   github.com/wnarutou/gitrieve/internal/server 19.173s
+```
+
+### Frontend syntax, whitespace, and refresh policy
+
+```text
+> node --check web/static/js/main.js
+(no output; exit 0)
+
+> git diff --check
+(no output; exit 0)
+
+> rg -n "setInterval|setTimeout|EventSource" web/static/js/main.js
+96:    el._t = setTimeout(() => { el.className = 'toast hidden'; }, 4000);
+348:    const es = new EventSource('/api/jobs/' + encodeURIComponent(jobId) + '/logs');
+370:    es.onerror = () => { /* EventSource auto-reconnects; dedupe + done event handle the rest */ };
+1193:    setInterval(refreshMetrics, 15000);
+```
+
+`TestRepositoryHealthAssets` also passed in the full suite and statically
+asserts that timer callbacks and the log SSE block do not call repository
+rendering functions.

--- a/.superpowers/sdd/2026-09-03-repository-sync-health/final-fix-2-report.md
+++ b/.superpowers/sdd/2026-09-03-repository-sync-health/final-fix-2-report.md
@@ -1,0 +1,192 @@
+# Final branch review - Fix round 2 report
+
+Date: 2026-09-04
+Base: `1e9f54c`
+
+## Result
+
+All three Fix Round 2 findings are resolved. GitHub API traffic from old and
+new runtime generations now shares one process arbiter, wiki preflight and
+user/org listing use the coordinated contextual retry path, and expansion
+failures or empty results can no longer be reported as successfully queued.
+
+## Implementation decisions
+
+### Stable process-wide GitHub API arbiter
+
+- `githubapi.Scope` retains only the immutable API config accepted with its job
+  generation so job snapshot assertions remain meaningful.
+- `Acquire` always delegates to the single coordinator stored in `current`.
+  `Publish` updates that coordinator's live config in place instead of replacing
+  it, preserving active count, start pacing, resource quota pauses, and the
+  secondary-limit pause across configuration publication.
+- The old fixed-capacity channel was replaced by mutex-protected `active` state
+  and a broadcast `changed` channel. Raising concurrency wakes waiters;
+  lowering it admits nothing new until active calls drain below the new limit.
+  Cancellation removes no capacity and cannot leak a permit.
+- The mutex is held only while inspecting/updating arbiter state. It is released
+  before timer waits and before the caller performs network I/O.
+- Existing config/GitHub publication read-boundary tests remain in force and
+  now assert that publication reconfigures the same coordinator instance.
+
+### Coordinated wiki preflight and user/org listing
+
+- Each wiki repository-existence REST attempt now uses the job context,
+  `config.GetRetryConfigContext`, `githubapi.Acquire("core")`, and
+  `Done(ObserveREST(...))`. Existing no-wiki skip reason and error presentation
+  are unchanged.
+- `scm/github.Client.GetReposContext` applies the same per-attempt sequence to
+  organization/user listing. The legacy `GetRepos` convenience method delegates
+  with a background context for CLI compatibility; executor/API expansion calls
+  only the contextual method.
+- HTTP-backed regressions prove permit gating, cancellation, job-snapshot retry,
+  REST quota observation, and permit release.
+
+### Fallible expansion and enqueue accounting
+
+- `repository.ExpandContext` now returns `([]typedef.Repository, error)` and
+  propagates contextual client creation/listing failures. Successful concrete
+  repositories still inherit the configured cron/storage/component options.
+- Executor production expansion propagates the error before reservation or
+  persistence. A zero-result expansion returns typed
+  `RepositoryExpansionEmptyError`.
+- `NewExecutorWithRunners` retains its existing optional slice-only expander
+  injection for compatibility, but zero results through that seam receive the
+  same typed failure.
+- Bulk's existing default enqueue-error branch counts expansion errors as
+  `failed_to_enqueue`. The regression proves an empty user expansion reports
+  queued=0, failed_to_enqueue=1, and persists no pending execution. Existing
+  normal user/org tests still prove one execution per concrete repository.
+
+## TDD evidence
+
+The behavior tests were written and observed failing before each implementation:
+
+1. Stable arbiter RED:
+   - new-generation acquisition returned `nil` error while an old-generation
+     permit was held;
+   - a new scope bypassed the old scope's secondary pause;
+   - a waiter returned before cancellation/resizing because each scope owned an
+     independent coordinator.
+2. Wiki RED:
+   - HTTP was reached while a process permit was held;
+   - cancellation did not interrupt a coordinated wait because no wait existed;
+   - the first transient failure returned immediately instead of using the job
+     snapshot's retry count.
+3. Listing/expansion RED:
+   - `GetReposContext` was undefined;
+   - `ExpandContext` supported only one return value and silently collapsed
+     errors into an empty slice;
+   - after correcting the user-prefix history fixture and removing the new
+     guard for the mutation check, bulk reported `queued=1` for an empty
+     expansion. Restoring the typed guard produced the required accounting.
+
+Repeated focused GREEN output:
+
+```text
+> go test ./internal/githubapi ./internal/scm/github ./internal/wiki ./internal/repository ./internal/executor ./internal/server -run '^(TestScopesShareOneProcessArbiterAcrossGenerations|TestScopePublicationPreservesObservedSecondaryPause|TestProcessArbiterCancellationAndResizeWakeSafely|TestGetReposContextCancellationInterruptsScopedPermitWait|TestGetReposContextRetriesFromSnapshotAndObservesREST|TestWikiPreflightWaitsForScopedPermitAndReleasesItAfterObservation|TestWikiPreflightCancellationInterruptsPermitWait|TestWikiPreflightRetriesFromJobSnapshot|TestExpandContextPropagatesClientAndListFailures|TestExpandContextPassesCancellationToListing|TestExpandContextReturnsConcreteRepositories|TestExecuteJobPropagatesProductionExpansionFailure|TestExecuteJobRejectsEmptyExpansionAsTypedEnqueueFailure|TestExecuteJobExpandsOrgIntoMultipleJobs|TestBulkEmptyUserExpansionCountsFailedToEnqueue|TestBulkUserRetryUsesUnicodePrefixIndexAndCountsOneCandidateForMultipleExecutions)$' -count=10
+ok   github.com/wnarutou/gitrieve/internal/githubapi 3.737s
+ok   github.com/wnarutou/gitrieve/internal/scm/github 11.486s
+ok   github.com/wnarutou/gitrieve/internal/wiki 4.024s
+ok   github.com/wnarutou/gitrieve/internal/repository 3.222s
+ok   github.com/wnarutou/gitrieve/internal/executor 3.394s
+ok   github.com/wnarutou/gitrieve/internal/server 3.249s
+```
+
+## Exact final verification output
+
+### Full tests
+
+```text
+> go test ./... -count=1
+?    github.com/wnarutou/gitrieve [no test files]
+ok   github.com/wnarutou/gitrieve/cmd 5.719s
+ok   github.com/wnarutou/gitrieve/cmd/daemon 0.699s
+?    github.com/wnarutou/gitrieve/cmd/discussion [no test files]
+?    github.com/wnarutou/gitrieve/cmd/issue [no test files]
+?    github.com/wnarutou/gitrieve/cmd/release [no test files]
+?    github.com/wnarutou/gitrieve/cmd/repository [no test files]
+?    github.com/wnarutou/gitrieve/cmd/run [no test files]
+ok   github.com/wnarutou/gitrieve/cmd/server 9.151s
+?    github.com/wnarutou/gitrieve/cmd/wiki [no test files]
+ok   github.com/wnarutou/gitrieve/internal/archive 7.806s
+ok   github.com/wnarutou/gitrieve/internal/auth 1.139s
+ok   github.com/wnarutou/gitrieve/internal/config 8.089s
+ok   github.com/wnarutou/gitrieve/internal/db 6.033s
+ok   github.com/wnarutou/gitrieve/internal/discussion 3.536s
+ok   github.com/wnarutou/gitrieve/internal/executor 7.890s
+ok   github.com/wnarutou/gitrieve/internal/githubapi 6.032s
+ok   github.com/wnarutou/gitrieve/internal/issue 2.350s
+ok   github.com/wnarutou/gitrieve/internal/lock 2.456s
+ok   github.com/wnarutou/gitrieve/internal/logger 1.874s
+ok   github.com/wnarutou/gitrieve/internal/monitoring 6.750s
+ok   github.com/wnarutou/gitrieve/internal/release 3.573s
+ok   github.com/wnarutou/gitrieve/internal/repository 3.039s
+ok   github.com/wnarutou/gitrieve/internal/retry 2.484s
+?    github.com/wnarutou/gitrieve/internal/scm [no test files]
+ok   github.com/wnarutou/gitrieve/internal/scm/github 1.984s
+ok   github.com/wnarutou/gitrieve/internal/server 9.670s
+?    github.com/wnarutou/gitrieve/internal/storage [no test files]
+ok   github.com/wnarutou/gitrieve/internal/syncresult 1.277s
+ok   github.com/wnarutou/gitrieve/internal/typedef 0.554s
+ok   github.com/wnarutou/gitrieve/internal/ui 0.675s
+ok   github.com/wnarutou/gitrieve/internal/wiki 1.618s
+?    github.com/wnarutou/gitrieve/web [no test files]
+```
+
+### Vet
+
+```text
+> go vet ./...
+(no output; exit 0)
+```
+
+### Race detector
+
+```text
+> $env:PATH='C:\Program Files\Vagrant\embedded\mingw64\bin;'+$env:PATH; $env:CGO_ENABLED='1'; go test -race ./internal/config ./internal/db ./internal/githubapi ./internal/repository ./internal/wiki ./internal/executor ./internal/server ./cmd/server -count=1
+ok   github.com/wnarutou/gitrieve/internal/config 17.367s
+ok   github.com/wnarutou/gitrieve/internal/db 8.035s
+ok   github.com/wnarutou/gitrieve/internal/githubapi 1.821s
+ok   github.com/wnarutou/gitrieve/internal/repository 9.151s
+ok   github.com/wnarutou/gitrieve/internal/wiki 6.467s
+ok   github.com/wnarutou/gitrieve/internal/executor 6.729s
+ok   github.com/wnarutou/gitrieve/internal/server 10.236s
+ok   github.com/wnarutou/gitrieve/cmd/server 6.184s
+```
+
+### Repository benchmark
+
+```text
+> go test ./internal/server -run '^$' -bench BenchmarkGetRepositories6000 -benchtime=1x -count=1
+goos: windows
+goarch: amd64
+pkg: github.com/wnarutou/gitrieve/internal/server
+cpu: AMD Ryzen 5 6600H with Radeon Graphics
+BenchmarkGetRepositories6000/attention-12          1  430613500 ns/op  16327296 B/op  331209 allocs/op
+BenchmarkGetRepositories6000/failed-12             1  417546100 ns/op  16259952 B/op  330194 allocs/op
+BenchmarkGetRepositories6000/overdue-12            1  422060400 ns/op  16260496 B/op  330201 allocs/op
+BenchmarkGetRepositories6000/last_success-12       1  416795800 ns/op  16260432 B/op  330199 allocs/op
+PASS
+ok   github.com/wnarutou/gitrieve/internal/server 18.498s
+```
+
+### Frontend syntax, whitespace, and manual-refresh policy
+
+```text
+> node --check web/static/js/main.js
+(no output; exit 0)
+
+> git diff --check
+(no output; exit 0)
+
+> rg -n "setInterval|setTimeout|EventSource" web/static/js/main.js
+96:    el._t = setTimeout(() => { el.className = 'toast hidden'; }, 4000);
+348:    const es = new EventSource('/api/jobs/' + encodeURIComponent(jobId) + '/logs');
+370:    es.onerror = () => { /* EventSource auto-reconnects; dedupe + done event handle the rest */ };
+1193:    setInterval(refreshMetrics, 15000);
+```
+
+The only periodic refresh remains `refreshMetrics`. Repository rendering is
+triggered only by navigation, explicit refresh, or successful user mutations;
+the job-log SSE block does not reload repository data.

--- a/.superpowers/sdd/2026-09-03-repository-sync-health/final-fix-3-report.md
+++ b/.superpowers/sdd/2026-09-03-repository-sync-health/final-fix-3-report.md
@@ -1,0 +1,185 @@
+# Final branch review - Fix round 3 report
+
+Date: 2026-09-04
+Base: `425e47f`
+
+## Result
+
+The remaining mixed-policy publication window is closed. API configuration
+publication now exposes package-global config, the stable process-wide GitHub
+arbiter policy, and the Executor runtime through one reader-observed boundary.
+Reload reads and validates an unpublished disk snapshot before using that same
+boundary, without writing the file or losing a later external edit.
+
+## Implementation decisions
+
+### Unified publication boundary
+
+- `config.PublishSnapshot` owns the config state lock and delegates to the
+  existing `githubapi.Publish` write gate. Its callback stores the immutable
+  package config and installs the matching Executor runtime before the stable
+  coordinator policy is reconfigured and the gate is released.
+- Every API create/update/delete/import publication uses this callback via
+  `publishConfigLocked`. Persistence and schedule refresh remain serialized by
+  the API generation lock, but stay outside the publication gate.
+- The arbiter remains one stable coordinator. Publication only updates its live
+  policy; old and new job scopes still share active counts, pacing, and quota
+  pauses.
+- Runtime snapshot reads used by ordinary and generation-bound admissions now
+  take the publication read gate. Reservation takes that gate before `queueMu`
+  and releases both before eligibility callbacks, database work, persistence,
+  or network expansion.
+
+### Lock order
+
+The production order is:
+
+```text
+API configMu -> config stateMu -> publication write gate -> Executor queueMu
+                                  publication read gate  -> Executor queueMu
+```
+
+No path acquires the publication read gate while already holding `queueMu`.
+`githubapi.Acquire` uses the read gate only to select the stable coordinator,
+then releases it before permit waits and network operations.
+
+### Unpublished reload snapshots
+
+- `config.ReadReloadSnapshot` reads, unmarshals, applies defaults, and validates
+  a fresh viper instance without changing package-global state.
+- `config.PublishReloadSnapshot` atomically installs the loaded viper state,
+  package config, arbiter policy, and API/Executor runtime callback. It never
+  reads or writes `config.yaml` during publication.
+- The server reload endpoint now reads the opaque snapshot first and publishes
+  it through the unified boundary. A deterministic post-read edit remains
+  byte-for-byte unchanged.
+- Package-level `config.Reload()` remains compatible and retains its original
+  state-lock serialization across the complete disk-read-to-publication span.
+
+## TDD evidence
+
+The Round 3 behavior tests were added before production implementation and the
+focused run failed at compile time on the deliberately missing boundaries:
+
+```text
+internal/config/importexport_test.go:104:17: undefined: ReadReloadSnapshot
+internal/config/importexport_test.go:111:2: undefined: PublishReloadSnapshot
+internal/executor/executor_test.go:1740:10: undefined: config.PublishSnapshot
+internal/server/config_publication_test.go:187:6: api.afterRuntimePublishForTest undefined
+FAIL
+```
+
+After implementation, the new focused tests passed:
+
+```text
+> go test ./internal/config ./internal/executor ./internal/server -run '^(TestReadReloadSnapshotDoesNotPublishUntilExplicitBoundary|TestReloadConfig|TestConfigPublicationAtomicallyExposesExecutorRuntimeAndTightenedArbiterPolicy|TestUnifiedPublicationDoesNotDeadlockQueueResizeAdmissionReservationAndAcquire)$' -count=1
+ok github.com/wnarutou/gitrieve/internal/config
+ok github.com/wnarutou/gitrieve/internal/executor
+ok github.com/wnarutou/gitrieve/internal/server
+```
+
+The first broad `-count=20` run exposed an unrelated fixture assumption in
+`TestConcurrentConfigPublicationAndSnapshotReads`: a reload test from a prior
+iteration could leave a coherent but out-of-domain global snapshot, which the
+test mislabeled as torn. Seeding one allowed generation before its goroutines
+start made the test independent of prior test order. Its isolated 20x run and
+the complete focused concurrency repetition both passed.
+
+```text
+> go test ./internal/config ./internal/githubapi ./internal/executor ./internal/server -run '<focused publication/reload/arbiter/generation/reservation regex>' -count=20
+ok github.com/wnarutou/gitrieve/internal/config 2.184s
+ok github.com/wnarutou/gitrieve/internal/githubapi 6.044s
+ok github.com/wnarutou/gitrieve/internal/executor 2.019s
+ok github.com/wnarutou/gitrieve/internal/server 8.020s
+```
+
+## Final verification
+
+### Full tests
+
+```text
+> go test ./... -count=1
+ok github.com/wnarutou/gitrieve/cmd 3.244s
+ok github.com/wnarutou/gitrieve/cmd/daemon 1.695s
+ok github.com/wnarutou/gitrieve/cmd/server 10.193s
+ok github.com/wnarutou/gitrieve/internal/archive 7.430s
+ok github.com/wnarutou/gitrieve/internal/auth 3.221s
+ok github.com/wnarutou/gitrieve/internal/config 7.710s
+ok github.com/wnarutou/gitrieve/internal/db 7.704s
+ok github.com/wnarutou/gitrieve/internal/discussion 7.449s
+ok github.com/wnarutou/gitrieve/internal/executor 4.308s
+ok github.com/wnarutou/gitrieve/internal/githubapi 7.768s
+ok github.com/wnarutou/gitrieve/internal/issue 4.754s
+ok github.com/wnarutou/gitrieve/internal/lock 3.303s
+ok github.com/wnarutou/gitrieve/internal/logger 1.323s
+ok github.com/wnarutou/gitrieve/internal/monitoring 1.510s
+ok github.com/wnarutou/gitrieve/internal/release 6.406s
+ok github.com/wnarutou/gitrieve/internal/repository 1.792s
+ok github.com/wnarutou/gitrieve/internal/retry 1.703s
+ok github.com/wnarutou/gitrieve/internal/scm/github 2.592s
+ok github.com/wnarutou/gitrieve/internal/server 10.387s
+ok github.com/wnarutou/gitrieve/internal/syncresult 0.406s
+ok github.com/wnarutou/gitrieve/internal/typedef 1.495s
+ok github.com/wnarutou/gitrieve/internal/ui 1.844s
+ok github.com/wnarutou/gitrieve/internal/wiki 2.696s
+```
+
+Packages without tests also completed successfully.
+
+### Vet
+
+```text
+> go vet ./...
+(no output; exit 0)
+```
+
+### Race detector
+
+```text
+> PATH='C:\Program Files\Vagrant\embedded\mingw64\bin;...'; CGO_ENABLED=1; go test -race ./internal/config ./internal/db ./internal/githubapi ./internal/repository ./internal/wiki ./internal/executor ./internal/server ./cmd/server -count=1
+ok github.com/wnarutou/gitrieve/internal/config 7.788s
+ok github.com/wnarutou/gitrieve/internal/db 5.571s
+ok github.com/wnarutou/gitrieve/internal/githubapi 5.015s
+ok github.com/wnarutou/gitrieve/internal/repository 9.925s
+ok github.com/wnarutou/gitrieve/internal/wiki 4.856s
+ok github.com/wnarutou/gitrieve/internal/executor 4.446s
+ok github.com/wnarutou/gitrieve/internal/server 12.932s
+ok github.com/wnarutou/gitrieve/cmd/server 7.749s
+```
+
+### 6000 x 100 benchmark
+
+```text
+> go test ./internal/server -run '^$' -bench BenchmarkGetRepositories6000 -benchtime=1x -count=1
+BenchmarkGetRepositories6000/attention-12       1  425801300 ns/op  16327760 B/op  331212 allocs/op
+BenchmarkGetRepositories6000/failed-12          1  400470400 ns/op  16260544 B/op  330200 allocs/op
+BenchmarkGetRepositories6000/overdue-12         1  401192900 ns/op  16260496 B/op  330201 allocs/op
+BenchmarkGetRepositories6000/last_success-12    1  406633200 ns/op  16260560 B/op  330200 allocs/op
+PASS
+```
+
+### Frontend syntax, whitespace, and refresh policy
+
+```text
+> node --check web/static/js/main.js
+(no output; exit 0)
+
+> git diff --check
+(no output; exit 0)
+
+> rg -n "setInterval|setTimeout|EventSource" web/static/js/main.js
+96:    el._t = setTimeout(() => { el.className = 'toast hidden'; }, 4000);
+348:    const es = new EventSource('/api/jobs/' + encodeURIComponent(jobId) + '/logs');
+370:    es.onerror = () => { /* EventSource auto-reconnects; dedupe + done event handle the rest */ };
+1193:    setInterval(refreshMetrics, 15000);
+```
+
+The only periodic refresh remains metrics-only. Repository data still refreshes
+only on navigation, explicit refresh, or successful user mutation; the job-log
+SSE path does not reload repository data.
+
+## Concerns
+
+None known. The publication callback is intentionally restricted to immutable
+in-memory stores; persistence, schedule refresh, permit waiting, and network I/O
+remain outside the gate.

--- a/.superpowers/sdd/2026-09-03-repository-sync-health/task-10-report.md
+++ b/.superpowers/sdd/2026-09-03-repository-sync-health/task-10-report.md
@@ -75,3 +75,57 @@ per request because the endpoint derives health for the full 6,000-repository
 snapshot before returning one page. It is comfortably within the specified
 latency target on the recorded environment, and changing that architecture was
 outside this task.
+
+## Fix Round 1
+
+### Review fixes
+
+- Made the benchmark history generator shared by the benchmark and a focused
+  boundary regression. Its newest execution is now two hours before fixture
+  `now`, so hourly cron plus a 30-minute grace period is overdue even during the
+  first half-hour. The regression fixes `now` at 12:05 and proves the newest
+  attempt (10:05) predates the eligible 11:00 occurrence.
+- Strengthened the production-query EXPLAIN check from whole-plan substring
+  matching to alias-specific nodes. `recent` must be a keyed `SEARCH` using
+  `idx_executions_repo_start` with `repo_key=?`; `successful` must be a keyed
+  `SEARCH` using `idx_executions_repo_status_end` with both `repo_key=?` and
+  `status=?`. A negative plan removes the successful index while leaving the
+  totals scan's same index name present, proving that misleading whole-plan
+  containment is rejected.
+- Corrected API, Web UI, README, Chinese README, and contributor documentation
+  to state that stuck classification applies to latest executions remaining
+  either `pending` or `running` beyond `syncStuckThreshold`.
+
+### TDD evidence
+
+- Fixture regression RED: build failed with undefined
+  `insertRepositoryBenchmarkHistory`; after extracting and using the shared
+  deterministic transaction fixture, the early-hour regression passed.
+- Plan regression RED: build failed with undefined alias-aware plan helpers;
+  after implementing the strict `SEARCH`/index/key matcher and negative plan,
+  the focused DB regression passed.
+
+### Performance rerun
+
+Command: `go test ./internal/server -run '^$' -bench BenchmarkGetRepositories6000 -benchtime=1x -count=3`
+
+| Sub-benchmark | Run 1 | Run 2 | Run 3 | Target |
+|---|---:|---:|---:|---:|
+| attention | 422.9327 ms/op | 408.6844 ms/op | 406.7927 ms/op | < 1 s/op |
+| failed | 408.2615 ms/op | 408.0346 ms/op | 406.1325 ms/op | < 1 s/op |
+| overdue | 410.3377 ms/op | 404.5534 ms/op | 409.8713 ms/op | < 1 s/op |
+| last_success | 414.0160 ms/op | 417.3786 ms/op | 406.5959 ms/op | < 1 s/op |
+
+All twelve Fix Round 1 observations meet the target. The run started at minute
+05, exercising the wall-clock boundary that the previous fixture did not
+guarantee, and the overdue handler returned a valid non-empty response.
+
+### Fix Round 1 verification
+
+- Focused DB/server regressions: PASS.
+- Three-count 6,000 x 100 handler benchmark: PASS, all results below one second.
+- `go test ./...`: PASS.
+- `go vet ./...`: PASS, no diagnostics.
+- `CGO_ENABLED=1 go test -race ./internal/db ./internal/executor ./internal/server ./cmd/server`
+  with the MinGW64 toolchain first in `PATH`: PASS.
+- `git diff --check`: PASS.

--- a/.superpowers/sdd/2026-09-03-repository-sync-health/task-10-report.md
+++ b/.superpowers/sdd/2026-09-03-repository-sync-health/task-10-report.md
@@ -1,0 +1,77 @@
+# Task 10 Report: Performance fixture, documentation, and final verification
+
+## Status
+
+Complete.
+
+## Implementation
+
+- Added `BenchmarkGetRepositories6000` with 6,000 configured repositories and
+  100 historical executions per repository (600,000 execution rows). Fixture
+  construction and the single transaction commit occur before the benchmark
+  timer. The four sub-benchmarks exercise attention sorting, failed filtering,
+  overdue filtering, and last-success sorting; every iteration checks HTTP 200
+  and decodes/validates the response payload.
+- Added `EXPLAIN QUERY PLAN` regression coverage over the production repository
+  statistics query. The joined detail output must mention both
+  `idx_executions_repo_start` and `idx_executions_repo_status_end`.
+- Reworked `RepositoryRunStats` from a full-history window plus multiple
+  aggregate passes to one covering-index totals pass with indexed correlated
+  lookups for latest attempt and latest success. `executions` remains the sole
+  source of truth; no materialized state table was introduced.
+- Updated the API, Web UI, English/Chinese README, and contributor guidance with
+  exact health settings/statuses/endpoints/filters/fields, component semantics,
+  bulk retry confirmation/partial results, executor concurrency, restart
+  reconciliation, and the explicit-refresh-only repository-page invariant.
+
+## TDD evidence
+
+The first representative benchmark run against the original query exceeded the
+one-second target:
+
+| Sub-benchmark | Original query |
+|---|---:|
+| attention | 4.317699600 s/op |
+| failed | 4.272863900 s/op |
+| overdue | 4.393945600 s/op |
+| last_success | 4.325288300 s/op |
+
+After the indexed-query change, the focused run measured 0.413–0.434 s/op and
+the repository-stat semantics/index-plan tests passed.
+
+## Benchmark environment and final results
+
+- OS: Microsoft Windows NT 10.0.26200.0 (`windows/amd64`)
+- CPU: AMD Ryzen 5 6600H with Radeon Graphics (AMD64 Family 25 Model 68)
+- Go: `go1.27.0 windows/amd64`
+- Fixture: 6,000 repositories x 100 executions = 600,000 execution rows;
+  setup performed in one transaction before timing
+- Command: `go test ./internal/server -run '^$' -bench BenchmarkGetRepositories6000 -benchtime=1x -count=3`
+
+| Sub-benchmark | Run 1 | Run 2 | Run 3 | Target |
+|---|---:|---:|---:|---:|
+| attention | 418.0522 ms/op | 404.5152 ms/op | 404.6631 ms/op | < 1 s/op |
+| failed | 401.9312 ms/op | 399.5494 ms/op | 400.9808 ms/op | < 1 s/op |
+| overdue | 404.0659 ms/op | 402.1244 ms/op | 410.5300 ms/op | < 1 s/op |
+| last_success | 403.0811 ms/op | 404.6101 ms/op | 403.4757 ms/op | < 1 s/op |
+
+All twelve observations meet the target.
+
+## Verification
+
+- Full Task 10 `gofmt -w` file list: PASS, no diagnostics.
+- `go vet ./...`: PASS, no diagnostics.
+- `go test ./...`: PASS.
+- `CGO_ENABLED=1 go test -race ./internal/db ./internal/executor ./internal/server ./cmd/server`
+  with `C:\Program Files\Vagrant\embedded\mingw64\bin` first in `PATH`: PASS.
+- `git diff --check`: PASS.
+- Scope: only Task 10 benchmark/query/tests/documentation plus this report;
+  `.codex-ui-test/` was not modified.
+
+## Concerns
+
+None blocking. The benchmark still allocates about 16 MB and 330,000 objects
+per request because the endpoint derives health for the full 6,000-repository
+snapshot before returning one page. It is comfortably within the specified
+latency target on the recorded environment, and changing that architecture was
+outside this task.

--- a/.superpowers/sdd/2026-09-03-repository-sync-health/task-9-report.md
+++ b/.superpowers/sdd/2026-09-03-repository-sync-health/task-9-report.md
@@ -30,3 +30,26 @@
 ## Concerns
 
 - Browser-level interaction testing was not run in this worktree; embedded static checks and Go API tests cover the required contracts. Existing mojibake in unrelated JavaScript text was left untouched to keep the diff scoped.
+
+## Fix Round 1
+
+### RED / GREEN
+
+- RED: the expanded embedded-asset test failed because bulk retry rebuilt the selector instead of posting a frozen `{selector, expected_count}` attempt and did not have route-epoch guards.
+- GREEN: the focused static test now validates frozen selector posting, 409 `actual_count` reconfirmation, route/detail epochs, execution detail controls, EventSource identity checks, and the single allowed metrics interval.
+
+### Fixes
+
+- Bulk retry snapshots the exact selector, expected count, and repository route epoch. A changed route/filter aborts both response handling and the second 409 confirmation.
+- Navigation tracks `activeRoute` and a monotonic `routeEpoch`; repository renders, CRUD/run continuations, component details, and detail retry refuse stale updates.
+- Execution details now show latest status, attempt time, duration, error, components, logs, and a single-repository retry control only for failed/cancelled/overdue work.
+- Closed/replaced EventSources cannot append or update the current log modal.
+
+### Verification
+
+- `node --check web/static/js/main.js`
+- `go test ./cmd/server -run 'TestStatic|TestRepositoryHealthAssets' -count=1`
+- `go test ./cmd/server ./internal/server -count=1`
+- `go test ./... -count=1`
+- `go vet ./cmd/server ./internal/server`
+- `git diff --check`

--- a/.superpowers/sdd/2026-09-03-repository-sync-health/task-9-report.md
+++ b/.superpowers/sdd/2026-09-03-repository-sync-health/task-9-report.md
@@ -1,0 +1,32 @@
+# Task 9 Report: Repository Sync Health Dashboard
+
+## RED / GREEN
+
+- RED: `go test ./cmd/server -run 'TestStatic|TestRepositoryHealthAssets' -count=1` failed because `repositoryParams` and the health dashboard assets did not exist.
+- GREEN: the same focused test now passes after the embedded dashboard, component detail, and explicit-refresh guards were added.
+
+## Files
+
+- `web/templates/index.html`: component detail section in the existing log modal.
+- `web/static/js/main.js`: bookmarkable repository health state, operational table, bulk retry confirmation/conflict handling, component drill-down, and no SSE completion render.
+- `web/static/css/main.css`: summary cards, health/component badges, responsive dashboard/table styling, and visible focus styles.
+- `cmd/server/static_test.go`: embedded-asset regression coverage.
+
+## Behavior covered
+
+- Repository data is fetched only on navigation and explicit repository actions. The sole interval remains `refreshMetrics` for the top bar.
+- Summary cards use API `summary`; bulk retry uses server-filtered `data.total`, never page rows.
+- The retry selector contains only search, health, and optional overdue; a 409 requires a fresh confirmation and retries once.
+- Closing the modal or opening ordinary logs invalidates pending component-detail fetches, preventing stale modal changes.
+
+## Verification
+
+- `go test ./cmd/server -run 'TestStatic|TestRepositoryHealthAssets' -count=1`
+- `go test ./cmd/server ./internal/server -count=1`
+- `go test ./... -count=1`
+- `go vet ./cmd/server ./internal/server`
+- `git diff --check`
+
+## Concerns
+
+- Browser-level interaction testing was not run in this worktree; embedded static checks and Go API tests cover the required contracts. Existing mojibake in unrelated JavaScript text was left untouched to keep the diff scoped.

--- a/.superpowers/sdd/2026-09-03-repository-sync-health/task-9-report.md
+++ b/.superpowers/sdd/2026-09-03-repository-sync-health/task-9-report.md
@@ -53,3 +53,18 @@
 - `go test ./... -count=1`
 - `go vet ./cmd/server ./internal/server`
 - `git diff --check`
+
+## Fix Round 2
+
+- RED: function-scoped static checks exposed the missing stale-modal close path for expanded detail retries.
+- GREEN: `renderExecutionDetails` resets the shared retry button, one execution opens its log, expanded results report the exact count and close the stale modal, and zero results report no returned log.
+- Static checks now scope repository async guards to each mutating function, validate the `total`-based frozen retry binding, forbid repository renders in the log stream function, and inspect balanced interval/timeout call expressions for forbidden callbacks.
+
+### Verification
+
+- `node --check web/static/js/main.js`
+- `go test ./cmd/server -run 'TestStatic|TestRepositoryHealthAssets' -count=1`
+- `go test ./cmd/server ./internal/server -count=1`
+- `go test ./... -count=1`
+- `go vet ./cmd/server ./internal/server`
+- `git diff --check`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ success, and compute summary counts across all search matches before health/
 diagnostic filters and pagination. Bulk retry must recompute and confirm the
 current eligible count, then account for partial outcomes.
 
+Stuck classification applies when the latest execution has remained either
+`pending` or `running` beyond `syncStuckThreshold`; do not narrow it to only
+running work.
+
 **Critical UI invariant:** the Repositories page refreshes only on an explicit
 user request. Never add polling, timer-triggered reloads, or SSE-completion
 reloads for this page.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,39 @@ code/wiki/issue/discussion/release. The lock is per-host and per-working-directo
 multi-host writes to shared storage (e.g. two machines writing one S3 bucket) are
 not guarded. Lock files are never deleted.
 
+### Server repository sync health
+
+`executions` remains the historical source of truth; do not add a materialized
+repository-state table without a separate design. `internal/db.RepositoryRunStats`
+uses `idx_executions_repo_start` for each latest attempt and
+`idx_executions_repo_status_end` for counts and latest success. Preserve those
+access paths and the 6,000 repositories x 100 executions benchmark when changing
+the overview query.
+
+Server cron, `POST /api/jobs`, and `POST /api/jobs/bulk` all enqueue through the
+same `Executor`. `cocurrencyNum` (intentional legacy spelling) caps actual
+running work, not just scheduler callbacks. Pending and running work must remain
+cancellable, and a repository with an active execution must not be enqueued a
+second time. Startup reconciles orphaned pending/running executions and active
+component rows to failed.
+
+Overall `completed` means every enabled component is `completed` or `skipped`.
+Any enabled component failure makes the execution `failed`, but ordinary
+failure does not prevent later enabled components from running. A skip is only
+for a recognizable unsupported capability, never for permission, network,
+storage, parsing, or rate-limit errors. Historical executions may legitimately
+have no component rows.
+
+Repository health precedence is never-synced, stuck, active pending/running,
+failed/cancelled, overdue, then healthy. Keep last attempt separate from last
+success, and compute summary counts across all search matches before health/
+diagnostic filters and pagination. Bulk retry must recompute and confirm the
+current eligible count, then account for partial outcomes.
+
+**Critical UI invariant:** the Repositories page refreshes only on an explicit
+user request. Never add polling, timer-triggered reloads, or SSE-completion
+reloads for this page.
+
 ### Deletion-safe sync (critical invariant — do not regress)
 A core design goal: **once code and history are pulled locally, a sync must never delete them**, even when the upstream repo is taken down, DMCA-disabled, deleted, made private, or replaced with a single README. This makes gitrieve a true archive/backup tool, not a mirror. When modifying `internal/repository/repository.go` (`Sync`), preserve these guarantees:
 
@@ -94,6 +127,8 @@ githubApiConcurrency: <uint, default 2>
 githubMinRequestInterval: <duration, default 200ms>
 githubLowRemainingThreshold: <int, default 100>
 githubScheduleJitter: <duration, default 30s; 0s disables daemon staggering>
+syncOverdueGrace: <duration, default 30m>
+syncStuckThreshold: <duration, default 24h>
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ gitrieve server
 
 From the UI you can trigger archive jobs, view real-time logs, and edit repository/storage configuration without touching `config.yaml` by hand. Repository cron schedules are refreshed immediately after repository edits, config imports, and config reloads. The server is configured via an optional `server` section in `config.yaml` (host, port, and optional bearer-token auth).
 
+The Repositories page provides server-side health counts, failed/never/overdue/
+stuck filters, attention-first sorting, component detail, and safe bulk retry.
+It distinguishes the latest attempt from the latest fully successful backup.
+An unsupported enabled component is recorded as skipped; a real component
+failure makes the overall execution fail. The page **never refreshes
+automatically** from polling, timers, or job-completion SSE events: use its
+Refresh button (or revisit the page) when you want a new snapshot.
+
 See the [Web UI guide](docs/web-ui.md) and the [API reference](docs/api.md) for details.
 
 ## Configuration
@@ -135,9 +143,20 @@ githubApiConcurrency: 2
 githubMinRequestInterval: 200ms
 githubLowRemainingThreshold: 100
 githubScheduleJitter: 30s
+syncOverdueGrace: 30m
+syncStuckThreshold: 24h
+cocurrencyNum: 6
 ```
 
 `githubScheduleJitter: 0s` disables staggering. Staggering applies only to daemon cron jobs; manual commands and Web API jobs start immediately. These settings reduce bursts but do not increase GitHub quota and do not coordinate separate processes or hosts.
+
+`syncOverdueGrace` and `syncStuckThreshold` default to `30m` and `24h`;
+non-positive values select those defaults. The existing, intentionally spelled
+`cocurrencyNum` setting limits actual running executor work across server cron,
+manual, and bulk requests. Extra work remains pending, and duplicate active
+work for one repository is rejected. On restart, the server marks executions
+and component rows left pending/running by the prior process as failed so they
+cannot remain active forever.
 
 For configuration, you can check out this [example](config/example.config.yaml).
 
@@ -194,4 +213,3 @@ docker compose up -d
 
 The released image is a multi-arch manifest covering `linux/amd64` and
 `linux/arm64`, so it works on both x86_64 and Apple Silicon machines.
-

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ From the UI you can trigger archive jobs, view real-time logs, and edit reposito
 The Repositories page provides server-side health counts, failed/never/overdue/
 stuck filters, attention-first sorting, component detail, and safe bulk retry.
 It distinguishes the latest attempt from the latest fully successful backup.
+Stuck includes executions that remain either pending or running beyond
+`syncStuckThreshold`.
 An unsupported enabled component is recorded as skipped; a real component
 failure makes the overall execution fail. The page **never refreshes
 automatically** from polling, timers, or job-completion SSE events: use its
@@ -151,6 +153,7 @@ cocurrencyNum: 6
 `githubScheduleJitter: 0s` disables staggering. Staggering applies only to daemon cron jobs; manual commands and Web API jobs start immediately. These settings reduce bursts but do not increase GitHub quota and do not coordinate separate processes or hosts.
 
 `syncOverdueGrace` and `syncStuckThreshold` default to `30m` and `24h`;
+the stuck threshold applies to both pending and running executions, and
 non-positive values select those defaults. The existing, intentionally spelled
 `cocurrencyNum` setting limits actual running executor work across server cron,
 manual, and bulk requests. Extra work remains pending, and duplicate active

--- a/README_zh.md
+++ b/README_zh.md
@@ -126,6 +126,12 @@ gitrieve server
 
 详见 [Web UI 指南](docs/web-ui.md) 和 [API 文档](docs/api.md)。
 
+Repositories 页面提供服务端全局健康计数、失败/从未同步/逾期/卡住筛选、
+优先关注排序、组件详情和安全的批量重试。页面会区分最近一次尝试和最近一次完整
+成功的备份：不支持的已启用组件记为 `skipped`，真实组件失败会使整个执行失败。
+该页面**绝不自动刷新**，不会轮询、设置定时器，也不会因任务完成 SSE 事件而重载；
+需要新快照时请点击 Refresh 或重新进入页面。
+
 ## 配置
 
 Issue、Discussion 和 Release 使用的 GitHub API 请求会在每个 gitrieve 进程内统一协调。可选配置及默认值如下：
@@ -135,7 +141,16 @@ githubApiConcurrency: 2
 githubMinRequestInterval: 200ms
 githubLowRemainingThreshold: 100
 githubScheduleJitter: 30s
+syncOverdueGrace: 30m
+syncStuckThreshold: 24h
+cocurrencyNum: 6
 ```
+
+`syncOverdueGrace` 和 `syncStuckThreshold` 的默认值分别为 `30m` 和 `24h`；
+非正值会恢复为默认值。沿用已有拼写的 `cocurrencyNum` 会统一限制 server 的
+Cron、手动执行和批量重试实际并发数；超出上限的任务保持 `pending`，同一仓库的
+重复活动任务会被拒绝。服务重启时，上一进程遗留的 `pending`/`running` 执行及
+组件记录会被对账为 `failed`，不会永久显示为活动状态。
 
 设置 `githubScheduleJitter: 0s` 可关闭错峰。错峰仅应用于 daemon 的 cron 任务，手工命令和 Web API 任务仍会立即开始。这些配置用于降低请求突发，不会增加 GitHub 配额，也不会协调不同进程或主机。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -128,7 +128,8 @@ gitrieve server
 
 Repositories 页面提供服务端全局健康计数、失败/从未同步/逾期/卡住筛选、
 优先关注排序、组件详情和安全的批量重试。页面会区分最近一次尝试和最近一次完整
-成功的备份：不支持的已启用组件记为 `skipped`，真实组件失败会使整个执行失败。
+成功的备份；最新执行以 `pending` 或 `running` 状态超过 `syncStuckThreshold`
+都会判定为卡住。不支持的已启用组件记为 `skipped`，真实组件失败会使整个执行失败。
 该页面**绝不自动刷新**，不会轮询、设置定时器，也不会因任务完成 SSE 事件而重载；
 需要新快照时请点击 Refresh 或重新进入页面。
 
@@ -147,7 +148,8 @@ cocurrencyNum: 6
 ```
 
 `syncOverdueGrace` 和 `syncStuckThreshold` 的默认值分别为 `30m` 和 `24h`；
-非正值会恢复为默认值。沿用已有拼写的 `cocurrencyNum` 会统一限制 server 的
+卡住阈值同时适用于 `pending` 和 `running`，非正值会恢复为默认值。沿用已有拼写的
+`cocurrencyNum` 会统一限制 server 的
 Cron、手动执行和批量重试实际并发数；超出上限的任务保持 `pending`，同一仓库的
 重复活动任务会被拒绝。服务重启时，上一进程遗留的 `pending`/`running` 执行及
 组件记录会被对账为 `failed`，不会永久显示为活动状态。

--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"github.com/wnarutou/gitrieve/internal/issue"
 	"github.com/wnarutou/gitrieve/internal/release"
 	"github.com/wnarutou/gitrieve/internal/repository"
+	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 	"github.com/wnarutou/gitrieve/internal/ui"
 	"github.com/wnarutou/gitrieve/internal/wiki"
@@ -44,6 +45,10 @@ func runStaggered(ctx context.Context, fn func() error) {
 		return
 	}
 	if err := fn(); err != nil {
+		if reason, ok := syncresult.SkippedReason(err); ok {
+			ui.Printf("Skipped: %s", reason)
+			return
+		}
 		ui.Errorf("Scheduled job failed: %s", err)
 	}
 }

--- a/cmd/daemon/daemon_test.go
+++ b/cmd/daemon/daemon_test.go
@@ -6,7 +6,24 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/syncresult"
+	"github.com/wnarutou/gitrieve/internal/ui"
 )
+
+type logRecord struct {
+	level   string
+	message string
+}
+
+type logSink struct {
+	logs []logRecord
+}
+
+func (s *logSink) Log(_, _, level, message string) error {
+	s.logs = append(s.logs, logRecord{level: level, message: message})
+	return nil
+}
 
 func TestStaggerZeroReturnsImmediately(t *testing.T) {
 	require.NoError(t, stagger(context.Background(), 0, func(int64) int64 { t.Fatal("random source called"); return 0 }))
@@ -25,4 +42,27 @@ func TestStaggerCancellationStopsWait(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	require.ErrorIs(t, stagger(ctx, time.Hour, func(int64) int64 { return int64(time.Hour) }), context.Canceled)
+}
+
+func TestRunStaggeredSkipCompletesWithoutFailureOrRetry(t *testing.T) {
+	previousConfig := config.GetIns()
+	config.SetIns(&config.Config{GitHubScheduleJitter: 0})
+	if previousConfig != nil {
+		t.Cleanup(func() { config.SetIns(previousConfig) })
+	}
+
+	sink := &logSink{}
+	ui.SetSink(sink)
+	t.Cleanup(func() { ui.SetSink(nil) })
+	unbind := ui.Bind("execution-1", "wiki")
+	defer unbind()
+
+	calls := 0
+	runStaggered(context.Background(), func() error {
+		calls++
+		return syncresult.Skip("not available")
+	})
+
+	require.Equal(t, 1, calls)
+	require.Equal(t, []logRecord{{level: "info", message: "Skipped: not available"}}, sink.logs)
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -60,6 +61,9 @@ func (s *Server) setupRoutes(cfg *config.Config) {
 	// 迁移旧库（新增 repo_key 列）。失败宁可起不来，也不在坏 schema 上跑。
 	if err := db.Migrate(database); err != nil {
 		ui.ErrorfExit("Failed to migrate database: %s", err)
+	}
+	if err := database.ReconcileInterrupted(context.Background(), time.Now()); err != nil {
+		ui.ErrorfExit("Failed to reconcile interrupted executions: %s", err)
 	}
 
 	// Initialize logger
@@ -192,14 +196,17 @@ func (s *Server) Close() error {
 	s.schedulerMu.Lock()
 	defer s.schedulerMu.Unlock()
 
-	var schedulerErr, databaseErr error
+	var schedulerErr, executorErr, databaseErr error
 	if s.scheduler != nil {
 		schedulerErr = s.scheduler.Shutdown()
+	}
+	if s.executor != nil {
+		executorErr = s.executor.Close()
 	}
 	if s.database != nil {
 		databaseErr = s.database.Close()
 	}
-	return errors.Join(schedulerErr, databaseErr)
+	return errors.Join(schedulerErr, executorErr, databaseErr)
 }
 
 var Cmd = &cobra.Command{

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -113,6 +113,7 @@ func (s *Server) setupRoutes(cfg *config.Config) {
 	apiGroup.DELETE("/api/jobs/:id", api.CancelJob)
 	apiGroup.GET("/api/jobs", api.GetJobs)
 	apiGroup.GET("/api/jobs/:id/logs", api.GetJobLogs)
+	apiGroup.GET("/api/jobs/:id/components", api.GetJobComponents)
 	apiGroup.GET("/api/repositories", api.GetRepositories)
 	apiGroup.POST("/api/repositories", api.CreateRepository)
 	// *id catch-all: the identity key is a URL like github.com/owner/repo and
@@ -135,6 +136,10 @@ func (s *Server) setupTestRoutes(db *db.DB) {
 	s.router.GET("/api/jobs", func(c *gin.Context) {
 		api := internalserver.NewAPI(&config.Config{}, db, nil)
 		api.GetJobs(c)
+	})
+	s.router.GET("/api/jobs/:id/components", func(c *gin.Context) {
+		api := internalserver.NewAPI(&config.Config{}, db, nil)
+		api.GetJobComponents(c)
 	})
 }
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -110,6 +110,7 @@ func (s *Server) setupRoutes(cfg *config.Config) {
 	}
 
 	apiGroup.POST("/api/jobs", api.CreateJob)
+	apiGroup.POST("/api/jobs/bulk", api.BulkCreateJobs)
 	apiGroup.DELETE("/api/jobs/:id", api.CancelJob)
 	apiGroup.GET("/api/jobs", api.GetJobs)
 	apiGroup.GET("/api/jobs/:id/logs", api.GetJobLogs)
@@ -133,6 +134,10 @@ func (s *Server) setupRoutes(cfg *config.Config) {
 }
 
 func (s *Server) setupTestRoutes(db *db.DB) {
+	s.router.POST("/api/jobs/bulk", func(c *gin.Context) {
+		api := internalserver.NewAPI(&config.Config{}, db, nil)
+		api.BulkCreateJobs(c)
+	})
 	s.router.GET("/api/jobs", func(c *gin.Context) {
 		api := internalserver.NewAPI(&config.Config{}, db, nil)
 		api.GetJobs(c)

--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/db"
+	internalserver "github.com/wnarutou/gitrieve/internal/server"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 )
 
@@ -24,6 +28,32 @@ func TestServerRootRoute(t *testing.T) {
 	if resp.Code != 200 {
 		t.Errorf("Expected status 200, got %d", resp.Code)
 	}
+}
+
+func TestServerReconcilesInterruptedExecutionsBeforeServing(t *testing.T) {
+	executionID := fmt.Sprintf("interrupted-startup-%d", time.Now().UnixNano())
+	database, err := db.Initialize(internalserver.GetServerConfig().DbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Migrate(database))
+	_, err = database.Exec(`
+		INSERT INTO executions (id, job_name, repo_key, start_time, status)
+		VALUES (?, ?, ?, ?, ?)`, executionID, "repo", "github.com/test/interrupted", time.Now(), "running")
+	require.NoError(t, err)
+	require.NoError(t, database.CreateComponents(context.Background(), executionID, []db.ComponentName{db.ComponentCode}))
+	require.NoError(t, database.StartComponent(context.Background(), executionID, db.ComponentCode, time.Now()))
+	require.NoError(t, database.Close())
+
+	server := NewServer(nil)
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+	var executionStatus, componentStatus string
+	require.NoError(t, server.database.QueryRow(
+		`SELECT status FROM executions WHERE id = ?`, executionID,
+	).Scan(&executionStatus))
+	require.NoError(t, server.database.QueryRow(
+		`SELECT status FROM execution_components WHERE execution_id = ?`, executionID,
+	).Scan(&componentStatus))
+	require.Equal(t, "failed", executionStatus)
+	require.Equal(t, "failed", componentStatus)
 }
 
 func TestServerStartsConfiguredCronJobs(t *testing.T) {

--- a/cmd/server/static_test.go
+++ b/cmd/server/static_test.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/web"
 )
 
 func TestStaticAssetServed(t *testing.T) {
@@ -22,4 +24,30 @@ func TestStaticAssetServed(t *testing.T) {
 			t.Errorf("GET %s: expected 200, got %d", path, resp.Code)
 		}
 	}
+}
+
+// TestRepositoryHealthAssets protects the operator-facing repository view from
+// regressing into page-sized bulk retry or completion-driven refresh behavior.
+func TestRepositoryHealthAssets(t *testing.T) {
+	js, err := fs.ReadFile(web.StaticFS, "js/main.js")
+	require.NoError(t, err)
+	css, err := fs.ReadFile(web.StaticFS, "css/main.css")
+	require.NoError(t, err)
+	template, err := fs.ReadFile(web.TemplatesFS, "templates/index.html")
+	require.NoError(t, err)
+
+	script := string(js)
+	require.Contains(t, script, "function repositoryParams()")
+	require.Contains(t, script, "function setRepositoryRoute(next)")
+	require.Contains(t, script, "function repositorySummaryCards(summary)")
+	require.Contains(t, script, "function retryFilteredRepositories(")
+	require.Contains(t, script, "function openExecutionDetails(executionID, name)")
+	require.Contains(t, script, "data.total")
+	require.NotContains(t, script, "expected_count: repos.length")
+	require.NotRegexp(t, `setInterval\([^)]*(renderRepositories|renderApp)`, script)
+	require.NotContains(t, script, "if (state.logJob === jobId) renderApp()")
+	require.Contains(t, script, "btn-refresh-repos")
+	require.Contains(t, string(template), "id=\"component-details\"")
+	require.Contains(t, string(css), ".summary-grid")
+	require.Contains(t, string(css), ".component-row")
 }

--- a/cmd/server/static_test.go
+++ b/cmd/server/static_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -62,8 +63,6 @@ func TestRepositoryHealthAssets(t *testing.T) {
 	require.Contains(t, script, "function isActiveRepositoryRoute(routeEpoch)")
 	require.Contains(t, script, "routeEpoch !== state.routeEpoch")
 	require.Contains(t, script, "if (state.es !== es) return")
-	require.Equal(t, 1, strings.Count(script, "setInterval("))
-	require.Contains(t, script, "setInterval(refreshMetrics, 15000)")
 	require.Contains(t, script, "btn-refresh-repos")
 	require.Contains(t, string(template), "id=\"component-details\"")
 	require.Contains(t, string(template), "id=\"execution-details\"")
@@ -72,15 +71,71 @@ func TestRepositoryHealthAssets(t *testing.T) {
 	require.Contains(t, string(css), ".summary-grid")
 	require.Contains(t, string(css), ".component-row")
 
-	bulkStart := strings.Index(script, "async function retryFilteredRepositories")
-	bulkEnd := strings.Index(script, "async function renderRepositories")
-	require.NotEqual(t, -1, bulkStart)
-	require.Greater(t, bulkEnd, bulkStart)
-	require.NotContains(t, script[bulkStart:bulkEnd], "job_ids")
+	bulk := jsFunctionSection(t, script, "async function retryFilteredRepositories", "async function renderRepositories")
+	require.NotContains(t, bulk, "job_ids")
+	require.Contains(t, bulk, "bulkRetryAttemptIsCurrent(attempt)")
+	require.Contains(t, bulk, "JSON.stringify({ selector: attempt.selector, expected_count: attempt.expectedCount })")
 
-	logStart := strings.Index(script, "function openLogModal")
-	logEnd := strings.Index(script, "function componentBadge")
-	require.NotEqual(t, -1, logStart)
-	require.Greater(t, logEnd, logStart)
-	require.NotContains(t, script[logStart:logEnd], "renderApp(")
+	render := jsFunctionSection(t, script, "async function renderRepositories", "function openStorageForm")
+	require.Contains(t, render, "isActiveRepositoryRoute(routeEpoch)")
+	require.Contains(t, render, "freezeBulkRetryAttempt(repositoryBulkSelector(), total, routeEpoch)")
+
+	detail := jsFunctionSection(t, script, "async function openExecutionDetails", "function appendLogLine")
+	require.Contains(t, detail, "isActiveRepositoryRoute(routeEpoch)")
+	require.Contains(t, detail, "detailSerial !== state.componentDetailSerial")
+
+	detailRetry := jsFunctionSection(t, script, "async function retryExecutionRepository", "async function openExecutionDetails")
+	require.Contains(t, detailRetry, "isActiveRepositoryRoute(routeEpoch)")
+	require.Contains(t, detailRetry, "if (jobIDs.length === 1)")
+	require.Contains(t, detailRetry, "closeLogModal()")
+
+	renderDetail := jsFunctionSection(t, script, "function renderExecutionDetails", "async function retryExecutionRepository")
+	require.Contains(t, renderDetail, "retry.disabled = false")
+
+	for _, name := range []string{"async function runRepo", "async function saveRepo", "async function deleteRepo"} {
+		require.Contains(t, jsFunctionSection(t, script, name, "\n}"), "isActiveRepositoryRoute(routeEpoch)")
+	}
+
+	log := jsFunctionSection(t, script, "function openLogModal", "function componentBadge")
+	require.NotContains(t, log, "renderApp(")
+	require.NotContains(t, log, "renderRepositories(")
+	require.Contains(t, log, "if (state.es !== es) return")
+	for _, timer := range jsTimerCalls(script) {
+		require.NotContains(t, timer, "renderRepositories")
+		require.NotContains(t, timer, "renderApp")
+	}
+}
+
+func jsFunctionSection(t *testing.T, script, start, end string) string {
+	t.Helper()
+	startAt := strings.Index(script, start)
+	require.NotEqual(t, -1, startAt, start)
+	endAt := strings.Index(script[startAt+len(start):], end)
+	require.NotEqual(t, -1, endAt, end)
+	return script[startAt : startAt+len(start)+endAt]
+}
+
+func jsTimerCalls(script string) []string {
+	var calls []string
+	timerStart := regexp.MustCompile(`\b(?:setInterval|setTimeout)\s*\(`)
+	for _, match := range timerStart.FindAllStringIndex(script, -1) {
+		start := match[0]
+		open := strings.Index(script[start:match[1]], "(") + start
+		depth, end := 0, open
+	foundEnd:
+		for ; end < len(script); end++ {
+			switch script[end] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					end++
+					calls = append(calls, script[start:end])
+					break foundEnd
+				}
+			}
+		}
+	}
+	return calls
 }

--- a/cmd/server/static_test.go
+++ b/cmd/server/static_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,15 +40,47 @@ func TestRepositoryHealthAssets(t *testing.T) {
 	script := string(js)
 	require.Contains(t, script, "function repositoryParams()")
 	require.Contains(t, script, "function setRepositoryRoute(next)")
+	require.Contains(t, script, "function routeFromHash()")
+	require.Contains(t, script, "function applyRepositoryRoute(hash)")
 	require.Contains(t, script, "function repositorySummaryCards(summary)")
 	require.Contains(t, script, "function retryFilteredRepositories(")
-	require.Contains(t, script, "function openExecutionDetails(executionID, name)")
+	require.Contains(t, script, "function openExecutionDetails(executionID, name, repository)")
+	require.Contains(t, script, "data.summary")
 	require.Contains(t, script, "data.total")
+	require.Contains(t, script, "repos-health")
+	require.Contains(t, script, "repos-overdue")
+	require.Contains(t, script, "repos-sort")
+	require.Contains(t, script, "repos-direction")
+	require.Contains(t, script, "btn-retry-filtered")
+	require.Contains(t, script, "btn-execution-details")
 	require.NotContains(t, script, "expected_count: repos.length")
-	require.NotRegexp(t, `setInterval\([^)]*(renderRepositories|renderApp)`, script)
-	require.NotContains(t, script, "if (state.logJob === jobId) renderApp()")
+	require.Contains(t, script, "JSON.stringify({ selector: attempt.selector, expected_count: attempt.expectedCount })")
+	require.Contains(t, script, "e.data.actual_count")
+	require.Contains(t, script, "function selectorsEqual(left, right)")
+	require.Contains(t, script, "routeEpoch")
+	require.Contains(t, script, "activeRoute")
+	require.Contains(t, script, "function isActiveRepositoryRoute(routeEpoch)")
+	require.Contains(t, script, "routeEpoch !== state.routeEpoch")
+	require.Contains(t, script, "if (state.es !== es) return")
+	require.Equal(t, 1, strings.Count(script, "setInterval("))
+	require.Contains(t, script, "setInterval(refreshMetrics, 15000)")
 	require.Contains(t, script, "btn-refresh-repos")
 	require.Contains(t, string(template), "id=\"component-details\"")
+	require.Contains(t, string(template), "id=\"execution-details\"")
+	require.Contains(t, string(template), "id=\"execution-status\"")
+	require.Contains(t, string(template), "id=\"btn-retry-execution\"")
 	require.Contains(t, string(css), ".summary-grid")
 	require.Contains(t, string(css), ".component-row")
+
+	bulkStart := strings.Index(script, "async function retryFilteredRepositories")
+	bulkEnd := strings.Index(script, "async function renderRepositories")
+	require.NotEqual(t, -1, bulkStart)
+	require.Greater(t, bulkEnd, bulkStart)
+	require.NotContains(t, script[bulkStart:bulkEnd], "job_ids")
+
+	logStart := strings.Index(script, "function openLogModal")
+	logEnd := strings.Index(script, "function componentBadge")
+	require.NotEqual(t, -1, logStart)
+	require.Greater(t, logEnd, logStart)
+	require.NotContains(t, script[logStart:logEnd], "renderApp(")
 }

--- a/cmd/wiki/wiki.go
+++ b/cmd/wiki/wiki.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/repository"
+	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 	"github.com/wnarutou/gitrieve/internal/ui"
 	"github.com/wnarutou/gitrieve/internal/wiki"
@@ -53,6 +54,10 @@ func runWiki(cmd *cobra.Command, args []string) {
 			if ctx.Err() != nil {
 				ui.Printf("Download cancelled")
 				break
+			}
+			if reason, ok := syncresult.SkippedReason(err); ok {
+				ui.Printf("Skipped: %s", reason)
+				continue
 			}
 			ui.Errorf("Error running %s, %s", repo.Name, err)
 			// move on to next repo

--- a/config/example.config.yaml
+++ b/config/example.config.yaml
@@ -67,6 +67,8 @@ githubApiConcurrency: 2
 githubMinRequestInterval: 200ms
 githubLowRemainingThreshold: 100
 githubScheduleJitter: 30s
+syncOverdueGrace: 30m
+syncStuckThreshold: 24h
 cocurrencyNum: 6
 releaseSizeLimit: 300000000
 releaseNumLimit: 3

--- a/docs/api.md
+++ b/docs/api.md
@@ -514,7 +514,7 @@ GET /api/repositories
 | `repositories[].latest_execution_id` | string | ID used by logs and component-detail endpoints |
 | `repositories[].last_error_message` | string | Concise latest execution error summary |
 | `repositories[].overdue` | bool | Whether the latest accepted attempt predates the latest cron occurrence outside the grace window |
-| `repositories[].stuck` | bool | Whether the latest execution has run beyond the stuck threshold |
+| `repositories[].stuck` | bool | Whether the latest execution has remained `pending` or `running` beyond the stuck threshold |
 | `repositories[].schedule_error` | string | Invalid cron diagnostic; such a row cannot be classified overdue |
 | `summary` | object | Fleet counts across all `search` matches, before health/overdue/stuck filters and pagination |
 | `total` | int | Total matching repositories (before pagination) |
@@ -891,8 +891,9 @@ syncStuckThreshold: 24h
 ```
 
 `syncOverdueGrace` delays missed-schedule classification until a cron
-occurrence is outside its grace window. `syncStuckThreshold` flags a running
-execution whose elapsed time is abnormally long. These are also the defaults;
+occurrence is outside its grace window. `syncStuckThreshold` flags a `pending`
+or `running` execution whose elapsed time is abnormally long. These are also
+the defaults;
 non-positive values select the defaults. Both settings participate in config
 load/save, export/import, apply, and reload.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,14 @@ Requests missing or mismatching the token are rejected. When `authEnabled` is `f
 
 ## Jobs
 
+All server-originated work (cron, single-job requests, and bulk retries) enters
+the same executor queue. `cocurrencyNum` (the existing spelling) limits actual
+running work; accepted work remains `pending` until a slot is available. A
+repository cannot have two pending/running executions. On server startup, any
+execution and component left pending/running by the previous process is marked
+`failed` with an interruption message, so a restart cannot leave permanent
+active rows.
+
 ### Create a job
 
 Trigger an archive job for a repository defined in configuration.
@@ -71,14 +79,14 @@ POST /api/jobs
 ```json
 {
   "job_ids": ["1719800000", "1719800001"],
-  "status": "running"
+  "status": "pending"
 }
 ```
 
 | Field | Type | Description |
 |---|---|---|
 | `job_ids` | array of string | One job identifier per expanded repository; pass each to the logs/cancel endpoints. A `repo`-type entry yields a single ID; a `user`/`org` entry yields one ID per concrete member repository |
-| `status` | string | Initial status, one of `pending` \| `running` \| `completed` \| `failed` \| `cancelled` |
+| `status` | string | Always `pending`: accepted jobs wait for an executor slot before becoming `running` |
 
 **Example**
 
@@ -92,10 +100,82 @@ curl -X POST http://localhost:8080/api/jobs \
 
 | Code | Meaning |
 |---|---|
-| 200 | Job started |
+| 200 | Job queued |
 | 400 | Invalid request body |
+| 409 | The repository already has a `pending` or `running` execution |
 | 404 | Repository not found in configuration |
 | 500 | Failed to start the job |
+
+---
+
+### Bulk retry repositories
+
+Retry the current server-side set of failed, cancelled, or overdue repositories.
+The request selects repositories rather than supplying a page-sized ID list.
+
+```
+POST /api/jobs/bulk
+```
+
+**Request body**
+
+```json
+{
+  "selector": {
+    "search": "github.com/acme",
+    "health": "failed",
+    "overdue": false
+  },
+  "expected_count": 37
+}
+```
+
+`selector.search`, `selector.health`, and `selector.overdue` use the same
+meaning as the repository-list filters. The server intersects that selection
+with repositories currently eligible to retry: latest status `failed` or
+`cancelled`, or `overdue=true`. Stuck executions are active and are never
+eligible; cancel them first. `expected_count` is the count the operator
+confirmed in the UI.
+
+The server recomputes the eligible count immediately before enqueueing. If it
+differs from `expected_count`, the response is `409 Conflict` with the new
+count, and the client must show a new confirmation:
+
+```json
+{
+  "code": 409,
+  "data": {"actual_count": 39},
+  "message": "Eligible repository count changed"
+}
+```
+
+On success, every repository in the confirmed snapshot is accounted for:
+
+```json
+{
+  "code": 200,
+  "data": {
+    "requested": 37,
+    "queued": 34,
+    "skipped_active": 1,
+    "no_longer_eligible": 1,
+    "failed_to_enqueue": 1
+  },
+  "message": ""
+}
+```
+
+The endpoint rechecks each repository and continues after an individual
+failure. Therefore `requested` always equals `queued + skipped_active +
+no_longer_eligible + failed_to_enqueue`. It intentionally does not return
+thousands of job IDs; use the Jobs page/API for individual executions.
+
+| Code | Meaning |
+|---|---|
+| 200 | Confirmed set processed; inspect the outcome counts for partial results |
+| 400 | Malformed selector or expected count |
+| 409 | Eligible count changed; confirm again using `actual_count` |
+| 500 | Executor unavailable or initial repository snapshot failed |
 
 ---
 
@@ -215,6 +295,60 @@ curl "http://localhost:8080/api/jobs?repository=github.com/wnarutou/gitrieve"
 
 ---
 
+### List job components
+
+Return the persisted component outcomes for one execution.
+
+```
+GET /api/jobs/:id/components
+```
+
+```json
+{
+  "code": 200,
+  "data": {
+    "components": [
+      {
+        "id": 1,
+        "execution_id": "1719800000",
+        "component": "code",
+        "status": "completed",
+        "start_time": "2026-08-05T10:00:00Z",
+        "end_time": "2026-08-05T10:02:00Z",
+        "error_message": ""
+      },
+      {
+        "id": 2,
+        "execution_id": "1719800000",
+        "component": "wiki",
+        "status": "skipped",
+        "start_time": "2026-08-05T10:02:00Z",
+        "end_time": "2026-08-05T10:02:01Z",
+        "error_message": "repository has no wiki"
+      }
+    ]
+  },
+  "message": ""
+}
+```
+
+`component` is `code`, `release`, `issues`, `wiki`, or `discussion`. Component
+status is `pending`, `running`, `completed`, `failed`, `skipped`, or
+`cancelled`. Disabled optional components have no row. A legitimate unsupported
+capability is `skipped` and does not fail the overall execution; any enabled
+component `failed` makes the overall execution `failed`, although later
+components are still attempted. Historical executions created before component
+tracking return an empty `components` array.
+
+| Code | Meaning |
+|---|---|
+| 200 | Components returned |
+| 400 | Job ID is empty |
+| 404 | Execution does not exist |
+| 500 | Component lookup failed |
+
+---
+
 ### Stream job logs (SSE)
 
 Stream the logs of a job in real time using Server-Sent Events.
@@ -286,7 +420,7 @@ Repositories are read from and written back to `config.yaml`. The `:id` path par
 
 ### List repositories
 
-List repositories from `config.yaml` (see [Configuration](../README.md#configuration)) with per-repository execution stats, pagination, and an optional fuzzy name-or-URL filter.
+List repositories from `config.yaml` (see [Configuration](../README.md#configuration)) with fleet health, server-side filtering/sorting, and pagination.
 
 ```
 GET /api/repositories
@@ -299,6 +433,11 @@ GET /api/repositories
 | `page` | int | `1` | Page number (1-based) |
 | `limit` | int | `20` | Items per page; clamped to `1`–`100` |
 | `search` | string | — | Fuzzy (partial) match on repository **name or URL**, case-insensitive for ASCII |
+| `health` | string | — | `healthy`, `failed`, `overdue`, `stuck`, `never_synced`, `cancelled`, `pending`, `running`, or `syncing` (`pending` plus `running`) |
+| `overdue` | bool | — | `true` or `false`; independent of the primary health category |
+| `stuck` | bool | — | `true` or `false`; independent of the primary health category |
+| `sort` | string | `attention` | `attention`, `name`, `last_attempt`, or `last_success` |
+| `direction` | string | `asc` | `asc` or `desc` |
 
 **Response `data`** — a paginated object (not a bare array). Each item embeds the repository fields (PascalCase, matching the `repository:` config entries) plus lower-cased execution stats.
 
@@ -323,10 +462,31 @@ GET /api/repositories
       "next_run_time": "2026-08-05T11:00:00Z",
       "total_runs": 42,
       "success_runs": 40,
-      "failed_runs": 2
+      "failed_runs": 2,
+      "last_status": "failed",
+      "health_status": "failed",
+      "last_attempt_time": "2026-08-05T10:02:30Z",
+      "last_success_time": "2026-08-04T10:02:30Z",
+      "last_duration_seconds": 151,
+      "latest_execution_id": "1719800000",
+      "last_error_message": "issues: API rate limit exceeded",
+      "overdue": false,
+      "stuck": false,
+      "schedule_error": ""
     }
   ],
-  "total": 42,
+  "summary": {
+    "total": 6000,
+    "healthy": 5800,
+    "failed": 75,
+    "pending": 10,
+    "running": 15,
+    "never_synced": 100,
+    "cancelled": 0,
+    "overdue": 120,
+    "stuck": 2
+  },
+  "total": 6000,
   "page": 1,
   "limit": 20
 }
@@ -346,11 +506,34 @@ GET /api/repositories
 | `repositories[].total_runs` | int | Total executions for the repository |
 | `repositories[].success_runs` | int | Executions that finished `completed` |
 | `repositories[].failed_runs` | int | Executions that finished `failed` |
+| `repositories[].last_status` | string | Raw latest execution status; empty when no execution exists |
+| `repositories[].health_status` | string | Mutually exclusive display health category |
+| `repositories[].last_attempt_time` | string \| null | Start time of the newest attempt, successful or not |
+| `repositories[].last_success_time` | string \| null | End time of the newest overall `completed` execution |
+| `repositories[].last_duration_seconds` | int \| null | Latest execution duration; active executions use elapsed time |
+| `repositories[].latest_execution_id` | string | ID used by logs and component-detail endpoints |
+| `repositories[].last_error_message` | string | Concise latest execution error summary |
+| `repositories[].overdue` | bool | Whether the latest accepted attempt predates the latest cron occurrence outside the grace window |
+| `repositories[].stuck` | bool | Whether the latest execution has run beyond the stuck threshold |
+| `repositories[].schedule_error` | string | Invalid cron diagnostic; such a row cannot be classified overdue |
+| `summary` | object | Fleet counts across all `search` matches, before health/overdue/stuck filters and pagination |
 | `total` | int | Total matching repositories (before pagination) |
 | `page` | int | Current page |
 | `limit` | int | Items per page |
 
 Other embedded repository fields (`UseCache`, `AllBranches`, `Depth`, `DownloadReleases`, `DownloadIssues`, `DownloadWiki`, `DownloadDiscussion`) are the boolean/int options from the config entry.
+
+`last_attempt_time` answers when any attempt most recently began;
+`last_success_time` answers when a fully successful backup most recently
+finished. A newer failure therefore never makes an older successful backup look
+fresh. Overall `completed` means every enabled component completed or was
+legitimately skipped.
+
+Health precedence is `never_synced`, `stuck`, active `pending`/`running`,
+`failed`/`cancelled`, `overdue`, then `healthy`. Summary overdue/stuck counts
+are independent diagnostics and can overlap the mutually exclusive status
+counts. Summary counts cover the whole search-matched fleet, not just the
+current page and not just rows selected by the health/overdue/stuck filters.
 
 **Examples**
 
@@ -366,6 +549,9 @@ curl "http://localhost:8080/api/repositories?search=github.com/wnarutou"
 
 # Page 2 with a custom limit
 curl "http://localhost:8080/api/repositories?page=2&limit=50"
+
+# Combine server-side health diagnostics and attention ordering
+curl "http://localhost:8080/api/repositories?health=failed&overdue=true&sort=attention"
 ```
 
 **Status codes**
@@ -696,6 +882,19 @@ curl http://localhost:8080/api/metrics
 ---
 
 ## Config
+
+Repository health uses two global duration settings:
+
+```yaml
+syncOverdueGrace: 30m
+syncStuckThreshold: 24h
+```
+
+`syncOverdueGrace` delays missed-schedule classification until a cron
+occurrence is outside its grace window. `syncStuckThreshold` flags a running
+execution whose elapsed time is abnormally long. These are also the defaults;
+non-positive values select the defaults. Both settings participate in config
+load/save, export/import, apply, and reload.
 
 ### Export config
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -431,7 +431,7 @@ GET /api/repositories
 | Param | Type | Default | Description |
 |---|---|---|---|
 | `page` | int | `1` | Page number (1-based) |
-| `limit` | int | `20` | Items per page; clamped to `1`–`100` |
+| `limit` | int | `20` | Items per page; values outside `1`–`100` are rejected |
 | `search` | string | — | Fuzzy (partial) match on repository **name or URL**, case-insensitive for ASCII |
 | `health` | string | — | `healthy`, `failed`, `overdue`, `stuck`, `never_synced`, `cancelled`, `pending`, `running`, or `syncing` (`pending` plus `running`) |
 | `overdue` | bool | — | `true` or `false`; independent of the primary health category |
@@ -534,6 +534,8 @@ Health precedence is `never_synced`, `stuck`, active `pending`/`running`,
 are independent diagnostics and can overlap the mutually exclusive status
 counts. Summary counts cover the whole search-matched fleet, not just the
 current page and not just rows selected by the health/overdue/stuck filters.
+`summary.healthy` is exactly the count selected by `health=healthy` for that
+same search; a completed but overdue repository is not counted as healthy.
 
 **Examples**
 
@@ -559,6 +561,7 @@ curl "http://localhost:8080/api/repositories?health=failed&overdue=true&sort=att
 | Code | Meaning |
 |---|---|
 | 200 | Repositories returned |
+| 400 | Invalid page, limit, health, overdue, stuck, sort, or direction |
 | 500 | Failed to query execution stats |
 
 ---

--- a/docs/superpowers/plans/2026-09-03-repository-sync-health.md
+++ b/docs/superpowers/plans/2026-09-03-repository-sync-health.md
@@ -1,0 +1,940 @@
+# Repository Sync Health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provide a trustworthy, manually refreshed health overview and safe retry workflow for approximately 6,000 server-scheduled repositories.
+
+**Architecture:** Keep `executions` as the historical source of truth, add component outcomes, and aggregate an indexed execution snapshot with configured repositories on each overview request. Move actual concurrency admission into `Executor`, then let cron, manual execution, and bulk retry use that same pending queue. Derive health in a focused server package and send only summary counts plus one page to the browser.
+
+**Tech Stack:** Go 1.23, SQLite through `modernc.org/sqlite`, Gin, `robfig/cron/v3`, Viper, Testify, embedded HTML/CSS/vanilla JavaScript.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-repository-sync-health-design.md`
+
+## Global Constraints
+
+- The feature applies to `gitrieve server`; standalone `gitrieve daemon` does not persist executions.
+- Primary usage is approximately 6,000 independently configured `type: repo` entries; preserve existing user/org behavior where touched.
+- Overall `completed` means every enabled component is `completed` or `skipped`; any enabled component failure makes the execution `failed`.
+- Continue later enabled components after an ordinary failure; stop promptly on context cancellation.
+- `syncOverdueGrace` defaults to `30m`; `syncStuckThreshold` defaults to `24h`; non-positive values select those defaults.
+- `cocurrencyNum` remains the existing, intentionally misspelled configuration key and limits actual running executor work.
+- The Repositories page must not poll, schedule a reload, or reload itself on an SSE completion event. Its existing explicit Refresh button remains.
+- Do not add outbound alerts, historical charts, organization-member expansion, or a materialized repository-state table.
+- Preserve the deletion-safe archive invariants documented in `CLAUDE.md`; do not alter repository fetch/archive behavior.
+- Existing SQLite databases migrate additively, and historical executions remain readable without component rows.
+- Keep `last_run_time`, `total_runs`, `success_runs`, and `failed_runs` in the repository API for compatibility while adding the new fields.
+- Do not modify or delete the existing untracked `.codex-ui-test/` directory.
+
+## Planned File Map
+
+- `internal/config/config.go`, `internal/config/importexport.go`, `internal/server/config_api.go`: own the two health thresholds through load/save/import/reload.
+- `internal/db/models.go`, `internal/db/db.go`, `internal/db/migrate.go`, new `internal/db/execution_store.go`: own component persistence, execution snapshots, active checks, and interrupted-run reconciliation.
+- New `internal/syncresult/syncresult.go`: defines a skip outcome that is distinguishable from failure.
+- `internal/wiki/wiki.go`, `cmd/wiki/wiki.go`, `cmd/daemon/daemon.go`: return and display the skip outcome without treating missing Wiki support as an error.
+- New `internal/executor/components.go`, plus `internal/executor/executor.go`: own component plans, final aggregation, pending admission, duplicate suppression, cancellation, and shutdown.
+- New `internal/server/repository_health.go`, plus `internal/server/types.go` and `internal/server/api.go`: derive health, filter/sort/paginate snapshots, serve component details, and enqueue bulk retries.
+- `cmd/server/server.go`: wires reconciliation, routes, and orderly executor shutdown.
+- `web/templates/index.html`, `web/static/js/main.js`, `web/static/css/main.css`: render the health dashboard, component detail, and retry controls with explicit refresh only.
+- `docs/api.md`, `docs/web-ui.md`, `README.md`, `README_zh.md`, `CLAUDE.md`, `config/example.config.yaml`: document the behavior and operational settings.
+
+---
+
+### Task 1: Health-threshold configuration lifecycle
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/config_test.go`
+- Modify: `internal/config/importexport.go`
+- Modify: `internal/config/importexport_test.go`
+- Modify: `internal/server/config_api.go`
+- Modify: `internal/server/config_api_test.go`
+- Modify: `config/example.config.yaml`
+
+**Interfaces:**
+- Produces: `config.Config.SyncOverdueGrace time.Duration`
+- Produces: `config.Config.SyncStuckThreshold time.Duration`
+- Produces: `config.GetSyncOverdueGrace() time.Duration`
+- Produces: `config.GetSyncStuckThreshold() time.Duration`
+- Produces constants `config.DefaultSyncOverdueGrace` and `config.DefaultSyncStuckThreshold`.
+
+- [ ] **Step 1: Write failing default and getter tests**
+
+Add to `internal/config/config_test.go`:
+
+```go
+func TestSyncHealthDefaults(t *testing.T) {
+    cfg := &Config{}
+    seedDefaults(cfg)
+    require.Equal(t, 30*time.Minute, cfg.SyncOverdueGrace)
+    require.Equal(t, 24*time.Hour, cfg.SyncStuckThreshold)
+}
+
+func TestSyncHealthNonPositiveValuesUseDefaults(t *testing.T) {
+    cfg := &Config{SyncOverdueGrace: -time.Second, SyncStuckThreshold: -time.Second}
+    seedDefaults(cfg)
+    require.Equal(t, DefaultSyncOverdueGrace, cfg.SyncOverdueGrace)
+    require.Equal(t, DefaultSyncStuckThreshold, cfg.SyncStuckThreshold)
+}
+```
+
+- [ ] **Step 2: Write failing export/import and config-API tests**
+
+Extend `internal/config/importexport_test.go` to assert exported YAML contains `syncOverdueGrace: 45m0s` and `syncStuckThreshold: 12h0m0s`, and that `ParseImport` restores both typed durations. Extend `internal/server/config_api_test.go` with preview/apply assertions whose imported values differ from current values and increase `globals_updated` by two.
+
+- [ ] **Step 3: Run tests to verify RED**
+
+Run: `go test ./internal/config ./internal/server`
+
+Expected: compilation fails because the two fields, constants, and getters do not exist.
+
+- [ ] **Step 4: Implement fields, defaults, persistence, and import/apply**
+
+Add to `internal/config/config.go`:
+
+```go
+const (
+    DefaultSyncOverdueGrace  = 30 * time.Minute
+    DefaultSyncStuckThreshold = 24 * time.Hour
+)
+
+type Config struct {
+    // existing fields remain unchanged
+    SyncOverdueGrace  time.Duration `yaml:"syncOverdueGrace" mapstructure:"syncOverdueGrace"`
+    SyncStuckThreshold time.Duration `yaml:"syncStuckThreshold" mapstructure:"syncStuckThreshold"`
+}
+
+func GetSyncOverdueGrace() time.Duration { return ins.SyncOverdueGrace }
+func GetSyncStuckThreshold() time.Duration { return ins.SyncStuckThreshold }
+```
+
+Seed both defaults in `seedDefaults`, write both in `Save`, add `DurationString` fields to `ExportConfig`, copy them in `ExportFrom`, seed them in `seedExportDefaults`, and add exact `diffGlobals`/`applyImport` branches in `internal/server/config_api.go`.
+Change `DurationString.UnmarshalYAML` diagnostics from the field-specific `retryBaseDelay` wording to generic `duration` wording so invalid values for either new setting produce an accurate error.
+
+- [ ] **Step 5: Add example values and verify GREEN**
+
+Add to `config/example.config.yaml`:
+
+```yaml
+syncOverdueGrace: 30m
+syncStuckThreshold: 24h
+```
+
+Run: `gofmt -w internal/config/config.go internal/config/config_test.go internal/config/importexport.go internal/config/importexport_test.go internal/server/config_api.go internal/server/config_api_test.go`
+
+Run: `go test ./internal/config ./internal/server`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/config internal/server/config_api.go internal/server/config_api_test.go config/example.config.yaml
+git commit -m "feat(config): add repository health thresholds"
+```
+
+### Task 2: Component persistence and interrupted-run reconciliation
+
+**Files:**
+- Modify: `internal/db/models.go`
+- Modify: `internal/db/db.go`
+- Modify: `internal/db/migrate.go`
+- Modify: `internal/db/migrations_test.go`
+- Create: `internal/db/execution_store.go`
+- Create: `internal/db/execution_store_test.go`
+
+**Interfaces:**
+- Produces: `db.ComponentName`, `db.ComponentStatus`, and `db.ComponentExecution`.
+- Produces: `(*db.DB).CreateComponents(context.Context, string, []db.ComponentName) error`.
+- Produces: `(*db.DB).StartComponent(context.Context, string, db.ComponentName, time.Time) error`.
+- Produces: `(*db.DB).FinishComponent(context.Context, string, db.ComponentName, db.ComponentStatus, time.Time, string) error`.
+- Produces: `(*db.DB).ListComponents(context.Context, string) ([]db.ComponentExecution, error)`.
+- Produces: `(*db.DB).ExecutionExists(context.Context, string) (bool, error)`.
+- Produces: `(*db.DB).ActiveExecutionExists(context.Context, string) (bool, error)`.
+- Produces: `(*db.DB).ReconcileInterrupted(context.Context, time.Time) error`.
+
+- [ ] **Step 1: Write failing fresh-schema and migration tests**
+
+Extend `internal/db/migrations_test.go` to initialize both a fresh database and a rebuilt legacy `executions` database, run `Migrate` twice, then assert these names exist through `sqlite_master`:
+
+```go
+for _, name := range []string{
+    "execution_components",
+    "idx_executions_repo_start",
+    "idx_executions_repo_status_end",
+    "idx_executions_status",
+    "idx_execution_components_execution",
+} {
+    var got string
+    require.NoError(t, testDB.QueryRow(
+        `SELECT name FROM sqlite_master WHERE name = ?`, name,
+    ).Scan(&got))
+    require.Equal(t, name, got)
+}
+```
+
+- [ ] **Step 2: Write failing store and reconciliation tests**
+
+In `internal/db/execution_store_test.go`, create one execution with code/wiki rows, transition them through running to completed/skipped, and assert ordered results. Add pending and running executions, call `ReconcileInterrupted(fixedNow)`, and assert both executions and active component rows become failed with `end_time=fixedNow` and an interruption message. Assert `ExecutionExists` distinguishes a known ID from an unknown one, and `ActiveExecutionExists` is true only for pending/running rows with the exact normalized `repo_key`.
+
+- [ ] **Step 3: Run tests to verify RED**
+
+Run: `go test ./internal/db`
+
+Expected: compilation fails because component types and DB methods do not exist.
+
+- [ ] **Step 4: Add the additive schema and indexes**
+
+Add `CREATE TABLE IF NOT EXISTS execution_components` and all four `CREATE INDEX IF NOT EXISTS` statements from the design spec to both fresh initialization and `Migrate`. Define:
+
+```go
+type ComponentName string
+type ComponentStatus string
+
+const (
+    ComponentCode ComponentName = "code"
+    ComponentRelease ComponentName = "release"
+    ComponentIssue ComponentName = "issues"
+    ComponentWiki ComponentName = "wiki"
+    ComponentDiscussion ComponentName = "discussion"
+
+    ComponentPending ComponentStatus = "pending"
+    ComponentRunning ComponentStatus = "running"
+    ComponentCompleted ComponentStatus = "completed"
+    ComponentFailed ComponentStatus = "failed"
+    ComponentSkipped ComponentStatus = "skipped"
+    ComponentCancelled ComponentStatus = "cancelled"
+)
+```
+
+- [ ] **Step 5: Implement transactional store helpers and reconciliation**
+
+Use `ExecContext` and one transaction for multi-row creation/reconciliation. `CreateComponents` inserts `pending` rows and relies on `UNIQUE(execution_id, component)`. `ListComponents` orders code, release, issues, wiki, discussion through a SQL `CASE`. `ExecutionExists` and `ActiveExecutionExists` use `SELECT EXISTS(...)`. Reconciliation first finalizes active component rows, then executions:
+
+```sql
+UPDATE execution_components
+SET status = 'failed', end_time = ?, error_message = ?
+WHERE status IN ('pending', 'running');
+
+UPDATE executions
+SET status = 'failed', end_time = ?, error_message = ?
+WHERE status IN ('pending', 'running');
+```
+
+- [ ] **Step 6: Verify GREEN**
+
+Run: `gofmt -w internal/db/models.go internal/db/db.go internal/db/migrate.go internal/db/migrations_test.go internal/db/execution_store.go internal/db/execution_store_test.go`
+
+Run: `go test ./internal/db`
+
+Expected: PASS, including idempotent migration.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add internal/db
+git commit -m "feat(db): persist component execution outcomes"
+```
+
+### Task 3: Explicit skipped-component contract
+
+**Files:**
+- Create: `internal/syncresult/syncresult.go`
+- Create: `internal/syncresult/syncresult_test.go`
+- Modify: `internal/wiki/wiki.go`
+- Modify: `internal/wiki/wiki_test.go`
+- Modify: `cmd/wiki/wiki.go`
+- Modify: `cmd/daemon/daemon.go`
+- Modify: `cmd/daemon/daemon_test.go`
+
+**Interfaces:**
+- Produces: `syncresult.Skip(reason string) error`.
+- Produces: `syncresult.SkippedReason(error) (string, bool)`.
+
+- [ ] **Step 1: Write failing wrapped-skip tests**
+
+Create `internal/syncresult/syncresult_test.go`:
+
+```go
+func TestSkippedReasonSurvivesWrapping(t *testing.T) {
+    err := fmt.Errorf("wiki preflight: %w", Skip("repository has no wiki"))
+    reason, ok := SkippedReason(err)
+    require.True(t, ok)
+    require.Equal(t, "repository has no wiki", reason)
+    _, ok = SkippedReason(errors.New("network down"))
+    require.False(t, ok)
+}
+```
+
+- [ ] **Step 2: Add a failing Wiki availability test**
+
+Extract a package-private `wikiAvailability(repoURL string, hasWiki bool) error`, then test that `false` returns a recognizable skip and `true` returns nil. This test avoids a network call while fixing the current fall-through that attempts Wiki sync even after GitHub reports no Wiki.
+
+- [ ] **Step 3: Run tests to verify RED**
+
+Run: `go test ./internal/syncresult ./internal/wiki ./cmd/wiki ./cmd/daemon`
+
+Expected: FAIL because `syncresult` and `wikiAvailability` do not exist.
+
+- [ ] **Step 4: Implement the skip type and Wiki early return**
+
+Implement an error type discoverable through `errors.As`:
+
+```go
+type SkippedError struct{ Reason string }
+
+func (e SkippedError) Error() string { return e.Reason }
+func Skip(reason string) error { return SkippedError{Reason: reason} }
+
+func SkippedReason(err error) (string, bool) {
+    var skipped SkippedError
+    if !errors.As(err, &skipped) { return "", false }
+    return skipped.Reason, true
+}
+```
+
+In `wiki.Sync`, check availability before `repository.Sync` without returning on the supported path:
+
+```go
+if err := wikiAvailability(repo.URL, gitrepo.GetHasWiki()); err != nil {
+    reason, _ := syncresult.SkippedReason(err)
+    ui.Printf("Skipped: %s", reason)
+    return err
+}
+```
+
+- [ ] **Step 5: Make CLI/daemon display skip without failure**
+
+In `cmd/wiki` and `cmd/daemon.runStaggered`, branch on `syncresult.SkippedReason(err)`: print `Skipped: <reason>` and return without an error-level message. Add a daemon test with a fake function returning `syncresult.Skip("not available")` and assert it completes without invoking retry behavior.
+
+- [ ] **Step 6: Verify GREEN and commit**
+
+Run: `gofmt -w internal/syncresult/syncresult.go internal/syncresult/syncresult_test.go internal/wiki/wiki.go internal/wiki/wiki_test.go cmd/wiki/wiki.go cmd/daemon/daemon.go cmd/daemon/daemon_test.go`
+
+Run: `go test ./internal/syncresult ./internal/wiki ./cmd/wiki ./cmd/daemon`
+
+Expected: PASS.
+
+```powershell
+git add internal/syncresult internal/wiki cmd/wiki cmd/daemon
+git commit -m "feat(sync): distinguish skipped components"
+```
+
+### Task 4: Component runner injection and truthful overall results
+
+**Files:**
+- Create: `internal/executor/components.go`
+- Modify: `internal/executor/executor.go`
+- Modify: `internal/executor/executor_test.go`
+
+**Interfaces:**
+- Produces: `executor.SyncFunc`.
+- Produces: `executor.Runners` with `Code`, `Release`, `Issue`, `Wiki`, and `Discussion` fields.
+- Produces: `executor.NewExecutorWithRunners(*logger.Logger, *db.DB, *config.Config, executor.Runners) *executor.Executor`.
+- Consumes all component DB methods from Task 2 and skip classification from Task 3.
+
+- [ ] **Step 1: Replace network-dependent executor tests with injected runners**
+
+Define test runners that append component names under a mutex and return controlled errors. Add tests for these sequences:
+
+```text
+code=completed, issue=failed, wiki=completed -> overall failed, all three ran
+code=failed, issue=completed              -> overall failed, issue still ran
+code=completed, wiki=skipped              -> overall completed
+context cancelled during issue            -> issue/remaining components cancelled, overall cancelled
+```
+
+Assert both `executions.status/error_message` and every `execution_components` row. Add a store-failure test with a SQLite trigger that raises `FAIL` before a component terminal update; assert the still-readable overall execution becomes failed rather than completed. Remove the existing 20-second real-network wait from `TestExecuteJobRunsConfiguredComponents`.
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run: `go test ./internal/executor -run 'TestExecuteJob(Component|Overall|Skip|Cancel)' -count=1`
+
+Expected: compilation fails because runners and component persistence integration are missing.
+
+- [ ] **Step 3: Implement component plans and default runners**
+
+Create:
+
+```go
+type SyncFunc func(context.Context, typedef.Repository, []typedef.MultiStorage) error
+
+type Runners struct {
+    Code SyncFunc
+    Release SyncFunc
+    Issue SyncFunc
+    Wiki SyncFunc
+    Discussion SyncFunc
+}
+
+type component struct {
+    name db.ComponentName
+    run  SyncFunc
+}
+```
+
+`componentPlan(repo, runners)` always includes code and conditionally appends enabled optional components in release, issue, wiki, discussion order. `NewExecutor` delegates to `NewExecutorWithRunners` with production functions.
+
+- [ ] **Step 4: Implement component state transitions and aggregation**
+
+Create all planned component rows before asynchronous execution starts. For each component, mark running, invoke it, then classify cancellation, skip, failure, or completion. Accumulate failures with their component name and update the overall execution only after component rows are terminal. Use semicolon-separated summaries such as `issue: rate limit; wiki: permission denied` in `executions.error_message`.
+
+- [ ] **Step 5: Verify cancellation and best-effort GREEN**
+
+Run: `gofmt -w internal/executor/components.go internal/executor/executor.go internal/executor/executor_test.go`
+
+Run: `go test -race ./internal/executor ./internal/db ./internal/syncresult`
+
+Expected: PASS with no real network calls and no data races.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add internal/executor
+git commit -m "feat(executor): aggregate component outcomes"
+```
+
+### Task 5: Executor-owned pending queue and concurrency limit
+
+**Files:**
+- Modify: `internal/executor/executor.go`
+- Modify: `internal/executor/executor_test.go`
+- Modify: `internal/server/api.go`
+- Modify: `internal/server/api_test.go`
+- Modify: `cmd/server/server.go`
+- Modify: `cmd/server/server_test.go`
+
+**Interfaces:**
+- Produces: `executor.ErrRepositoryActive`.
+- Produces: `(*executor.Executor).Close() error`.
+- Preserves: `ExecuteJob(string) ([]string, error)`, `CancelJob(string) error`, and `RefreshConfig(*config.Config)`.
+- Changes newly accepted job responses to deterministic status `pending`.
+
+- [ ] **Step 1: Write failing concurrency, pending, duplicate, and cancellation tests**
+
+Use a blocking fake code runner and atomics. With `ConcurrencyNum: 2`, enqueue six repositories, wait until two enter, and assert `maxRunning == 2` while the other four remain pending. Assert a second `ExecuteJob` for an active repo returns `ErrRepositoryActive` without inserting another row. Cancel one queued job and assert it becomes cancelled without entering the runner.
+
+- [ ] **Step 2: Write failing resize and shutdown tests**
+
+Start with limit one, queue three jobs, call `RefreshConfig` with limit two, and assert a second job enters. Call `Close`, assert queued and running contexts are cancelled, wait for all terminal DB updates, and call `Close` again to prove idempotence.
+
+- [ ] **Step 3: Run tests to verify RED**
+
+Run: `go test ./internal/executor ./internal/server ./cmd/server`
+
+Expected: tests fail because all jobs currently change to running immediately and actual work is not executor-limited.
+
+- [ ] **Step 4: Implement a dispatcher-backed queue**
+
+Add queue state protected by one mutex/condition:
+
+```go
+type queuedJob struct {
+    id string
+    repo typedef.Repository
+    ctx context.Context
+}
+
+type Executor struct {
+    // existing db/config fields remain
+    queueMu sync.Mutex
+    queueCond *sync.Cond
+    pending []*queuedJob
+    jobs map[string]*JobContext
+    activeByRepo map[string]string
+    running int
+    limit int
+    closed bool
+    dispatcherDone chan struct{}
+    workers sync.WaitGroup
+}
+```
+
+The dispatcher starts lazily on the first enqueue, waits until `len(pending)>0 && running<limit`, then starts exactly one admitted goroutine and increments `running`. Lazy startup prevents read-only API tests from leaking an idle dispatcher. Completion removes both ID and repo-key entries, decrements `running`, and broadcasts. `RefreshConfig` atomically publishes config, applies default limit three for nil config or a zero setting, updates `limit`, and broadcasts.
+
+- [ ] **Step 5: Implement pending cancellation, duplicate suppression, and orderly close**
+
+While holding the queue mutex, reject a key found in `activeByRepo` or reported active by `ActiveExecutionExists`, then reserve `activeByRepo[repo.Key()]` before inserting the execution. Roll the reservation back on insert/component-row/enqueue failure. `CancelJob` removes a queued item and finalizes it cancelled immediately; for a running item it only cancels the context and lets the worker write one terminal result. `Close` rejects new work, cancels/detaches pending jobs, cancels running jobs, wakes the dispatcher, and waits for dispatcher/workers before returning. Register `Executor.Close` with `t.Cleanup` in `newTestExecutor` and every server/cmd test that enqueues work.
+
+- [ ] **Step 6: Wire startup reconciliation and server shutdown order**
+
+In `cmd/server.setupRoutes`, call `database.ReconcileInterrupted(context.Background(), time.Now())` after `Migrate` and before creating `Executor`. In `Server.Close`, stop the scheduler, close the executor, then close the database. Change `CreateJobResponse.Status` from hard-coded running to pending and map `ErrRepositoryActive` to HTTP `409`.
+
+- [ ] **Step 7: Verify GREEN and race safety**
+
+Run: `gofmt -w internal/executor/executor.go internal/executor/executor_test.go internal/server/api.go internal/server/api_test.go cmd/server/server.go cmd/server/server_test.go`
+
+Run: `go test -race ./internal/executor ./internal/server ./cmd/server`
+
+Expected: PASS; maximum observed runner concurrency never exceeds `cocurrencyNum`.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add internal/executor internal/server/api.go internal/server/api_test.go cmd/server
+git commit -m "feat(executor): queue server jobs with real concurrency limits"
+```
+
+### Task 6: Indexed repository execution snapshot and health derivation
+
+**Files:**
+- Modify: `internal/db/models.go`
+- Modify: `internal/db/execution_store.go`
+- Modify: `internal/db/execution_store_test.go`
+- Create: `internal/server/repository_health.go`
+- Create: `internal/server/repository_health_test.go`
+- Modify: `internal/server/types.go`
+- Modify: `internal/server/helpers.go`
+- Modify: `internal/server/helpers_test.go`
+
+**Interfaces:**
+- Produces: `db.RepositoryRunStats` and `(*db.DB).RepositoryRunStats(context.Context) (map[string]db.RepositoryRunStats, error)`.
+- Produces: `server.RepositoryHealthFilter`, extended `server.RepositoryOverview`, and `server.RepositoryHealthSummary`.
+- Produces package-private `buildRepositorySnapshot`, `searchRepositorySnapshot`, `filterRepositorySnapshot`, `sortRepositorySnapshot`, and `summarizeRepositorySnapshot` helpers.
+
+- [ ] **Step 1: Write failing execution-snapshot tests**
+
+Insert success then failure rows for one repo, a running row for another, and tied start times for a third. Assert `RepositoryRunStats` returns latest execution ID/status/start/end/error, latest successful end time, and cumulative counts. For ties, assert descending execution ID is the deterministic winner.
+
+Use this exact shape in `internal/db/models.go`:
+
+```go
+type RepositoryRunStats struct {
+    LatestExecutionID string
+    LatestStatus string
+    LatestStart time.Time
+    LatestEnd *time.Time
+    LatestError string
+    LastSuccess *time.Time
+    TotalRuns int64
+    SuccessRuns int64
+    FailedRuns int64
+}
+```
+
+- [ ] **Step 2: Write failing health and cron-boundary table tests**
+
+Use a fixed `now` and table cases for never synced, stuck, pending, running, failed, cancelled, overdue, and healthy. The overdue assertion must use `schedule.Next(lastAttempt) <= now-grace`; never-run and active repos are not overdue. Add timezone/DST cases using `time.LoadLocation("America/New_York")` and invalid-cron cases that populate `schedule_error` without setting overdue.
+
+- [ ] **Step 3: Run tests to verify RED**
+
+Run: `go test ./internal/db ./internal/server -run 'Repository(RunStats|Health)|Overdue' -count=1`
+
+Expected: compilation fails because the snapshot and health helpers do not exist.
+
+- [ ] **Step 4: Implement one indexed execution aggregation query**
+
+Use a window-ranked latest row plus grouped totals and last success:
+
+```sql
+WITH ranked AS (
+  SELECT id, repo_key, start_time, end_time, status, error_message,
+         ROW_NUMBER() OVER (
+           PARTITION BY repo_key ORDER BY start_time DESC, id DESC
+         ) AS rn
+  FROM executions WHERE repo_key <> ''
+), totals AS (
+  SELECT repo_key,
+         COUNT(*) AS total_runs,
+         COALESCE(SUM(status = 'completed'), 0) AS success_runs,
+         COALESCE(SUM(status = 'failed'), 0) AS failed_runs
+  FROM executions WHERE repo_key <> '' GROUP BY repo_key
+), successes AS (
+  SELECT repo_key, MAX(end_time) AS last_success
+  FROM executions
+  WHERE repo_key <> '' AND status = 'completed'
+  GROUP BY repo_key
+)
+SELECT ranked.id, ranked.repo_key, ranked.start_time, ranked.end_time,
+       ranked.status, ranked.error_message, successes.last_success,
+       totals.total_runs, totals.success_runs, totals.failed_runs
+FROM ranked
+JOIN totals USING (repo_key)
+LEFT JOIN successes USING (repo_key)
+WHERE ranked.rn = 1;
+```
+
+Scan nullable dates/messages explicitly and return one immutable map used for the whole API response.
+
+- [ ] **Step 5: Implement health projection, filters, summaries, and stable sorting**
+
+Define the reusable filter and DTOs before the API handler consumes them:
+
+```go
+type RepositoryHealthFilter struct {
+    Search string
+    Health string
+    Overdue *bool
+    Stuck *bool
+    Sort string
+    Direction string
+}
+
+func buildRepositorySnapshot(
+    repos []typedef.Repository,
+    stats map[string]db.RepositoryRunStats,
+    now time.Time,
+    overdueGrace time.Duration,
+    stuckThreshold time.Duration,
+) []RepositoryOverview
+
+func searchRepositorySnapshot(in []RepositoryOverview, search string) []RepositoryOverview
+func summarizeRepositorySnapshot(in []RepositoryOverview) RepositoryHealthSummary
+func filterRepositorySnapshot(in []RepositoryOverview, filter RepositoryHealthFilter) []RepositoryOverview
+func sortRepositorySnapshot(in []RepositoryOverview, sortKey, direction string)
+```
+
+Build an overview for every config entry, preserving `EffectiveURL` and current org-prefix rollup behavior. Set `last_run_time` equal to `last_attempt_time` for compatibility. When either threshold on an in-memory config is non-positive, use the exported Task 1 default; this keeps directly constructed test/server configs safe. Derive health in the exact attention order `stuck`, `failed`, `overdue`, `never_synced`, `cancelled`, `pending`, `running`, `healthy`, calculate latest duration, and break sort ties with lowercase name and normalized key. Summary status buckets are mutually exclusive; overdue/stuck totals are independent and may overlap.
+
+- [ ] **Step 6: Verify GREEN**
+
+Run: `gofmt -w internal/db/models.go internal/db/execution_store.go internal/db/execution_store_test.go internal/server/types.go internal/server/repository_health.go internal/server/repository_health_test.go internal/server/helpers.go internal/server/helpers_test.go`
+
+Run: `go test ./internal/db ./internal/server`
+
+Expected: PASS with deterministic fixed-clock assertions.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add internal/db internal/server/types.go internal/server/repository_health.go internal/server/repository_health_test.go internal/server/helpers.go internal/server/helpers_test.go
+git commit -m "feat(server): derive repository sync health"
+```
+
+### Task 7: Repository health and component-detail APIs
+
+**Files:**
+- Modify: `internal/server/types.go`
+- Modify: `internal/server/api.go`
+- Modify: `internal/server/repository_test.go`
+- Modify: `internal/server/export_test.go`
+- Modify: `cmd/server/server.go`
+
+**Interfaces:**
+- Extends `GET /api/repositories` with `health`, `overdue`, `stuck`, `sort`, and `direction`.
+- Produces: `GET /api/jobs/:id/components`.
+- Consumes the repository overview/filter/summary DTOs from Task 6 and produces `ListRepositoriesResponse` plus `ListComponentsResponse` JSON responses.
+
+- [ ] **Step 1: Write failing response-shape and filter tests**
+
+Extend `internal/server/repository_test.go` with fixed execution rows and assert:
+
+```go
+type repoView struct {
+    LastStatus string `json:"last_status"`
+    HealthStatus string `json:"health_status"`
+    LastAttemptTime *time.Time `json:"last_attempt_time"`
+    LastSuccessTime *time.Time `json:"last_success_time"`
+    LastDurationSeconds *int64 `json:"last_duration_seconds"`
+    LatestExecutionID string `json:"latest_execution_id"`
+    LastErrorMessage string `json:"last_error_message"`
+    Overdue bool `json:"overdue"`
+    Stuck bool `json:"stuck"`
+    ScheduleError string `json:"schedule_error"`
+}
+```
+
+Exercise `health=failed`, `health=syncing`, `overdue=true`, each sort/direction, search plus health, and pagination. Assert summary counts cover every search match rather than only the returned page. Invalid health, booleans, sort, or direction return `400`.
+
+- [ ] **Step 2: Write failing component-detail endpoint tests**
+
+Register the route in `NewTestServerWithExecutor`; assert a known execution returns ordered component rows, a historical execution returns an empty array with `200`, and an unknown execution returns `404`.
+
+- [ ] **Step 3: Run API tests to verify RED**
+
+Run: `go test ./internal/server -run 'TestGetRepositories|TestGetJobComponents' -count=1`
+
+Expected: response fields, filters, and component route are missing.
+
+- [ ] **Step 4: Extend DTOs and replace the old repository aggregation handler**
+
+Keep the legacy fields and add:
+
+```go
+type RepositoryHealthSummary struct {
+    Total int `json:"total"`
+    Healthy int `json:"healthy"`
+    Failed int `json:"failed"`
+    Pending int `json:"pending"`
+    Running int `json:"running"`
+    NeverSynced int `json:"never_synced"`
+    Cancelled int `json:"cancelled"`
+    Overdue int `json:"overdue"`
+    Stuck int `json:"stuck"`
+}
+```
+
+Have `GetRepositories` load one DB snapshot, combine it with config, apply search, compute summary, apply health/boolean filters, sort, and finally paginate. `syncing` matches pending plus running. Use one fixed `now := time.Now()` throughout the response.
+
+- [ ] **Step 5: Add component-detail handler and routes**
+
+Verify the execution exists before reading components; return `ListComponentsResponse{Components: []db.ComponentExecution{}}` for legacy executions. Register `GET /api/jobs/:id/components` in production and test routers.
+
+- [ ] **Step 6: Verify GREEN and commit**
+
+Run: `gofmt -w internal/server/types.go internal/server/api.go internal/server/repository_test.go internal/server/export_test.go cmd/server/server.go`
+
+Run: `go test ./internal/server ./cmd/server`
+
+Expected: PASS.
+
+```powershell
+git add internal/server cmd/server/server.go
+git commit -m "feat(api): expose repository health and component details"
+```
+
+### Task 8: Safe server-side bulk retry
+
+**Files:**
+- Modify: `internal/server/types.go`
+- Modify: `internal/server/api.go`
+- Create: `internal/server/bulk_jobs_test.go`
+- Modify: `internal/server/export_test.go`
+- Modify: `cmd/server/server.go`
+
+**Interfaces:**
+- Produces: `POST /api/jobs/bulk`.
+- Produces DTOs `BulkJobSelector`, `BulkCreateJobsRequest`, and `BulkCreateJobsResponse`.
+- Consumes `executor.ErrRepositoryActive` and the repository snapshot/filter helpers.
+
+- [ ] **Step 1: Write failing count-conflict and eligibility tests**
+
+Use failed, cancelled, overdue, healthy, pending, and stuck repos. Post a selector and wrong `expected_count`; assert HTTP `409` includes `actual_count` and creates no execution. With the correct count, assert only failed/cancelled/overdue repos are candidates; stuck remains active and is not retryable.
+
+- [ ] **Step 2: Write failing partial-result and concurrency tests**
+
+Use injected runners and one already-active repository. Assert the response reports exact values for `requested`, `queued`, `skipped_active`, `no_longer_eligible`, and `failed_to_enqueue`. Confirm queued work passes through the Task 5 executor and never exceeds its concurrency limit.
+
+- [ ] **Step 3: Run tests to verify RED**
+
+Run: `go test ./internal/server -run 'TestBulk' -count=1`
+
+Expected: `POST /api/jobs/bulk` is not registered.
+
+- [ ] **Step 4: Implement selector validation and expected-count guard**
+
+Define:
+
+```go
+type BulkJobSelector struct {
+    Search string `json:"search"`
+    Health string `json:"health"`
+    Overdue *bool `json:"overdue,omitempty"`
+}
+
+type BulkCreateJobsRequest struct {
+    Selector BulkJobSelector `json:"selector"`
+    ExpectedCount int `json:"expected_count"`
+}
+```
+
+Rebuild the current snapshot server-side, apply the selector, then intersect with retryable states: failed, cancelled, or `overdue=true`. Return `409` if the eligible count differs from `expected_count`.
+
+- [ ] **Step 5: Enqueue independently and report partial outcomes**
+
+Loop over deterministic name/key order and call `ExecuteJob`. Count `ErrRepositoryActive` separately, continue after individual insertion/enqueue failures, and return aggregate counts without thousands of IDs. Register the protected route in `cmd/server` and test constructors.
+
+- [ ] **Step 6: Verify GREEN and commit**
+
+Run: `gofmt -w internal/server/types.go internal/server/api.go internal/server/bulk_jobs_test.go internal/server/export_test.go cmd/server/server.go`
+
+Run: `go test -race ./internal/server ./internal/executor ./cmd/server`
+
+Expected: PASS.
+
+```powershell
+git add internal/server cmd/server/server.go
+git commit -m "feat(api): add safe bulk repository retry"
+```
+
+### Task 9: Manually refreshed repository health dashboard
+
+**Files:**
+- Modify: `web/templates/index.html`
+- Modify: `web/static/js/main.js`
+- Modify: `web/static/css/main.css`
+- Modify: `cmd/server/static_test.go`
+
+**Interfaces:**
+- Consumes extended `GET /api/repositories`, `GET /api/jobs/:id/components`, and `POST /api/jobs/bulk`.
+- Preserves the explicit `#btn-refresh-repos` refresh control.
+- Produces hash query state such as `#/repositories?health=failed&sort=attention`.
+
+- [ ] **Step 1: Write failing embedded-asset regression tests**
+
+Read `web.StaticFS` in `cmd/server/static_test.go` and assert the repository UI contains summary/filter/bulk/detail IDs. Add explicit-refresh guards:
+
+```go
+require.NotRegexp(t, `setInterval\([^)]*(renderRepositories|renderApp)`, js)
+require.NotContains(t, js, "if (state.logJob === jobId) renderApp()")
+require.Contains(t, js, "btn-refresh-repos")
+```
+
+The existing `setInterval(refreshMetrics, 15000)` remains allowed because it updates only the top-bar server metric, not the repository page.
+
+- [ ] **Step 2: Run the static test to verify RED**
+
+Run: `go test ./cmd/server -run 'TestStatic|TestRepositoryHealthAssets' -count=1`
+
+Expected: FAIL because health controls and component detail markup do not exist.
+
+- [ ] **Step 3: Add health state, URL synchronization, and server query building**
+
+Extend repository state with `reposHealth`, `reposOverdue`, `reposSort`, and `reposDirection`. Parse the query portion of the hash on navigation and update the hash only on explicit filter/search/sort actions. Build request parameters from that state; do not install timers, observers, or SSE-driven page reloads.
+
+Add focused helpers with these concrete behaviors:
+
+```javascript
+function repositoryParams() {
+    const p = new URLSearchParams({ page: state.reposPage, limit: 20 });
+    if (state.reposSearch) p.set('search', state.reposSearch);
+    if (state.reposHealth) p.set('health', state.reposHealth);
+    if (state.reposOverdue) p.set('overdue', 'true');
+    p.set('sort', state.reposSort || 'attention');
+    p.set('direction', state.reposDirection || 'asc');
+    return p;
+}
+
+function repositoryHealthBadge(repo) {
+    return '<span class="badge health-' + esc(repo.health_status) + '">' +
+        esc(repo.health_status || 'never_synced') + '</span>';
+}
+
+function setRepositoryRoute(next) {
+    Object.assign(state, next);
+    const p = repositoryParams();
+    p.delete('limit');
+    location.hash = '#/repositories?' + p.toString();
+}
+
+function repositorySummaryCards(summary) {
+    const cards = [
+        { key: 'total', label: 'All', count: summary.total, health: '' },
+        { key: 'healthy', label: 'Healthy', count: summary.healthy, health: 'healthy' },
+        { key: 'failed', label: 'Failed', count: summary.failed, health: 'failed' },
+        { key: 'syncing', label: 'Syncing', count: summary.pending + summary.running, health: 'syncing' },
+        { key: 'never_synced', label: 'Never synced', count: summary.never_synced, health: 'never_synced' },
+        { key: 'overdue', label: 'Overdue', count: summary.overdue, overdue: true }
+    ];
+    return cards.map(card =>
+        '<button class="summary-card" data-health="' + esc(card.health || '') +
+        '" data-overdue="' + (card.overdue ? 'true' : '') + '">' +
+        '<strong>' + esc(card.count) + '</strong><span>' + esc(card.label) + '</span></button>'
+    ).join('');
+}
+```
+
+- [ ] **Step 4: Render the operational table and summary controls**
+
+Render cards for total, healthy, failed, syncing, never synced, and overdue. Render filters for health/overdue and sorts for attention/name/last attempt/last success. Replace configuration-heavy columns with status, name/URL, last attempt, last success, duration, next run, error summary, and actions. Use the API's summary rather than counting the current page.
+
+- [ ] **Step 5: Add component detail and bulk retry interactions**
+
+Add a component section to the existing log modal. `openExecutionDetails(executionID, name)` fetches component rows, shows status/timing/error per component, then opens the existing log stream/history. `retryFilteredRepositories()` confirms the displayed eligible count, posts selector plus `expected_count`, and shows returned aggregate counts. It may render the immediate POST result, but it must not schedule later refreshes.
+
+- [ ] **Step 6: Remove the SSE completion page reload and style the view**
+
+Delete the existing completion-handler call that runs `renderApp()`. Keep closing the EventSource and updating modal state. Add `.summary-grid`, `.summary-card`, health badge variants, component rows, responsive toolbar/table rules, and visible focus styles in `main.css`.
+
+- [ ] **Step 7: Verify embedded assets and manual behavior**
+
+Run: `go test ./cmd/server ./internal/server`
+
+Expected: PASS.
+
+Run the server against a test config, open `#/repositories`, and verify: card/filter URLs are bookmarkable; failure detail opens the matching execution; bulk confirmation displays the server count; clicking Refresh reloads; leaving the page idle and finishing a job does not issue another `/api/repositories` request.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add web cmd/server/static_test.go
+git commit -m "feat(web): add repository sync health dashboard"
+```
+
+### Task 10: Performance fixture, documentation, and final verification
+
+**Files:**
+- Create: `internal/server/repository_benchmark_test.go`
+- Modify: `internal/db/execution_store_test.go`
+- Modify: `docs/api.md`
+- Modify: `docs/web-ui.md`
+- Modify: `README.md`
+- Modify: `README_zh.md`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Documents exact settings, statuses, endpoints, filters, response fields, bulk semantics, and explicit-refresh behavior.
+- Produces benchmark `BenchmarkGetRepositories6000` and index-plan regression coverage.
+
+- [ ] **Step 1: Add a 6,000-repository benchmark fixture**
+
+Build 6,000 config entries and insert 100 historical executions per repository inside one transaction before starting the benchmark timer. Benchmark `GET /api/repositories?sort=attention&page=1&limit=20`, failed filtering, overdue filtering, and last-success sorting with `b.Run` sub-benchmarks. Verify response status and decode the response outside the timed setup.
+
+- [ ] **Step 2: Add query-plan assertions**
+
+Use `EXPLAIN QUERY PLAN` for the latest-execution and successful-execution access paths. Join all detail strings and assert they mention `idx_executions_repo_start` and `idx_executions_repo_status_end`; this prevents a future accidental per-repository full scan.
+
+- [ ] **Step 3: Run performance verification**
+
+Run: `go test ./internal/server -run '^$' -bench BenchmarkGetRepositories6000 -benchtime=1x -count=3`
+
+Expected: each overview sub-benchmark reports less than `1s/op` on the supported local SQLite test environment. Record the OS, CPU, Go version, fixture size, and observed values in the commit/PR notes; if the target is missed, optimize the indexed query without introducing the deferred materialized state table.
+
+- [ ] **Step 4: Update API and operations documentation**
+
+Document:
+
+```text
+GET /api/repositories?health=failed&overdue=true&sort=attention
+GET /api/jobs/:id/components
+POST /api/jobs/bulk
+syncOverdueGrace: 30m
+syncStuckThreshold: 24h
+```
+
+Explain last attempt versus last success, skip versus failure, health precedence, summary count scope, expected-count conflicts, executor concurrency, restart reconciliation, and the fact that the Repositories page refreshes only when the user requests it.
+
+- [ ] **Step 5: Format and run static verification**
+
+Run:
+
+```powershell
+gofmt -w internal/config/config.go internal/config/config_test.go internal/config/importexport.go internal/config/importexport_test.go internal/db/models.go internal/db/db.go internal/db/migrate.go internal/db/migrations_test.go internal/db/execution_store.go internal/db/execution_store_test.go internal/syncresult/syncresult.go internal/syncresult/syncresult_test.go internal/wiki/wiki.go internal/wiki/wiki_test.go internal/executor/components.go internal/executor/executor.go internal/executor/executor_test.go internal/server/types.go internal/server/api.go internal/server/config_api.go internal/server/config_api_test.go internal/server/repository_health.go internal/server/repository_health_test.go internal/server/repository_test.go internal/server/bulk_jobs_test.go internal/server/repository_benchmark_test.go cmd/wiki/wiki.go cmd/daemon/daemon.go cmd/daemon/daemon_test.go cmd/server/server.go cmd/server/server_test.go cmd/server/static_test.go
+```
+
+Run: `go vet ./...`
+
+Expected: both commands succeed without diagnostics.
+
+- [ ] **Step 6: Run the full test and race suites**
+
+Run: `go test ./...`
+
+Run: `go test -race ./internal/db ./internal/executor ./internal/server ./cmd/server`
+
+Expected: PASS with no failures, hangs, leaked workers, or races.
+
+- [ ] **Step 7: Check worktree scope and whitespace**
+
+Run: `git diff --check`
+
+Run: `git status --short`
+
+Expected: no whitespace errors; `.codex-ui-test/` remains untracked and untouched; only planned feature files are changed.
+
+- [ ] **Step 8: Commit**
+
+```powershell
+git add internal/server/repository_benchmark_test.go internal/db/execution_store_test.go docs/api.md docs/web-ui.md README.md README_zh.md CLAUDE.md
+git commit -m "docs: describe repository sync health operations"
+```
+
+## Final Acceptance
+
+- A user can see fleet-wide counts, find failed/never/overdue/stuck repositories, and sort attention-first without loading all 6,000 rows into the browser.
+- Every row distinguishes last attempt from last successful backup and links to the exact latest execution/component details.
+- Optional component failure makes the execution fail; unsupported capability is recorded as skipped.
+- Cron, manual runs, and bulk retries share the same actual executor concurrency cap and duplicate-active protection.
+- Server restart cannot leave an execution permanently pending/running.
+- Bulk retry confirms the current server-side eligible count and reports partial outcomes safely.
+- The repository page performs no automatic refresh or polling.
+- Additive migration, full tests, focused race tests, query-plan checks, and the 6,000-repository benchmark all pass.

--- a/docs/superpowers/specs/2026-09-03-repository-sync-health-design.md
+++ b/docs/superpowers/specs/2026-09-03-repository-sync-health-design.md
@@ -1,0 +1,302 @@
+# Repository Sync Health Design
+
+## Purpose
+
+gitrieve can schedule thousands of repositories through `gitrieve server`, but the Repositories page does not provide a reliable fleet-level answer to three operational questions:
+
+1. How many repositories are healthy or need attention?
+2. Which repositories failed, never ran, missed their schedule, or are still active?
+3. When did each repository last produce a fully successful backup?
+
+The existing page already reports `last_run_time`, `next_run_time`, and cumulative success/failure counts. This phase turns that data into an operational health view for roughly 6,000 independently configured `type: repo` entries. It also makes an execution successful only when every enabled component succeeds or is legitimately skipped.
+
+## Confirmed Decisions
+
+- The server scheduler is the only scheduling path in scope; standalone `gitrieve daemon` execution is unchanged.
+- Every configured item is a concrete `type: repo` entry. Organization/user expansion does not need a new detail view in this phase.
+- Code, release, issue, wiki, and discussion synchronization contribute to the overall execution result when enabled.
+- An enabled component that the upstream does not support is `skipped` and does not fail the execution.
+- The first phase provides an overview and rapid troubleshooting, not outbound alerts.
+- The repository overview never refreshes itself on a timer or when a job-completion event arrives. Users refresh it explicitly.
+
+## Scope
+
+This phase adds:
+
+- component-level execution outcomes;
+- correct overall success/failure aggregation;
+- executor-level concurrency admission shared by cron, single execution, and bulk retry;
+- repository health fields, summary counts, server-side filters, and server-side sorting;
+- missed-schedule and long-running detection;
+- a repository health dashboard within the existing Repositories page;
+- execution/component drill-down and safe bulk retry;
+- startup reconciliation for executions left active by an interrupted server process;
+- indexes and performance coverage appropriate for 6,000 repositories.
+
+## Out of Scope
+
+- outbound notifications, webhooks, email, or chat alerts;
+- automatic page refresh or polling;
+- a separate monitoring service;
+- historical charts and success-rate trends;
+- daemon-mode execution persistence;
+- organization/user member-repository expansion;
+- cross-process or cross-host job queues.
+
+## Status Model
+
+### Execution status
+
+The existing execution statuses remain:
+
+- `pending`: accepted and waiting for an executor concurrency slot;
+- `running`: admitted and currently executing;
+- `completed`: every enabled component completed or was skipped;
+- `failed`: at least one enabled component failed, or an interrupted process left the execution incomplete;
+- `cancelled`: cancelled by the user.
+
+An execution continues attempting the remaining enabled components after one component fails. This preserves the current best-effort behavior while making the final status truthful.
+
+### Component status
+
+Each enabled component has one record with one of:
+
+- `pending`;
+- `running`;
+- `completed`;
+- `failed`;
+- `skipped`;
+- `cancelled`.
+
+Code is always an enabled component. Release, issue, wiki, and discussion records are created only when their corresponding repository options are enabled. A component returns a recognizable unsupported/not-available outcome when the upstream does not expose that capability; the executor records it as `skipped`. Disabled components have no row.
+
+### Repository health
+
+The API exposes both the latest raw execution status and a display-oriented health value. Health categories are mutually exclusive and use this precedence:
+
+1. `never_synced`: the repository has no execution;
+2. `stuck`: the latest execution is `running` beyond `syncStuckThreshold`;
+3. `pending` or `running`: the latest execution is active and not stuck;
+4. `failed` or `cancelled`: the latest terminal execution has that status;
+5. `overdue`: the latest execution completed, but no later execution was accepted for the latest cron occurrence outside the grace window;
+6. `healthy`: the latest execution completed and is not overdue.
+
+The response also includes independent `overdue` and `stuck` booleans so clients do not need to reverse-engineer the precedence.
+
+For a repository with a cron expression, let `E` be the most recent scheduled occurrence no later than `now - syncOverdueGrace`. The repository is overdue when it has execution history, has no active execution, and its latest attempt started before `E`. A never-run repository stays `never_synced` rather than also being counted as overdue. Manual executions after `E` satisfy the schedule for this calculation.
+
+Two global duration settings are added:
+
+```yaml
+syncOverdueGrace: 30m
+syncStuckThreshold: 24h
+```
+
+The grace window avoids reporting a job as missed immediately after its cron time. The stuck threshold flags abnormally long running work. Both settings participate in validation, save, import/export, apply, and configuration reload. Non-positive values use their documented defaults.
+
+## Persistence
+
+The existing `executions` table remains the source of overall and historical execution state. Add:
+
+```sql
+CREATE TABLE execution_components (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    execution_id TEXT NOT NULL,
+    component TEXT NOT NULL,
+    status TEXT NOT NULL,
+    start_time DATETIME,
+    end_time DATETIME,
+    error_message TEXT,
+    UNIQUE(execution_id, component),
+    FOREIGN KEY (execution_id) REFERENCES executions(id)
+);
+```
+
+Add indexes supporting latest-execution, last-success, active-job, and component-detail lookups:
+
+```sql
+CREATE INDEX idx_executions_repo_start
+    ON executions(repo_key, start_time DESC);
+CREATE INDEX idx_executions_repo_status_end
+    ON executions(repo_key, status, end_time DESC);
+CREATE INDEX idx_executions_status
+    ON executions(status);
+CREATE INDEX idx_execution_components_execution
+    ON execution_components(execution_id);
+```
+
+The migration is additive and does not rewrite historical execution rows. Historical tasks have no component detail, which the API represents as an empty component list.
+
+A separate materialized repository-state table is intentionally deferred. The first implementation extends the current query-on-read aggregation and measures it against representative history. This avoids a second mutable source of truth. If the performance target cannot be met with indexed queries, adopting a rebuildable summary table requires a follow-up design rather than an implicit change in this phase.
+
+## Execution Architecture
+
+### Shared concurrency admission
+
+The scheduler currently limits concurrent callback invocations, but `ExecuteJob` starts asynchronous work and returns quickly. That callback limit therefore does not reliably bound the actual synchronization work.
+
+Concurrency control moves into `Executor` and applies to all server-originated work:
+
+```text
+cron / single execute / bulk retry
+              |
+              v
+   insert execution as pending
+              |
+              v
+       executor wait queue
+              |
+       acquire cocurrencyNum
+              |
+              v
+       mark execution running
+              |
+              v
+   run enabled components and aggregate
+```
+
+Pending and running jobs remain cancellable. A repository with an existing pending or running execution is not enqueued again. The existing per-repository filesystem lock remains a final safety layer, but duplicate suppression happens before a redundant execution is created.
+
+The executor must not create an unbounded number of simultaneously running goroutines. Queue storage is process-local and bounded in active work by the existing `cocurrencyNum` setting. If enqueueing fails after the database row is created, the row is finalized as failed with the enqueue error.
+
+### Component aggregation
+
+For each execution, the executor:
+
+1. creates rows for code and every enabled optional component;
+2. marks a component running immediately before invoking it;
+3. records completed, failed, skipped, or cancelled with timing and error detail;
+4. continues to subsequent enabled components after ordinary failure;
+5. stops promptly on context cancellation;
+6. writes the overall terminal status only after all component terminal rows are persisted.
+
+`executions.error_message` contains a concise aggregate suitable for list display. Full component-specific messages remain in `execution_components`, and detailed output remains in `logs`.
+
+### Interrupted-process reconciliation
+
+After database migration and before accepting work, server startup marks leftover `pending` and `running` executions as failed, sets `end_time`, and records that the previous server process ended before completion. Corresponding active component rows are also finalized as failed. This prevents jobs from appearing active forever after a crash or restart.
+
+## Repository Health API
+
+`GET /api/repositories` retains its paginated response and existing search behavior. It gains these query parameters:
+
+- `health`: one health category, with `syncing` as an alias for `pending` plus `running`;
+- `overdue`: optional boolean filter;
+- `stuck`: optional boolean filter;
+- `sort`: `attention`, `name`, `last_attempt`, or `last_success`;
+- `direction`: `asc` or `desc`.
+
+The default sort is `attention`, then repository name. Attention order is stuck, failed, overdue, never synced, cancelled, pending, running, and healthy. Stable name/key tie-breakers prevent rows moving unpredictably between pages.
+
+Each repository overview adds:
+
+```json
+{
+  "last_status": "failed",
+  "health_status": "failed",
+  "last_attempt_time": "2026-09-03T10:00:00Z",
+  "last_success_time": "2026-09-01T10:02:30Z",
+  "last_duration_seconds": 151,
+  "latest_execution_id": "...",
+  "last_error_message": "issues: API rate limit exceeded",
+  "overdue": false,
+  "stuck": false
+}
+```
+
+`last_attempt_time` is the latest execution start. `last_success_time` is the end time of the latest overall `completed` execution. Keeping both prevents a recent failed attempt from making an old backup appear fresh.
+
+The paginated response also includes fleet summary counts for total, healthy, failed, pending, running, never synced, and cancelled. It additionally returns independent overdue and stuck totals; these diagnostic totals can overlap terminal/active status counts. Summary counts apply the name/URL search but are computed before health, overdue, and stuck filters, so the cards remain useful for switching categories. Counts cover all search-matched repositories, not only the current page.
+
+Add a read endpoint for an execution's component rows. Existing log endpoints remain authoritative for full logs.
+
+## Repositories Page
+
+The page header contains summary cards for total, healthy, failed, syncing, never synced, and overdue. Clicking a card applies the corresponding server-side filter. Stuck work appears within the syncing area with a distinct warning and is available as a dedicated filter.
+
+The toolbar supports:
+
+- name/URL search;
+- latest health filter;
+- overdue-only filtering;
+- attention, name, last-attempt, and last-success sorting;
+- explicit refresh;
+- add repository.
+
+The primary table columns are:
+
+- health/status;
+- repository name and URL;
+- last attempt;
+- last successful completion;
+- latest duration;
+- next scheduled run;
+- latest error summary;
+- actions.
+
+Less operational configuration remains available in the edit dialog instead of consuming the primary scan path. Failed rows link directly to the latest execution details and offer a single-repository retry.
+
+The detail view shows overall timing and status, component status/timing/error rows, historical or live logs, and a retry action. Historical executions created before this feature show "component details unavailable" instead of synthesizing misleading component results.
+
+The Repositories page performs no periodic polling and does not reload in response to an SSE completion event. Navigation and explicit user actions may render their immediate response, but later server-side changes appear only after the user clicks Refresh or revisits the page.
+
+Filters and sorting are encoded in the hash/query state so an operator can bookmark an exception view.
+
+## Safe Bulk Retry
+
+Bulk retry is enabled for a filtered failed, cancelled, or overdue set. A stuck execution is still active and must be cancelled before it becomes retryable. The UI first obtains the eligible count and asks for explicit confirmation with that number.
+
+The bulk endpoint accepts the same repository selector plus the confirmed expected count. It recomputes eligibility server-side. If the count changed, it returns a conflict with the new count and requires confirmation again. It never trusts a page-sized client list as the full result set.
+
+For each eligible repository, the server:
+
+- skips repositories already pending or running;
+- creates a pending execution and enqueues it through the shared executor;
+- continues processing other repositories if one enqueue fails.
+
+The response reports requested, queued, skipped-active, no-longer-eligible, and failed-to-enqueue counts. Thousands of job IDs are not returned in the summary response; the Jobs page remains the place to inspect individual executions.
+
+## Error Handling
+
+- Component failures retain their component name and original error while the overall execution receives a concise summary.
+- Unsupported upstream capabilities use an explicit skipped outcome; arbitrary permission, authentication, rate-limit, network, storage, and parsing errors are failures.
+- Database failure while recording a component terminal result prevents the execution from being reported completed.
+- Cancellation wins while queued, while waiting for admission, and during component work.
+- Invalid cron expressions do not crash overview generation. The row reports the schedule error and cannot be classified overdue until corrected.
+- A repository deleted from configuration remains in job history but is absent from the current repository overview.
+- Summary and list queries use one consistent database snapshot so counts and page contents do not disagree within a response.
+
+## Performance
+
+Filtering, health derivation, sorting, and pagination happen on the server. The browser receives only one page plus summary counts.
+
+Performance verification uses at least 6,000 configured repositories and representative execution history, including multiple historical runs per repository. The default overview, failed filter, overdue filter, attention sort, and last-success sort are benchmarked. The acceptance target is a sub-second API response on the project's supported local SQLite deployment under this fixture, with the exact benchmark environment recorded alongside the result.
+
+The query plan must use the new indexes for latest and successful execution lookup. A full unindexed scan per configured repository is not acceptable.
+
+## Testing
+
+Tests cover:
+
+- overall failure when any enabled component fails;
+- continued best-effort execution of later components after a failure;
+- skipped unsupported components not failing the overall execution;
+- disabled components producing no component row;
+- last-attempt and last-success semantics across success/failure sequences;
+- health precedence and summary counts;
+- overdue cron boundary, grace, timezone, and daylight-saving behavior;
+- stuck-threshold behavior;
+- combined search, health, overdue, sorting, and pagination;
+- stable pagination tie-breakers;
+- summary counts covering the full match set rather than the current page;
+- historical executions with no component rows;
+- startup reconciliation of orphaned pending/running executions;
+- cancellation while pending and running;
+- duplicate active-execution suppression per repository;
+- actual executor concurrency never exceeding `cocurrencyNum` for cron, manual, and bulk work;
+- bulk retry count conflicts and partial enqueue results;
+- explicit-refresh-only frontend behavior;
+- additive migration from existing SQLite databases;
+- the 6,000-repository performance fixture and query-plan assertions.
+
+The full `go test ./...` suite is the final verification gate.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -43,6 +43,38 @@ The default host is `localhost` and the default port is `8080`. Static assets (C
 - **Cancel a job** — stop a running or pending job.
 - **Real-time logs** — every job has a live log stream that updates as the job runs, using Server-Sent Events. The stream closes automatically when the job finishes.
 
+### Repository sync health
+
+The Repositories page is a server-paginated fleet overview. Summary cards show
+total, healthy, failed, syncing, never-synced, and overdue counts across every
+repository matching the current text search, not only the visible page. Health,
+overdue, and stuck filters plus attention/name/last-attempt/last-success sorting
+are kept in the URL hash, so exception views can be bookmarked.
+
+Each row deliberately shows both the last attempt and last successful
+completion. A recent failed attempt must not make an older successful backup
+look recent. Primary health uses this precedence: never synced; stuck; pending
+or running; failed or cancelled; overdue; healthy. Overdue and stuck are also
+shown as independent diagnostics.
+
+Open a row's execution detail to see the exact latest execution, its component
+outcomes, and its logs. Code is always enabled; release, issues, wiki, and
+discussion appear when configured. Unsupported capabilities are `skipped` and
+do not fail an execution. A real failure in any enabled component makes the
+overall execution `failed`, although later components are still attempted.
+Older executions created before component tracking show that component details
+are unavailable instead of inventing results.
+
+Bulk retry operates on the complete server-side failed/cancelled/overdue
+selection. The confirmation displays the eligible count. If that count changes
+before submission, the server returns the new count and the UI asks again.
+Active or no-longer-eligible repositories are safely accounted for, and one
+enqueue failure does not stop the remaining repositories.
+
+**Refresh is always explicit.** The Repositories page never polls, schedules a
+timer reload, or reloads because a job's SSE stream completes. Click **Refresh**
+or revisit the page to see later server-side changes.
+
 ### Configuration management
 
 - **Repositories** — add, edit, and remove repository entries from your `config.yaml` without editing the file by hand. Changes are persisted back to the config file.
@@ -98,11 +130,23 @@ storage:
     path: ./repo
 
 githubToken: your-github-token
+syncOverdueGrace: 30m
+syncStuckThreshold: 24h
+cocurrencyNum: 6
 ```
 
 The `server` process executes every non-empty repository `cron` schedule. Cron
 registrations are refreshed immediately when repositories are created, updated,
 or deleted through the API, and after config import or reload.
+
+`syncOverdueGrace` defaults to `30m` and prevents a repository from being
+declared overdue immediately after its cron time. `syncStuckThreshold` defaults
+to `24h` and flags unusually long-running work. Non-positive values select
+those defaults. `cocurrencyNum` is intentionally spelled as shown and limits
+actual executor work shared by cron, manual runs, and bulk retries; excess work
+waits as `pending`. Duplicate active work for the same repository is rejected.
+At startup the server reconciles executions left `pending` or `running` by the
+previous process to `failed`, including active component rows.
 
 ## Security notes
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -55,7 +55,8 @@ Each row deliberately shows both the last attempt and last successful
 completion. A recent failed attempt must not make an older successful backup
 look recent. Primary health uses this precedence: never synced; stuck; pending
 or running; failed or cancelled; overdue; healthy. Overdue and stuck are also
-shown as independent diagnostics.
+shown as independent diagnostics. A repository is stuck when its latest
+execution remains `pending` or `running` beyond `syncStuckThreshold`.
 
 Open a row's execution detail to see the exact latest execution, its component
 outcomes, and its logs. Code is always enabled; release, issues, wiki, and
@@ -141,10 +142,11 @@ or deleted through the API, and after config import or reload.
 
 `syncOverdueGrace` defaults to `30m` and prevents a repository from being
 declared overdue immediately after its cron time. `syncStuckThreshold` defaults
-to `24h` and flags unusually long-running work. Non-positive values select
-those defaults. `cocurrencyNum` is intentionally spelled as shown and limits
-actual executor work shared by cron, manual runs, and bulk retries; excess work
-waits as `pending`. Duplicate active work for the same repository is rejected.
+to `24h` and flags work that remains `pending` or `running` past that duration.
+Non-positive values select those defaults. `cocurrencyNum` is intentionally
+spelled as shown and limits actual executor work shared by cron, manual runs,
+and bulk retries; excess work waits as `pending`. Duplicate active work for the
+same repository is rejected.
 At startup the server reconciles executions left `pending` or `running` by the
 previous process to `failed`, including active component rows.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,8 +38,9 @@ type Config struct {
 var Path string
 
 var vp *viper.Viper
-var vpMu sync.Mutex
+var stateMu sync.Mutex
 var ins atomic.Pointer[Config]
+var configureGitHubAPI = githubapi.Configure
 
 func Init() {
 	nextViper := viper.New()
@@ -61,10 +62,11 @@ func Init() {
 	if err := validateIdentity(&next); err != nil {
 		ui.ErrorfExit("Invalid configuration: %s", err)
 	}
-	vpMu.Lock()
+	snapshot := Clone(&next)
+	stateMu.Lock()
 	vp = nextViper
-	vpMu.Unlock()
-	SetIns(&next)
+	setInsLocked(snapshot)
+	stateMu.Unlock()
 }
 
 // seedDefaults fills zero-valued global options with their defaults. It runs in
@@ -131,8 +133,14 @@ func GetIns() *Config {
 // observe a complete old or complete new instance, never a torn one.
 func SetIns(cfg *Config) {
 	snapshot := Clone(cfg)
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	setInsLocked(snapshot)
+}
+
+func setInsLocked(snapshot *Config) {
 	ins.Store(snapshot)
-	githubapi.Configure(gitHubAPIConfig(snapshot))
+	configureGitHubAPI(gitHubAPIConfig(snapshot))
 }
 
 func currentConfig() *Config {
@@ -143,15 +151,19 @@ func currentConfig() *Config {
 	return cfg
 }
 
-// GetViper returns the viper instance that loaded the config file. It is nil
-// until Init has run (registered via cobra.OnInitialize, so it runs before any
-// command executes). Exposed so packages that read config sections outside the
-// top-level Config struct (e.g. the `server:` settings) read from the same
-// loaded instance rather than the empty global viper singleton.
+// GetViper returns a detached copy of the viper instance that loaded the
+// config file. It is nil until Init has run (registered via cobra.OnInitialize,
+// so it runs before any command executes). Mutating the returned instance
+// cannot bypass the package's configuration publication lock.
 func GetViper() *viper.Viper {
-	vpMu.Lock()
-	defer vpMu.Unlock()
-	return vp
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	if vp == nil {
+		return nil
+	}
+	detached := viper.New()
+	_ = detached.MergeConfigMap(vp.AllSettings())
+	return detached
 }
 
 func GetStorageMap() map[string]typedef.MultiStorage {
@@ -246,12 +258,28 @@ func validateIdentity(cfg *Config) error {
 
 // Save persists the current in-memory config back to the config file via viper.
 func Save() error {
-	vpMu.Lock()
-	defer vpMu.Unlock()
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	return saveSnapshotLocked(currentConfig())
+}
+
+// SaveSnapshot persists cfg through the current viper instance without
+// republishing it. Callers can therefore save the exact generation they
+// committed even if package-global configuration changes concurrently.
+func SaveSnapshot(cfg *Config) error {
+	snapshot := Clone(cfg)
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	return saveSnapshotLocked(snapshot)
+}
+
+func saveSnapshotLocked(cfg *Config) error {
 	if vp == nil {
 		return fmt.Errorf("config not initialized")
 	}
-	cfg := currentConfig()
+	if cfg == nil {
+		cfg = &Config{}
+	}
 	// Update the viper config with current ins values
 	vp.Set("repository", cfg.Repository)
 	vp.Set("storage", cfg.Storage)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,16 +173,34 @@ func GetIns() *Config {
 // publish a fully-built replacement so concurrent readers (job goroutines)
 // observe a complete old or complete new instance, never a torn one.
 func SetIns(cfg *Config) {
-	snapshot := Clone(cfg)
-	stateMu.Lock()
-	defer stateMu.Unlock()
-	setInsLocked(snapshot)
+	PublishSnapshot(cfg, nil)
 }
 
 func setInsLocked(snapshot *Config) {
-	publishGitHubAPI(gitHubAPIConfig(snapshot), func() {
-		ins.Store(snapshot)
+	publishSnapshotLocked(snapshot, nil, nil)
+}
+
+// PublishSnapshot installs package config, the stable GitHub arbiter policy,
+// and any caller-owned immutable runtime state through one reader-observed
+// boundary. install must not perform network or persistence work.
+func PublishSnapshot(cfg *Config, install func(*Config)) *Config {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	return publishSnapshotLocked(cfg, nil, install)
+}
+
+func publishSnapshotLocked(cfg *Config, nextViper *viper.Viper, install func(*Config)) *Config {
+	published := Clone(cfg)
+	publishGitHubAPI(gitHubAPIConfig(published), func() {
+		if nextViper != nil {
+			vp = nextViper
+		}
+		ins.Store(published)
+		if install != nil {
+			install(Clone(published))
+		}
 	})
+	return Clone(published)
 }
 
 func currentConfig() *Config {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,11 @@ import (
 	"github.com/wnarutou/gitrieve/internal/ui"
 )
 
+const (
+	DefaultSyncOverdueGrace   = 30 * time.Minute
+	DefaultSyncStuckThreshold = 24 * time.Hour
+)
+
 type Config struct {
 	Repository                  []typedef.Repository   `yaml:"repository"`
 	Storage                     []typedef.MultiStorage `yaml:"storage"`
@@ -20,6 +25,8 @@ type Config struct {
 	ReleaseNumLimit             int                    `yaml:"releaseNumLimit"`
 	RetryMaxCount               int                    `yaml:"retryMaxCount"`
 	RetryBaseDelay              time.Duration          `yaml:"retryBaseDelay"`
+	SyncOverdueGrace            time.Duration          `yaml:"syncOverdueGrace" mapstructure:"syncOverdueGrace"`
+	SyncStuckThreshold          time.Duration          `yaml:"syncStuckThreshold" mapstructure:"syncStuckThreshold"`
 	GitHubAPIConcurrency        uint                   `yaml:"githubApiConcurrency" mapstructure:"githubApiConcurrency"`
 	GitHubMinRequestInterval    time.Duration          `yaml:"githubMinRequestInterval" mapstructure:"githubMinRequestInterval"`
 	GitHubLowRemainingThreshold int                    `yaml:"githubLowRemainingThreshold" mapstructure:"githubLowRemainingThreshold"`
@@ -64,6 +71,12 @@ func seedDefaults(cfg *Config) {
 	}
 	if cfg.RetryBaseDelay <= 0 {
 		cfg.RetryBaseDelay = 5 * time.Second
+	}
+	if cfg.SyncOverdueGrace <= 0 {
+		cfg.SyncOverdueGrace = DefaultSyncOverdueGrace
+	}
+	if cfg.SyncStuckThreshold <= 0 {
+		cfg.SyncStuckThreshold = DefaultSyncStuckThreshold
 	}
 	if cfg.ConcurrencyNum == 0 {
 		cfg.ConcurrencyNum = 3
@@ -152,6 +165,10 @@ func GetRetryBaseDelay() time.Duration {
 	return ins.RetryBaseDelay
 }
 
+func GetSyncOverdueGrace() time.Duration { return ins.SyncOverdueGrace }
+
+func GetSyncStuckThreshold() time.Duration { return ins.SyncStuckThreshold }
+
 func GetGitHubAPIConcurrency() uint { return ins.GitHubAPIConcurrency }
 
 func GetGitHubMinRequestInterval() time.Duration { return ins.GitHubMinRequestInterval }
@@ -202,6 +219,8 @@ func Save() error {
 	vp.Set("releaseNumLimit", ins.ReleaseNumLimit)
 	vp.Set("retryMaxCount", ins.RetryMaxCount)
 	vp.Set("retryBaseDelay", ins.RetryBaseDelay)
+	vp.Set("syncOverdueGrace", ins.SyncOverdueGrace)
+	vp.Set("syncStuckThreshold", ins.SyncStuckThreshold)
 	vp.Set("githubApiConcurrency", ins.GitHubAPIConcurrency)
 	vp.Set("githubMinRequestInterval", ins.GitHubMinRequestInterval)
 	vp.Set("githubLowRemainingThreshold", ins.GitHubLowRemainingThreshold)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -42,6 +43,37 @@ var vp *viper.Viper
 var stateMu sync.Mutex
 var ins atomic.Pointer[Config]
 var publishGitHubAPI = githubapi.Publish
+
+type executionConfigContextKey struct{}
+
+// ExecutionSnapshot is an immutable configuration generation carried by one
+// admitted executor job. Its contents are never republished process-wide.
+type ExecutionSnapshot struct {
+	config *Config
+}
+
+func NewExecutionSnapshot(cfg *Config) *ExecutionSnapshot {
+	return &ExecutionSnapshot{config: Clone(cfg)}
+}
+
+// WithExecutionSnapshot binds a frozen configuration generation to ctx.
+func WithExecutionSnapshot(ctx context.Context, snapshot *ExecutionSnapshot) context.Context {
+	if snapshot == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, executionConfigContextKey{}, snapshot)
+}
+
+// GetExecutionConfig returns the job-bound configuration when present, and
+// preserves the package-global behavior for CLI/daemon callers otherwise.
+func GetExecutionConfig(ctx context.Context) *Config {
+	if ctx != nil {
+		if snapshot, ok := ctx.Value(executionConfigContextKey{}).(*ExecutionSnapshot); ok && snapshot != nil {
+			return Clone(snapshot.config)
+		}
+	}
+	return GetIns()
+}
 
 // configPublicationReadTestHook is a package-private synchronization seam for
 // tests that need to substitute the publication read gate itself.
@@ -274,11 +306,19 @@ func GetReleaseNumLimit() int {
 	return currentConfig().ReleaseNumLimit
 }
 
+func GetReleaseNumLimitContext(ctx context.Context) int {
+	return executionConfig(ctx).ReleaseNumLimit
+}
+
 // GetReleaseSizeLimit returns the max total release size to keep. Init seeds it
 // to 300000000 when the config value is zero; a negative value means "no
 // limit". It is read-only so it is safe under concurrent workers.
 func GetReleaseSizeLimit() int {
 	return currentConfig().ReleaseSizeLimit
+}
+
+func GetReleaseSizeLimitContext(ctx context.Context) int {
+	return executionConfig(ctx).ReleaseSizeLimit
 }
 
 // GetConcurrencyNum returns the max number of concurrent scheduler jobs. Init
@@ -318,6 +358,11 @@ func GetGitHubAPIConfig() githubapi.Config {
 	return gitHubAPIConfig(currentConfig())
 }
 
+// GitHubAPIConfigFrom returns the API-coordination inputs belonging to cfg.
+func GitHubAPIConfigFrom(cfg *Config) githubapi.Config {
+	return gitHubAPIConfig(cfg)
+}
+
 func gitHubAPIConfig(cfg *Config) githubapi.Config {
 	if cfg == nil {
 		return githubapi.Config{}
@@ -332,6 +377,20 @@ func GetRetryConfig() retry.Config {
 		MaxRetries: GetRetryMaxCount(),
 		BaseDelay:  GetRetryBaseDelay(),
 	}
+}
+
+func GetRetryConfigContext(ctx context.Context) retry.Config {
+	cfg := executionConfig(ctx)
+	return retry.Config{MaxRetries: cfg.RetryMaxCount, BaseDelay: cfg.RetryBaseDelay}
+}
+
+func executionConfig(ctx context.Context) *Config {
+	if ctx != nil {
+		if snapshot, ok := ctx.Value(executionConfigContextKey{}).(*ExecutionSnapshot); ok && snapshot != nil && snapshot.config != nil {
+			return snapshot.config
+		}
+	}
+	return currentConfig()
 }
 
 // validateIdentity ensures every repository entry has a usable identity (a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,14 @@ var stateMu sync.Mutex
 var ins atomic.Pointer[Config]
 var publishGitHubAPI = githubapi.Publish
 
+// configPublicationReadTestHook is a package-private synchronization seam for
+// tests that need to substitute the publication read gate itself.
+type configPublicationReadTestHook struct {
+	read func(func())
+}
+
+var configPublicationReadHookForTest atomic.Pointer[configPublicationReadTestHook]
+
 func Init() {
 	nextViper := viper.New()
 	nextViper.SetConfigFile(Path)
@@ -155,7 +163,11 @@ func currentConfig() *Config {
 
 func loadPublishedConfig() *Config {
 	var cfg *Config
-	githubapi.ReadPublication(func() {
+	readPublication := githubapi.ReadPublication
+	if hook := configPublicationReadHookForTest.Load(); hook != nil {
+		readPublication = hook.read
+	}
+	readPublication(func() {
 		cfg = ins.Load()
 	})
 	return cfg

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,7 +41,7 @@ var Path string
 var vp *viper.Viper
 var stateMu sync.Mutex
 var ins atomic.Pointer[Config]
-var configureGitHubAPI = githubapi.Configure
+var publishGitHubAPI = githubapi.Publish
 
 func Init() {
 	nextViper := viper.New()
@@ -125,7 +126,7 @@ func Clone(cfg *Config) *Config {
 }
 
 func GetIns() *Config {
-	return Clone(ins.Load())
+	return Clone(loadPublishedConfig())
 }
 
 // SetIns replaces the package-global config instance. Used by apply/import to
@@ -139,15 +140,24 @@ func SetIns(cfg *Config) {
 }
 
 func setInsLocked(snapshot *Config) {
-	ins.Store(snapshot)
-	configureGitHubAPI(gitHubAPIConfig(snapshot))
+	publishGitHubAPI(gitHubAPIConfig(snapshot), func() {
+		ins.Store(snapshot)
+	})
 }
 
 func currentConfig() *Config {
-	cfg := ins.Load()
+	cfg := loadPublishedConfig()
 	if cfg == nil {
 		return &Config{}
 	}
+	return cfg
+}
+
+func loadPublishedConfig() *Config {
+	var cfg *Config
+	githubapi.ReadPublication(func() {
+		cfg = ins.Load()
+	})
 	return cfg
 }
 
@@ -162,8 +172,79 @@ func GetViper() *viper.Viper {
 		return nil
 	}
 	detached := viper.New()
-	_ = detached.MergeConfigMap(vp.AllSettings())
+	_ = detached.MergeConfigMap(cloneViperSettings(vp.AllSettings()))
 	return detached
+}
+
+func cloneViperSettings(settings map[string]interface{}) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(settings))
+	for key, value := range settings {
+		if value == nil {
+			cloned[key] = nil
+			continue
+		}
+		cloned[key] = cloneViperValue(reflect.ValueOf(value)).Interface()
+	}
+	return cloned
+}
+
+func cloneViperValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return reflect.ValueOf(nil)
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := cloneViperValue(value.Elem())
+		result := reflect.New(value.Type()).Elem()
+		result.Set(cloned)
+		return result
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.New(value.Type().Elem())
+		result.Elem().Set(cloneViperValue(value.Elem()))
+		return result
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iterator := value.MapRange()
+		for iterator.Next() {
+			result.SetMapIndex(iterator.Key(), cloneViperValue(iterator.Value()))
+		}
+		return result
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for index := 0; index < value.Len(); index++ {
+			result.Index(index).Set(cloneViperValue(value.Index(index)))
+		}
+		return result
+	case reflect.Array:
+		result := reflect.New(value.Type()).Elem()
+		for index := 0; index < value.Len(); index++ {
+			result.Index(index).Set(cloneViperValue(value.Index(index)))
+		}
+		return result
+	case reflect.Struct:
+		result := reflect.New(value.Type()).Elem()
+		result.Set(value)
+		for index := 0; index < value.NumField(); index++ {
+			if result.Field(index).CanSet() && value.Field(index).CanInterface() {
+				result.Field(index).Set(cloneViperValue(value.Field(index)))
+			}
+		}
+		return result
+	default:
+		return value
+	}
 }
 
 func GetStorageMap() map[string]typedef.MultiStorage {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/viper"
@@ -36,29 +38,33 @@ type Config struct {
 var Path string
 
 var vp *viper.Viper
-var ins *Config
+var vpMu sync.Mutex
+var ins atomic.Pointer[Config]
 
 func Init() {
-	vp = viper.New()
-	vp.SetConfigFile(Path)
-	err := vp.ReadInConfig()
+	nextViper := viper.New()
+	nextViper.SetConfigFile(Path)
+	err := nextViper.ReadInConfig()
 	if err != nil {
 		ui.ErrorfExit("Error reading config file, %s", err)
 	}
-	err = vp.Unmarshal(&ins)
+	var next Config
+	err = nextViper.Unmarshal(&next)
 	if err != nil {
 		ui.ErrorfExit("Error unmarshalling config file, %s", err)
 	}
-	seedDefaults(ins)
-	if !vp.IsSet("githubScheduleJitter") {
-		ins.GitHubScheduleJitter = 30 * time.Second
+	seedDefaults(&next)
+	if !nextViper.IsSet("githubScheduleJitter") {
+		next.GitHubScheduleJitter = 30 * time.Second
 	}
-	githubapi.Configure(GetGitHubAPIConfig())
-	// 启动校验：每个仓库条目都必须有可用身份。身份键为空意味着永远无法被
-	// 匹配或执行，直接拒绝启动。
-	if err := validateIdentity(ins); err != nil {
+	// Every repository entry must have an identity before publication.
+	if err := validateIdentity(&next); err != nil {
 		ui.ErrorfExit("Invalid configuration: %s", err)
 	}
+	vpMu.Lock()
+	vp = nextViper
+	vpMu.Unlock()
+	SetIns(&next)
 }
 
 // seedDefaults fills zero-valued global options with their defaults. It runs in
@@ -101,16 +107,40 @@ func seedDefaults(cfg *Config) {
 	}
 }
 
+// Clone returns a deep copy suitable for copy-on-write configuration updates.
+func Clone(cfg *Config) *Config {
+	if cfg == nil {
+		return nil
+	}
+	cloned := *cfg
+	cloned.Repository = make([]typedef.Repository, len(cfg.Repository))
+	for index, repository := range cfg.Repository {
+		repository.Storage = append([]string(nil), repository.Storage...)
+		cloned.Repository[index] = repository
+	}
+	cloned.Storage = append([]typedef.MultiStorage(nil), cfg.Storage...)
+	return &cloned
+}
+
 func GetIns() *Config {
-	return ins
+	return Clone(ins.Load())
 }
 
 // SetIns replaces the package-global config instance. Used by apply/import to
 // publish a fully-built replacement so concurrent readers (job goroutines)
 // observe a complete old or complete new instance, never a torn one.
 func SetIns(cfg *Config) {
-	ins = cfg
-	githubapi.Configure(GetGitHubAPIConfig())
+	snapshot := Clone(cfg)
+	ins.Store(snapshot)
+	githubapi.Configure(gitHubAPIConfig(snapshot))
+}
+
+func currentConfig() *Config {
+	cfg := ins.Load()
+	if cfg == nil {
+		return &Config{}
+	}
+	return cfg
 }
 
 // GetViper returns the viper instance that loaded the config file. It is nil
@@ -119,12 +149,14 @@ func SetIns(cfg *Config) {
 // top-level Config struct (e.g. the `server:` settings) read from the same
 // loaded instance rather than the empty global viper singleton.
 func GetViper() *viper.Viper {
+	vpMu.Lock()
+	defer vpMu.Unlock()
 	return vp
 }
 
 func GetStorageMap() map[string]typedef.MultiStorage {
 	storageMap := make(map[string]typedef.MultiStorage)
-	for _, storage := range ins.Storage {
+	for _, storage := range currentConfig().Storage {
 		storageMap[storage.Name] = storage
 	}
 	return storageMap
@@ -134,51 +166,58 @@ func GetStorageMap() map[string]typedef.MultiStorage {
 // to 3 when the config value is zero; a negative value means "no limit". It is
 // read-only (no lazy mutation) so it is safe under concurrent workers.
 func GetReleaseNumLimit() int {
-	return ins.ReleaseNumLimit
+	return currentConfig().ReleaseNumLimit
 }
 
 // GetReleaseSizeLimit returns the max total release size to keep. Init seeds it
 // to 300000000 when the config value is zero; a negative value means "no
 // limit". It is read-only so it is safe under concurrent workers.
 func GetReleaseSizeLimit() int {
-	return ins.ReleaseSizeLimit
+	return currentConfig().ReleaseSizeLimit
 }
 
 // GetConcurrencyNum returns the max number of concurrent scheduler jobs. Init
 // seeds it to 3 when the config value is zero. It is read-only so it is safe
 // under concurrent workers.
 func GetConcurrencyNum() uint {
-	return ins.ConcurrencyNum
+	return currentConfig().ConcurrencyNum
 }
 
 // GetRetryMaxCount returns the configured max retries per API call. Init seeds
 // it to 3 when the config value is zero or negative, so this getter is
 // read-only.
 func GetRetryMaxCount() int {
-	return ins.RetryMaxCount
+	return currentConfig().RetryMaxCount
 }
 
 // GetRetryBaseDelay returns the exponential-backoff base delay. Init seeds it
 // to 5 seconds when the config value is zero or negative, so this getter is
 // read-only.
 func GetRetryBaseDelay() time.Duration {
-	return ins.RetryBaseDelay
+	return currentConfig().RetryBaseDelay
 }
 
-func GetSyncOverdueGrace() time.Duration { return ins.SyncOverdueGrace }
+func GetSyncOverdueGrace() time.Duration { return currentConfig().SyncOverdueGrace }
 
-func GetSyncStuckThreshold() time.Duration { return ins.SyncStuckThreshold }
+func GetSyncStuckThreshold() time.Duration { return currentConfig().SyncStuckThreshold }
 
-func GetGitHubAPIConcurrency() uint { return ins.GitHubAPIConcurrency }
+func GetGitHubAPIConcurrency() uint { return currentConfig().GitHubAPIConcurrency }
 
-func GetGitHubMinRequestInterval() time.Duration { return ins.GitHubMinRequestInterval }
+func GetGitHubMinRequestInterval() time.Duration { return currentConfig().GitHubMinRequestInterval }
 
-func GetGitHubLowRemainingThreshold() int { return ins.GitHubLowRemainingThreshold }
+func GetGitHubLowRemainingThreshold() int { return currentConfig().GitHubLowRemainingThreshold }
 
-func GetGitHubScheduleJitter() time.Duration { return ins.GitHubScheduleJitter }
+func GetGitHubScheduleJitter() time.Duration { return currentConfig().GitHubScheduleJitter }
 
 func GetGitHubAPIConfig() githubapi.Config {
-	return githubapi.Config{Concurrency: ins.GitHubAPIConcurrency, MinRequestInterval: ins.GitHubMinRequestInterval, LowRemainingThreshold: ins.GitHubLowRemainingThreshold}
+	return gitHubAPIConfig(currentConfig())
+}
+
+func gitHubAPIConfig(cfg *Config) githubapi.Config {
+	if cfg == nil {
+		return githubapi.Config{}
+	}
+	return githubapi.Config{Concurrency: cfg.GitHubAPIConcurrency, MinRequestInterval: cfg.GitHubMinRequestInterval, LowRemainingThreshold: cfg.GitHubLowRemainingThreshold}
 }
 
 // GetRetryConfig assembles the retry configuration used by every GitHub API
@@ -207,23 +246,26 @@ func validateIdentity(cfg *Config) error {
 
 // Save persists the current in-memory config back to the config file via viper.
 func Save() error {
+	vpMu.Lock()
+	defer vpMu.Unlock()
 	if vp == nil {
 		return fmt.Errorf("config not initialized")
 	}
+	cfg := currentConfig()
 	// Update the viper config with current ins values
-	vp.Set("repository", ins.Repository)
-	vp.Set("storage", ins.Storage)
-	vp.Set("githubToken", ins.GitHubToken)
-	vp.Set("cocurrencyNum", ins.ConcurrencyNum)
-	vp.Set("releaseSizeLimit", ins.ReleaseSizeLimit)
-	vp.Set("releaseNumLimit", ins.ReleaseNumLimit)
-	vp.Set("retryMaxCount", ins.RetryMaxCount)
-	vp.Set("retryBaseDelay", ins.RetryBaseDelay)
-	vp.Set("syncOverdueGrace", ins.SyncOverdueGrace)
-	vp.Set("syncStuckThreshold", ins.SyncStuckThreshold)
-	vp.Set("githubApiConcurrency", ins.GitHubAPIConcurrency)
-	vp.Set("githubMinRequestInterval", ins.GitHubMinRequestInterval)
-	vp.Set("githubLowRemainingThreshold", ins.GitHubLowRemainingThreshold)
-	vp.Set("githubScheduleJitter", ins.GitHubScheduleJitter)
+	vp.Set("repository", cfg.Repository)
+	vp.Set("storage", cfg.Storage)
+	vp.Set("githubToken", cfg.GitHubToken)
+	vp.Set("cocurrencyNum", cfg.ConcurrencyNum)
+	vp.Set("releaseSizeLimit", cfg.ReleaseSizeLimit)
+	vp.Set("releaseNumLimit", cfg.ReleaseNumLimit)
+	vp.Set("retryMaxCount", cfg.RetryMaxCount)
+	vp.Set("retryBaseDelay", cfg.RetryBaseDelay)
+	vp.Set("syncOverdueGrace", cfg.SyncOverdueGrace)
+	vp.Set("syncStuckThreshold", cfg.SyncStuckThreshold)
+	vp.Set("githubApiConcurrency", cfg.GitHubAPIConcurrency)
+	vp.Set("githubMinRequestInterval", cfg.GitHubMinRequestInterval)
+	vp.Set("githubLowRemainingThreshold", cfg.GitHubLowRemainingThreshold)
+	vp.Set("githubScheduleJitter", cfg.GitHubScheduleJitter)
 	return vp.WriteConfig()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -190,4 +192,80 @@ func TestValidateIdentity(t *testing.T) {
 
 	// 空仓库列表 → 通过。
 	require.NoError(t, validateIdentity(&Config{}))
+}
+
+func TestSetInsPublishesDefensiveImmutableSnapshots(t *testing.T) {
+	previous := GetIns()
+	t.Cleanup(func() {
+		if previous == nil {
+			SetIns(&Config{})
+			return
+		}
+		SetIns(previous)
+	})
+
+	input := &Config{
+		Repository: []typedef.Repository{{
+			Name:    "original",
+			URL:     "github.com/acme/original",
+			Storage: []string{"archive"},
+		}},
+		Storage: []typedef.MultiStorage{{Storage: typedef.Storage{Name: "archive", Type: "file", Path: "old"}}},
+	}
+	SetIns(input)
+	input.Repository[0].Name = "input mutation"
+	input.Repository[0].Storage[0] = "input mutation"
+	input.Storage[0].Path = "input mutation"
+
+	callerSnapshot := GetIns()
+	callerSnapshot.Repository[0].Name = "caller mutation"
+	callerSnapshot.Repository[0].Storage[0] = "caller mutation"
+	callerSnapshot.Storage[0].Path = "caller mutation"
+
+	actual := GetIns()
+	require.Equal(t, "original", actual.Repository[0].Name)
+	require.Equal(t, []string{"archive"}, actual.Repository[0].Storage)
+	require.Equal(t, "old", actual.Storage[0].Path)
+}
+
+func TestConcurrentConfigPublicationAndSnapshotReads(t *testing.T) {
+	previous := GetIns()
+	t.Cleanup(func() { SetIns(previous) })
+	configs := []*Config{
+		{Repository: []typedef.Repository{{Name: "one", URL: "github.com/acme/one"}}, SyncOverdueGrace: time.Minute},
+		{Repository: []typedef.Repository{{Name: "two", URL: "github.com/acme/two"}}, SyncOverdueGrace: 2 * time.Minute},
+	}
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	var incoherent atomic.Bool
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		<-start
+		for index := 0; index < 1000; index++ {
+			SetIns(configs[index%len(configs)])
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		<-start
+		for index := 0; index < 1000; index++ {
+			snapshot := GetIns()
+			if snapshot == nil || len(snapshot.Repository) == 0 {
+				continue
+			}
+			switch snapshot.Repository[0].Name {
+			case "one":
+				incoherent.CompareAndSwap(false, snapshot.SyncOverdueGrace != time.Minute)
+			case "two":
+				incoherent.CompareAndSwap(false, snapshot.SyncOverdueGrace != 2*time.Minute)
+			default:
+				incoherent.Store(true)
+			}
+			_ = GetSyncOverdueGrace()
+		}
+	}()
+	close(start)
+	workers.Wait()
+	require.False(t, incoherent.Load(), "observed partial configuration generation")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,6 +32,31 @@ func TestGetRetryDefaults(t *testing.T) {
 	require.Equal(t, 5*time.Second, rc.BaseDelay)
 }
 
+func TestSyncHealthDefaults(t *testing.T) {
+	cfg := &Config{}
+	seedDefaults(cfg)
+	require.Equal(t, 30*time.Minute, cfg.SyncOverdueGrace)
+	require.Equal(t, 24*time.Hour, cfg.SyncStuckThreshold)
+}
+
+func TestSyncHealthNonPositiveValuesUseDefaults(t *testing.T) {
+	cfg := &Config{SyncOverdueGrace: -time.Second, SyncStuckThreshold: -time.Second}
+	seedDefaults(cfg)
+	require.Equal(t, DefaultSyncOverdueGrace, cfg.SyncOverdueGrace)
+	require.Equal(t, DefaultSyncStuckThreshold, cfg.SyncStuckThreshold)
+}
+
+func TestSyncHealthGettersAndSaveRoundTrip(t *testing.T) {
+	writeTmpConfig(t, "githubtoken: test\nsyncOverdueGrace: 45m\nsyncStuckThreshold: 12h\n")
+	require.Equal(t, 45*time.Minute, GetSyncOverdueGrace())
+	require.Equal(t, 12*time.Hour, GetSyncStuckThreshold())
+
+	require.NoError(t, Save())
+	Init()
+	require.Equal(t, 45*time.Minute, GetSyncOverdueGrace())
+	require.Equal(t, 12*time.Hour, GetSyncStuckThreshold())
+}
+
 func TestGetGitHubAPIDefaults(t *testing.T) {
 	writeTmpConfig(t, "githubtoken: test\n")
 	require.Equal(t, uint(2), GetGitHubAPIConcurrency())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -244,6 +244,10 @@ func TestConcurrentConfigPublicationAndSnapshotReads(t *testing.T) {
 		{Repository: []typedef.Repository{{Name: "one", URL: "github.com/acme/one"}}, SyncOverdueGrace: time.Minute},
 		{Repository: []typedef.Repository{{Name: "two", URL: "github.com/acme/two"}}, SyncOverdueGrace: 2 * time.Minute},
 	}
+	// Seed an allowed generation before either goroutine starts. Under -count,
+	// a prior reload test may leave a coherent but unrelated package snapshot;
+	// observing that snapshot is not evidence of a torn publication.
+	SetIns(configs[0])
 	start := make(chan struct{})
 	var workers sync.WaitGroup
 	var incoherent atomic.Bool

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -387,12 +386,14 @@ func TestConcurrentSetInsKeepsConfigAndGitHubCoordinatorPaired(t *testing.T) {
 	require.Equal(t, uint64(2), appliedConcurrency.Load())
 }
 
-func TestSetInsPublicationExcludesConfigAndCoordinatorReaders(t *testing.T) {
+func TestSetInsPublicationExcludesConfigReaders(t *testing.T) {
 	previousConfig := GetIns()
 	previousPublish := publishGitHubAPI
 	SetIns(&Config{GitHubToken: "old", GitHubAPIConcurrency: 1})
-	oldPermit, err := githubapi.Acquire(context.Background(), "core")
-	require.NoError(t, err)
+	t.Cleanup(func() {
+		publishGitHubAPI = previousPublish
+		SetIns(previousConfig)
+	})
 
 	publishEntered := make(chan struct{})
 	publishRelease := make(chan struct{})
@@ -407,57 +408,89 @@ func TestSetInsPublicationExcludesConfigAndCoordinatorReaders(t *testing.T) {
 	}
 
 	publishDone := make(chan struct{})
+	var publishReleaseOnce sync.Once
+	var publishWorkers sync.WaitGroup
+	publishWorkers.Add(1)
 	go func() {
+		defer publishWorkers.Done()
 		SetIns(&Config{GitHubToken: "new", GitHubAPIConcurrency: 2})
 		close(publishDone)
 	}()
-	<-publishEntered
 
-	configReadStarted := make(chan struct{})
+	readerEntered := make(chan struct{}, 2)
+	readerProceed := make(chan struct{})
+	var readerProceedOnce sync.Once
+	var readerWorkers sync.WaitGroup
+	t.Cleanup(func() {
+		publishReleaseOnce.Do(func() { close(publishRelease) })
+		publishWorkers.Wait()
+		readerProceedOnce.Do(func() { close(readerProceed) })
+		readerWorkers.Wait()
+	})
+	select {
+	case <-publishEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for publication writer")
+	}
+
+	readHook := &configPublicationReadTestHook{read: func(read func()) {
+		readerEntered <- struct{}{}
+		<-readerProceed
+		githubapi.ReadPublication(read)
+	}}
+	configPublicationReadHookForTest.Store(readHook)
+	t.Cleanup(func() { configPublicationReadHookForTest.CompareAndSwap(readHook, nil) })
+
 	configReadDone := make(chan *Config, 1)
+	readerWorkers.Add(2)
 	go func() {
-		close(configReadStarted)
+		defer readerWorkers.Done()
 		configReadDone <- GetIns()
 	}()
-	<-configReadStarted
-
-	acquireCtx, cancelAcquire := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancelAcquire()
-	type acquireResult struct {
-		permit githubapi.Permit
-		err    error
-	}
-	acquireStarted := make(chan struct{})
-	acquireDone := make(chan acquireResult, 1)
+	scalarReadDone := make(chan uint, 1)
 	go func() {
-		close(acquireStarted)
-		permit, acquireErr := githubapi.Acquire(acquireCtx, "core")
-		acquireDone <- acquireResult{permit: permit, err: acquireErr}
+		defer readerWorkers.Done()
+		scalarReadDone <- GetGitHubAPIConcurrency()
 	}()
-	<-acquireStarted
+	for range 2 {
+		select {
+		case <-readerEntered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for config reader to reach the pre-read barrier")
+		}
+	}
+	select {
+	case <-configReadDone:
+		t.Fatal("GetIns returned while blocked inside the publication read gate")
+	default:
+	}
+	select {
+	case <-scalarReadDone:
+		t.Fatal("scalar getter returned while blocked inside the publication read gate")
+	default:
+	}
 
-	configReturnedDuringPublication := false
+	publishReleaseOnce.Do(func() { close(publishRelease) })
+	select {
+	case <-publishDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for publication writer completion")
+	}
+	readerProceedOnce.Do(func() { close(readerProceed) })
+
 	var publishedConfig *Config
 	select {
 	case publishedConfig = <-configReadDone:
-		configReturnedDuringPublication = true
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for GetIns")
 	}
-	close(publishRelease)
-	<-publishDone
+	var publishedConcurrency uint
+	select {
+	case publishedConcurrency = <-scalarReadDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for scalar config getter")
+	}
 
-	if publishedConfig == nil {
-		publishedConfig = <-configReadDone
-	}
-	acquired := <-acquireDone
-	oldPermit.Done(githubapi.Observation{})
-	if acquired.permit != nil {
-		acquired.permit.Done(githubapi.Observation{})
-	}
-	publishGitHubAPI = previousPublish
-	SetIns(previousConfig)
-
-	assert.False(t, configReturnedDuringPublication, "GetIns observed the ins-before-coordinator publication window")
 	require.Equal(t, "new", publishedConfig.GitHubToken)
-	assert.NoError(t, acquired.err, "Acquire remained queued on the saturated old coordinator")
+	require.Equal(t, uint(2), publishedConcurrency)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,12 +1,14 @@
 package config
 
 import (
+	"context"
 	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/typedef"
@@ -229,6 +231,13 @@ func TestSetInsPublishesDefensiveImmutableSnapshots(t *testing.T) {
 	require.Equal(t, "old", actual.Storage[0].Path)
 }
 
+func TestGetInsPreservesUninitializedNil(t *testing.T) {
+	previous := GetIns()
+	t.Cleanup(func() { SetIns(previous) })
+	SetIns(nil)
+	require.Nil(t, GetIns())
+}
+
 func TestConcurrentConfigPublicationAndSnapshotReads(t *testing.T) {
 	previous := GetIns()
 	t.Cleanup(func() { SetIns(previous) })
@@ -281,22 +290,71 @@ func TestGetViperReturnsDetachedSnapshot(t *testing.T) {
 	require.Equal(t, "8081", GetViper().GetString("server.port"))
 }
 
+func TestGetViperReturnsDeepDetachedCompositeSnapshot(t *testing.T) {
+	writeTmpConfig(t, `repository:
+  - name: original
+    url: github.com/acme/original
+    storage:
+      - archive
+storage:
+  - name: archive
+    type: file
+    path: original-path
+`)
+	// Save installs typed slices in viper, which is the aliasing path a shallow
+	// AllSettings/MergeConfigMap copy fails to detach.
+	require.NoError(t, Save())
+
+	detached := GetViper()
+	repositories, ok := detached.Get("repository").([]typedef.Repository)
+	require.Truef(t, ok, "repository setting has unexpected type %T", detached.Get("repository"))
+	storages, ok := detached.Get("storage").([]typedef.MultiStorage)
+	require.Truef(t, ok, "storage setting has unexpected type %T", detached.Get("storage"))
+	repositories[0].Name = "detached mutation"
+	repositories[0].Storage[0] = "detached mutation"
+	storages[0].Path = "detached mutation"
+
+	fresh := GetViper()
+	freshRepositories, ok := fresh.Get("repository").([]typedef.Repository)
+	require.Truef(t, ok, "fresh repository setting has unexpected type %T", fresh.Get("repository"))
+	freshStorages, ok := fresh.Get("storage").([]typedef.MultiStorage)
+	require.Truef(t, ok, "fresh storage setting has unexpected type %T", fresh.Get("storage"))
+	live := GetIns()
+	assert.Equal(t, "original", freshRepositories[0].Name)
+	assert.Equal(t, []string{"archive"}, freshRepositories[0].Storage)
+	assert.Equal(t, "original-path", freshStorages[0].Path)
+	assert.Equal(t, "original", live.Repository[0].Name)
+	assert.Equal(t, []string{"archive"}, live.Repository[0].Storage)
+	assert.Equal(t, "original-path", live.Storage[0].Path)
+
+	require.NoError(t, Save())
+	saved, err := os.ReadFile(Path)
+	require.NoError(t, err)
+	assert.Contains(t, string(saved), "name: original")
+	assert.Contains(t, string(saved), "- archive")
+	assert.Contains(t, string(saved), "path: original-path")
+	assert.NotContains(t, string(saved), "detached mutation")
+}
+
 func TestConcurrentSetInsKeepsConfigAndGitHubCoordinatorPaired(t *testing.T) {
 	previousConfig := GetIns()
-	previousConfigure := configureGitHubAPI
+	previousPublish := publishGitHubAPI
 	t.Cleanup(func() {
-		configureGitHubAPI = previousConfigure
+		publishGitHubAPI = previousPublish
 		SetIns(previousConfig)
 	})
 
 	firstConfigureEntered := make(chan struct{})
 	firstConfigureRelease := make(chan struct{})
 	var appliedConcurrency atomic.Uint64
-	configureGitHubAPI = func(cfg githubapi.Config) {
-		if cfg.Concurrency == 1 {
-			close(firstConfigureEntered)
-			<-firstConfigureRelease
-		}
+	publishGitHubAPI = func(cfg githubapi.Config, install func()) {
+		previousPublish(cfg, func() {
+			install()
+			if cfg.Concurrency == 1 {
+				close(firstConfigureEntered)
+				<-firstConfigureRelease
+			}
+		})
 		appliedConcurrency.Store(uint64(cfg.Concurrency))
 	}
 
@@ -327,4 +385,79 @@ func TestConcurrentSetInsKeepsConfigAndGitHubCoordinatorPaired(t *testing.T) {
 	require.Equal(t, "two", GetIns().GitHubToken)
 	require.Equal(t, uint(2), GetIns().GitHubAPIConcurrency)
 	require.Equal(t, uint64(2), appliedConcurrency.Load())
+}
+
+func TestSetInsPublicationExcludesConfigAndCoordinatorReaders(t *testing.T) {
+	previousConfig := GetIns()
+	previousPublish := publishGitHubAPI
+	SetIns(&Config{GitHubToken: "old", GitHubAPIConcurrency: 1})
+	oldPermit, err := githubapi.Acquire(context.Background(), "core")
+	require.NoError(t, err)
+
+	publishEntered := make(chan struct{})
+	publishRelease := make(chan struct{})
+	publishGitHubAPI = func(cfg githubapi.Config, install func()) {
+		previousPublish(cfg, func() {
+			install()
+			if cfg.Concurrency == 2 {
+				close(publishEntered)
+				<-publishRelease
+			}
+		})
+	}
+
+	publishDone := make(chan struct{})
+	go func() {
+		SetIns(&Config{GitHubToken: "new", GitHubAPIConcurrency: 2})
+		close(publishDone)
+	}()
+	<-publishEntered
+
+	configReadStarted := make(chan struct{})
+	configReadDone := make(chan *Config, 1)
+	go func() {
+		close(configReadStarted)
+		configReadDone <- GetIns()
+	}()
+	<-configReadStarted
+
+	acquireCtx, cancelAcquire := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelAcquire()
+	type acquireResult struct {
+		permit githubapi.Permit
+		err    error
+	}
+	acquireStarted := make(chan struct{})
+	acquireDone := make(chan acquireResult, 1)
+	go func() {
+		close(acquireStarted)
+		permit, acquireErr := githubapi.Acquire(acquireCtx, "core")
+		acquireDone <- acquireResult{permit: permit, err: acquireErr}
+	}()
+	<-acquireStarted
+
+	configReturnedDuringPublication := false
+	var publishedConfig *Config
+	select {
+	case publishedConfig = <-configReadDone:
+		configReturnedDuringPublication = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(publishRelease)
+	<-publishDone
+
+	if publishedConfig == nil {
+		publishedConfig = <-configReadDone
+	}
+	acquired := <-acquireDone
+	oldPermit.Done(githubapi.Observation{})
+	if acquired.permit != nil {
+		acquired.permit.Done(githubapi.Observation{})
+	}
+	publishGitHubAPI = previousPublish
+	SetIns(previousConfig)
+
+	assert.False(t, configReturnedDuringPublication, "GetIns observed the ins-before-coordinator publication window")
+	require.Equal(t, "new", publishedConfig.GitHubToken)
+	assert.NoError(t, acquired.err, "Acquire remained queued on the saturated old coordinator")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 )
 
@@ -268,4 +269,62 @@ func TestConcurrentConfigPublicationAndSnapshotReads(t *testing.T) {
 	close(start)
 	workers.Wait()
 	require.False(t, incoherent.Load(), "observed partial configuration generation")
+}
+
+func TestGetViperReturnsDetachedSnapshot(t *testing.T) {
+	writeTmpConfig(t, "server:\n  port: \"8081\"\n")
+	detached := GetViper()
+	require.NotNil(t, detached)
+	detached.Set("server.port", "9999")
+
+	require.Equal(t, "8081", GetServerSection().Port)
+	require.Equal(t, "8081", GetViper().GetString("server.port"))
+}
+
+func TestConcurrentSetInsKeepsConfigAndGitHubCoordinatorPaired(t *testing.T) {
+	previousConfig := GetIns()
+	previousConfigure := configureGitHubAPI
+	t.Cleanup(func() {
+		configureGitHubAPI = previousConfigure
+		SetIns(previousConfig)
+	})
+
+	firstConfigureEntered := make(chan struct{})
+	firstConfigureRelease := make(chan struct{})
+	var appliedConcurrency atomic.Uint64
+	configureGitHubAPI = func(cfg githubapi.Config) {
+		if cfg.Concurrency == 1 {
+			close(firstConfigureEntered)
+			<-firstConfigureRelease
+		}
+		appliedConcurrency.Store(uint64(cfg.Concurrency))
+	}
+
+	firstDone := make(chan struct{})
+	go func() {
+		SetIns(&Config{GitHubToken: "one", GitHubAPIConcurrency: 1})
+		close(firstDone)
+	}()
+	<-firstConfigureEntered
+	secondStarted := make(chan struct{})
+	secondDone := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		SetIns(&Config{GitHubToken: "two", GitHubAPIConcurrency: 2})
+		close(secondDone)
+	}()
+	<-secondStarted
+
+	lockedAcrossConfigure := !stateMu.TryLock()
+	if !lockedAcrossConfigure {
+		stateMu.Unlock()
+	}
+	close(firstConfigureRelease)
+	<-firstDone
+	<-secondDone
+
+	require.True(t, lockedAcrossConfigure, "config state lock was released before GitHub coordinator publication")
+	require.Equal(t, "two", GetIns().GitHubToken)
+	require.Equal(t, uint(2), GetIns().GitHubAPIConcurrency)
+	require.Equal(t, uint64(2), appliedConcurrency.Load())
 }

--- a/internal/config/importexport.go
+++ b/internal/config/importexport.go
@@ -77,7 +77,9 @@ type ExportConfig struct {
 // it falls back to the global viper singleton so callers can still override
 // settings directly.
 func GetServerSection() ServerSection {
-	v := GetViper()
+	vpMu.Lock()
+	defer vpMu.Unlock()
+	v := vp
 	if v == nil {
 		v = viper.GetViper()
 	}
@@ -136,7 +138,10 @@ func Export() (string, error) {
 // exits the process: on any error the previous in-memory config is kept and the
 // error returned (the running server must survive a bad config file).
 func Reload() error {
-	if vp == nil {
+	vpMu.Lock()
+	initialized := vp != nil
+	vpMu.Unlock()
+	if !initialized {
 		return fmt.Errorf("config not initialized")
 	}
 	// A fresh viper avoids inheriting override keys: Save()/SetServerField leave
@@ -158,7 +163,9 @@ func Reload() error {
 	if err := validateIdentity(&next); err != nil {
 		return err
 	}
+	vpMu.Lock()
 	vp = nv
+	vpMu.Unlock()
 	SetIns(&next)
 	return nil
 }
@@ -281,6 +288,8 @@ func ValidateImport(doc *ExportConfig) []string {
 // never re-reads the server section, so this only takes effect after a restart.
 // Returns an error when the config was never initialized.
 func SetServerField(field string, value interface{}) error {
+	vpMu.Lock()
+	defer vpMu.Unlock()
 	if vp == nil {
 		return fmt.Errorf("config not initialized")
 	}

--- a/internal/config/importexport.go
+++ b/internal/config/importexport.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var readConfigFile = func(v *viper.Viper) error { return v.ReadInConfig() }
+
 // ServerSection mirrors the `server:` section of config.yaml. It carries both
 // yaml and mapstructure tags so it can be (de)serialized directly and read via
 // viper's UnmarshalKey.
@@ -139,9 +141,12 @@ func Export() (string, error) {
 // error returned (the running server must survive a bad config file).
 func Reload() error {
 	stateMu.Lock()
-	initialized := vp != nil
-	stateMu.Unlock()
-	if !initialized {
+	defer stateMu.Unlock()
+	return reloadLocked()
+}
+
+func reloadLocked() error {
+	if vp == nil {
 		return fmt.Errorf("config not initialized")
 	}
 	// A fresh viper avoids inheriting override keys: Save()/SetServerField leave
@@ -149,7 +154,7 @@ func Reload() error {
 	// the stale overrides on top of the freshly-read file.
 	nv := viper.New()
 	nv.SetConfigFile(Path)
-	if err := nv.ReadInConfig(); err != nil {
+	if err := readConfigFile(nv); err != nil {
 		return fmt.Errorf("failed to read config file: %w", err)
 	}
 	var next Config
@@ -164,10 +169,8 @@ func Reload() error {
 		return err
 	}
 	snapshot := Clone(&next)
-	stateMu.Lock()
 	vp = nv
 	setInsLocked(snapshot)
-	stateMu.Unlock()
 	return nil
 }
 

--- a/internal/config/importexport.go
+++ b/internal/config/importexport.go
@@ -77,8 +77,8 @@ type ExportConfig struct {
 // it falls back to the global viper singleton so callers can still override
 // settings directly.
 func GetServerSection() ServerSection {
-	vpMu.Lock()
-	defer vpMu.Unlock()
+	stateMu.Lock()
+	defer stateMu.Unlock()
 	v := vp
 	if v == nil {
 		v = viper.GetViper()
@@ -138,9 +138,9 @@ func Export() (string, error) {
 // exits the process: on any error the previous in-memory config is kept and the
 // error returned (the running server must survive a bad config file).
 func Reload() error {
-	vpMu.Lock()
+	stateMu.Lock()
 	initialized := vp != nil
-	vpMu.Unlock()
+	stateMu.Unlock()
 	if !initialized {
 		return fmt.Errorf("config not initialized")
 	}
@@ -163,10 +163,11 @@ func Reload() error {
 	if err := validateIdentity(&next); err != nil {
 		return err
 	}
-	vpMu.Lock()
+	snapshot := Clone(&next)
+	stateMu.Lock()
 	vp = nv
-	vpMu.Unlock()
-	SetIns(&next)
+	setInsLocked(snapshot)
+	stateMu.Unlock()
 	return nil
 }
 
@@ -288,8 +289,8 @@ func ValidateImport(doc *ExportConfig) []string {
 // never re-reads the server section, so this only takes effect after a restart.
 // Returns an error when the config was never initialized.
 func SetServerField(field string, value interface{}) error {
-	vpMu.Lock()
-	defer vpMu.Unlock()
+	stateMu.Lock()
+	defer stateMu.Unlock()
 	if vp == nil {
 		return fmt.Errorf("config not initialized")
 	}

--- a/internal/config/importexport.go
+++ b/internal/config/importexport.go
@@ -136,18 +136,33 @@ func Export() (string, error) {
 	return ExportFrom(GetIns())
 }
 
-// Reload re-reads the config file into the package global. Unlike Init it never
-// exits the process: on any error the previous in-memory config is kept and the
-// error returned (the running server must survive a bad config file).
-func Reload() error {
-	stateMu.Lock()
-	defer stateMu.Unlock()
-	return reloadLocked()
+// ReloadSnapshot is a validated, unpublished config-file generation. Its
+// internals remain private so callers cannot mutate the config or viper state
+// between the read and the unified publication boundary.
+type ReloadSnapshot struct {
+	config *Config
+	viper  *viper.Viper
 }
 
-func reloadLocked() error {
+// Config returns a defensive copy of the unpublished disk generation.
+func (s *ReloadSnapshot) Config() *Config {
+	if s == nil {
+		return nil
+	}
+	return Clone(s.config)
+}
+
+// ReadReloadSnapshot reads, unmarshals, defaults, and validates config.yaml
+// without changing any package-global or runtime state.
+func ReadReloadSnapshot() (*ReloadSnapshot, error) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	return readReloadSnapshotLocked()
+}
+
+func readReloadSnapshotLocked() (*ReloadSnapshot, error) {
 	if vp == nil {
-		return fmt.Errorf("config not initialized")
+		return nil, fmt.Errorf("config not initialized")
 	}
 	// A fresh viper avoids inheriting override keys: Save()/SetServerField leave
 	// vp.Set() overrides that ReadInConfig never clears, so Unmarshal would merge
@@ -155,22 +170,44 @@ func reloadLocked() error {
 	nv := viper.New()
 	nv.SetConfigFile(Path)
 	if err := readConfigFile(nv); err != nil {
-		return fmt.Errorf("failed to read config file: %w", err)
+		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 	var next Config
 	if err := nv.Unmarshal(&next); err != nil {
-		return fmt.Errorf("failed to unmarshal config file: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal config file: %w", err)
 	}
 	seedDefaults(&next)
 	if !nv.IsSet("githubScheduleJitter") {
 		next.GitHubScheduleJitter = 30 * time.Second
 	}
 	if err := validateIdentity(&next); err != nil {
+		return nil, err
+	}
+	return &ReloadSnapshot{config: Clone(&next), viper: nv}, nil
+}
+
+// PublishReloadSnapshot installs a previously validated disk generation
+// without re-reading or writing config.yaml. Package config, GitHub policy, and
+// install's immutable runtime state share the normal publication boundary.
+func PublishReloadSnapshot(snapshot *ReloadSnapshot, install func(*Config)) *Config {
+	if snapshot == nil {
+		return nil
+	}
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	return publishSnapshotLocked(snapshot.config, snapshot.viper, install)
+}
+
+// Reload preserves the package-level behavior for non-server callers while
+// holding stateMu across the complete disk-read-to-publication operation.
+func Reload() error {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	snapshot, err := readReloadSnapshotLocked()
+	if err != nil {
 		return err
 	}
-	snapshot := Clone(&next)
-	vp = nv
-	setInsLocked(snapshot)
+	publishSnapshotLocked(snapshot.config, snapshot.viper, nil)
 	return nil
 }
 

--- a/internal/config/importexport.go
+++ b/internal/config/importexport.go
@@ -33,7 +33,7 @@ func (d DurationString) MarshalYAML() (interface{}, error) {
 
 func (d *DurationString) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.ScalarNode {
-		return fmt.Errorf("retryBaseDelay must be a string or integer")
+		return fmt.Errorf("duration must be a string or integer")
 	}
 	if node.Tag == "!!int" {
 		n, err := strconv.ParseInt(node.Value, 10, 64)
@@ -45,7 +45,7 @@ func (d *DurationString) UnmarshalYAML(node *yaml.Node) error {
 	}
 	parsed, err := time.ParseDuration(node.Value)
 	if err != nil {
-		return fmt.Errorf("invalid retryBaseDelay %q: %w", node.Value, err)
+		return fmt.Errorf("invalid duration %q: %w", node.Value, err)
 	}
 	*d = DurationString(parsed)
 	return nil
@@ -62,6 +62,8 @@ type ExportConfig struct {
 	ReleaseNumLimit             int                    `yaml:"releaseNumLimit"`
 	RetryMaxCount               int                    `yaml:"retryMaxCount"`
 	RetryBaseDelay              DurationString         `yaml:"retryBaseDelay"`
+	SyncOverdueGrace            DurationString         `yaml:"syncOverdueGrace"`
+	SyncStuckThreshold          DurationString         `yaml:"syncStuckThreshold"`
 	GitHubAPIConcurrency        uint                   `yaml:"githubApiConcurrency"`
 	GitHubMinRequestInterval    DurationString         `yaml:"githubMinRequestInterval"`
 	GitHubLowRemainingThreshold int                    `yaml:"githubLowRemainingThreshold"`
@@ -110,6 +112,8 @@ func ExportFrom(cfg *Config) (string, error) {
 		ReleaseNumLimit:             cfg.ReleaseNumLimit,
 		RetryMaxCount:               cfg.RetryMaxCount,
 		RetryBaseDelay:              DurationString(cfg.RetryBaseDelay),
+		SyncOverdueGrace:            DurationString(cfg.SyncOverdueGrace),
+		SyncStuckThreshold:          DurationString(cfg.SyncStuckThreshold),
 		GitHubAPIConcurrency:        cfg.GitHubAPIConcurrency,
 		GitHubMinRequestInterval:    DurationString(cfg.GitHubMinRequestInterval),
 		GitHubLowRemainingThreshold: cfg.GitHubLowRemainingThreshold,
@@ -168,6 +172,12 @@ func seedExportDefaults(doc *ExportConfig, jitterPresent bool) {
 	}
 	if time.Duration(doc.RetryBaseDelay) <= 0 {
 		doc.RetryBaseDelay = DurationString(5 * time.Second)
+	}
+	if time.Duration(doc.SyncOverdueGrace) <= 0 {
+		doc.SyncOverdueGrace = DurationString(DefaultSyncOverdueGrace)
+	}
+	if time.Duration(doc.SyncStuckThreshold) <= 0 {
+		doc.SyncStuckThreshold = DurationString(DefaultSyncStuckThreshold)
 	}
 	if doc.ConcurrencyNum == 0 {
 		doc.ConcurrencyNum = 3

--- a/internal/config/importexport_test.go
+++ b/internal/config/importexport_test.go
@@ -108,8 +108,10 @@ func TestReloadAfterSave(t *testing.T) {
 	writeTmpConfig(t, "githubToken: aaa\nrepository:\n  - name: one\n    url: github.com/one/repo\n")
 	require.Equal(t, "aaa", GetIns().GitHubToken)
 
-	// Simulate applyImport mutating the in-memory config, then persisting.
-	GetIns().GitHubToken = "zzz"
+	// Simulate applyImport publishing a copy-on-write config, then persisting.
+	next := GetIns()
+	next.GitHubToken = "zzz"
+	SetIns(next)
 	require.NoError(t, Save())
 
 	// The operator restores/edits config.yaml on disk to something else.

--- a/internal/config/importexport_test.go
+++ b/internal/config/importexport_test.go
@@ -90,6 +90,31 @@ func TestReload(t *testing.T) {
 	Path = ""
 }
 
+func TestReadReloadSnapshotDoesNotPublishUntilExplicitBoundary(t *testing.T) {
+	writeTmpConfig(t, "githubToken: old\nrepository:\n  - name: old\n    url: github.com/acme/old\n")
+	reloadFile, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	require.NoError(t, err)
+	readBytes := []byte("githubToken: read\nrepository:\n  - name: read\n    url: github.com/acme/read\n")
+	_, err = reloadFile.Write(readBytes)
+	require.NoError(t, err)
+	require.NoError(t, reloadFile.Close())
+	Path = reloadFile.Name()
+	t.Cleanup(func() { Path = "" })
+
+	loaded, err := ReadReloadSnapshot()
+	require.NoError(t, err)
+	require.Equal(t, "old", GetIns().GitHubToken, "validated disk read must remain unpublished")
+	require.Equal(t, "read", loaded.Config().GitHubToken)
+
+	afterRead := []byte("# external edit after read\ngithubToken: edited\n")
+	require.NoError(t, os.WriteFile(Path, afterRead, 0o644))
+	PublishReloadSnapshot(loaded, nil)
+	require.Equal(t, "read", GetIns().GitHubToken)
+	actual, err := os.ReadFile(Path)
+	require.NoError(t, err)
+	require.Equal(t, afterRead, actual, "publishing a read snapshot must never rewrite later disk edits")
+}
+
 func TestReloadRejectsIdentitylessRepo(t *testing.T) {
 	writeTmpConfig(t, "repository:\n  - name: one\n    url: github.com/one/repo\n")
 	tmp, err := os.CreateTemp(t.TempDir(), "config-*.yaml")

--- a/internal/config/importexport_test.go
+++ b/internal/config/importexport_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 	"gopkg.in/yaml.v3"
 )
@@ -126,6 +127,68 @@ func TestReloadAfterSave(t *testing.T) {
 	require.Equal(t, "bbb", GetIns().GitHubToken, "reload must reflect the file, not stale Save() overrides")
 	require.Equal(t, "two", GetIns().Repository[0].Name)
 	Path = ""
+}
+
+func TestSaveSnapshotPersistsTheSuppliedGeneration(t *testing.T) {
+	writeTmpConfig(t, "githubToken: initial\nrepository:\n  - name: initial\n    url: github.com/acme/initial\n")
+	newer := &Config{GitHubToken: "newer", Repository: []typedef.Repository{{Name: "newer", URL: "github.com/acme/newer"}}}
+	SetIns(newer)
+	older := &Config{GitHubToken: "older", Repository: []typedef.Repository{{Name: "older", URL: "github.com/acme/older"}}}
+
+	require.NoError(t, SaveSnapshot(older))
+	saved, err := os.ReadFile(Path)
+	require.NoError(t, err)
+	require.Contains(t, string(saved), "githubtoken: older")
+	require.Contains(t, string(saved), "name: older")
+	require.Equal(t, "newer", GetIns().GitHubToken, "saving an explicit snapshot must not republish it")
+}
+
+func TestReloadAndSaveShareOneCoherentStateBoundary(t *testing.T) {
+	writeTmpConfig(t, "githubToken: old\nrepository:\n  - name: old\n    url: github.com/acme/old\n")
+	newFile, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	require.NoError(t, err)
+	_, err = newFile.WriteString("githubToken: new\ngithubApiConcurrency: 7\nrepository:\n  - name: new\n    url: github.com/acme/new\n")
+	require.NoError(t, err)
+	require.NoError(t, newFile.Close())
+	Path = newFile.Name()
+	t.Cleanup(func() { Path = "" })
+
+	previousConfigure := configureGitHubAPI
+	configureEntered := make(chan struct{})
+	configureRelease := make(chan struct{})
+	configureGitHubAPI = func(cfg githubapi.Config) {
+		if cfg.Concurrency == 7 {
+			close(configureEntered)
+			<-configureRelease
+		}
+		previousConfigure(cfg)
+	}
+	t.Cleanup(func() { configureGitHubAPI = previousConfigure })
+
+	reloadDone := make(chan error, 1)
+	go func() { reloadDone <- Reload() }()
+	<-configureEntered
+	saveStarted := make(chan struct{})
+	saveDone := make(chan error, 1)
+	go func() {
+		close(saveStarted)
+		saveDone <- Save()
+	}()
+	<-saveStarted
+	lockedAcrossReload := !stateMu.TryLock()
+	if !lockedAcrossReload {
+		stateMu.Unlock()
+	}
+	close(configureRelease)
+
+	require.NoError(t, <-reloadDone)
+	require.NoError(t, <-saveDone)
+	require.True(t, lockedAcrossReload, "reload released state lock between viper and config publication")
+	require.Equal(t, "new", GetIns().GitHubToken)
+	saved, err := os.ReadFile(Path)
+	require.NoError(t, err)
+	require.Contains(t, string(saved), "githubtoken: new")
+	require.NotContains(t, string(saved), "githubtoken: old")
 }
 
 func TestGetServerSectionReadsFromConfigFile(t *testing.T) {

--- a/internal/config/importexport_test.go
+++ b/internal/config/importexport_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 	"gopkg.in/yaml.v3"
 )
@@ -153,21 +153,30 @@ func TestReloadAndSaveShareOneCoherentStateBoundary(t *testing.T) {
 	Path = newFile.Name()
 	t.Cleanup(func() { Path = "" })
 
-	previousConfigure := configureGitHubAPI
-	configureEntered := make(chan struct{})
-	configureRelease := make(chan struct{})
-	configureGitHubAPI = func(cfg githubapi.Config) {
-		if cfg.Concurrency == 7 {
-			close(configureEntered)
-			<-configureRelease
+	previousReadConfigFile := readConfigFile
+	readComplete := make(chan struct{})
+	readRelease := make(chan struct{})
+	readConfigFile = func(v *viper.Viper) error {
+		err := previousReadConfigFile(v)
+		if err != nil {
+			return err
 		}
-		previousConfigure(cfg)
+		close(readComplete)
+		<-readRelease
+		return nil
 	}
-	t.Cleanup(func() { configureGitHubAPI = previousConfigure })
+	t.Cleanup(func() { readConfigFile = previousReadConfigFile })
 
 	reloadDone := make(chan error, 1)
 	go func() { reloadDone <- Reload() }()
-	<-configureEntered
+	<-readComplete
+
+	// The disk generation has been read, but Reload has not parsed or installed
+	// it yet. Reload must already own stateMu before Save is launched here.
+	reloadOwnsState := !stateMu.TryLock()
+	if !reloadOwnsState {
+		stateMu.Unlock()
+	}
 	saveStarted := make(chan struct{})
 	saveDone := make(chan error, 1)
 	go func() {
@@ -175,15 +184,22 @@ func TestReloadAndSaveShareOneCoherentStateBoundary(t *testing.T) {
 		saveDone <- Save()
 	}()
 	<-saveStarted
-	lockedAcrossReload := !stateMu.TryLock()
-	if !lockedAcrossReload {
-		stateMu.Unlock()
-	}
-	close(configureRelease)
 
-	require.NoError(t, <-reloadDone)
-	require.NoError(t, <-saveDone)
-	require.True(t, lockedAcrossReload, "reload released state lock between viper and config publication")
+	// On the broken implementation Reload does not own the lock, so Save can
+	// finish in the read-to-install window and overwrite generation B with A.
+	var saveErr error
+	if !reloadOwnsState {
+		saveErr = <-saveDone
+	}
+	close(readRelease)
+
+	reloadErr := <-reloadDone
+	if reloadOwnsState {
+		saveErr = <-saveDone
+	}
+	require.NoError(t, reloadErr)
+	require.NoError(t, saveErr)
+	require.True(t, reloadOwnsState, "reload did not serialize the disk read-to-install window against Save")
 	require.Equal(t, "new", GetIns().GitHubToken)
 	saved, err := os.ReadFile(Path)
 	require.NoError(t, err)

--- a/internal/config/importexport_test.go
+++ b/internal/config/importexport_test.go
@@ -25,18 +25,21 @@ func TestDurationStringYAML(t *testing.T) {
 
 	// A bad duration is rejected.
 	var doc ExportConfig
-	require.Error(t, yaml.Unmarshal([]byte("retryBaseDelay: 5pigs"), &doc))
+	err = yaml.Unmarshal([]byte("retryBaseDelay: 5pigs"), &doc)
+	require.ErrorContains(t, err, "invalid duration")
 }
 
 func TestExportFromRoundTrip(t *testing.T) {
 	writeTmpConfig(t, "server:\n  host: 127.0.0.1\n  port: \"8081\"\n")
 
 	cfg := &Config{
-		Repository:     []typedef.Repository{{Name: "r1", URL: "github.com/a/b"}},
-		Storage:        []typedef.MultiStorage{{Storage: typedef.Storage{Name: "local", Type: "file", Path: "/tmp"}}},
-		GitHubToken:    "tok",
-		ConcurrencyNum: 3,
-		RetryBaseDelay: 5 * time.Second,
+		Repository:         []typedef.Repository{{Name: "r1", URL: "github.com/a/b"}},
+		Storage:            []typedef.MultiStorage{{Storage: typedef.Storage{Name: "local", Type: "file", Path: "/tmp"}}},
+		GitHubToken:        "tok",
+		ConcurrencyNum:     3,
+		RetryBaseDelay:     5 * time.Second,
+		SyncOverdueGrace:   45 * time.Minute,
+		SyncStuckThreshold: 12 * time.Hour,
 	}
 	yamlStr, err := ExportFrom(cfg)
 	require.NoError(t, err)
@@ -44,13 +47,17 @@ func TestExportFromRoundTrip(t *testing.T) {
 	require.Contains(t, yamlStr, "url: github.com/a/b")
 	require.Contains(t, yamlStr, "githubToken: tok")
 	require.Contains(t, yamlStr, "retryBaseDelay: 5s")
+	require.Contains(t, yamlStr, "syncOverdueGrace: 45m0s")
+	require.Contains(t, yamlStr, "syncStuckThreshold: 12h0m0s")
 	require.Contains(t, yamlStr, "server:")
 	require.Contains(t, yamlStr, "host: 127.0.0.1")
 
 	// Round-trip: the exported YAML parses back with the same globals.
-	var doc ExportConfig
-	require.NoError(t, yaml.Unmarshal([]byte(yamlStr), &doc))
+	doc, err := ParseImport(yamlStr)
+	require.NoError(t, err)
 	require.Equal(t, DurationString(5*time.Second), doc.RetryBaseDelay)
+	require.Equal(t, DurationString(45*time.Minute), doc.SyncOverdueGrace)
+	require.Equal(t, DurationString(12*time.Hour), doc.SyncStuckThreshold)
 	require.Equal(t, "tok", doc.GitHubToken)
 	require.Equal(t, "127.0.0.1", doc.Server.Host)
 }
@@ -166,6 +173,8 @@ server:
 	require.Equal(t, "local", doc.Storage[0].Name)
 	require.Equal(t, "tok", doc.GitHubToken)
 	require.Equal(t, DurationString(5*time.Second), doc.RetryBaseDelay)
+	require.Equal(t, DurationString(DefaultSyncOverdueGrace), doc.SyncOverdueGrace)
+	require.Equal(t, DurationString(DefaultSyncStuckThreshold), doc.SyncStuckThreshold)
 	require.Equal(t, "127.0.0.1", doc.Server.Host)
 	require.Equal(t, "8081", doc.Server.Port)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -18,14 +18,17 @@ const componentSchema = `
 		FOREIGN KEY (execution_id) REFERENCES executions(id)
 	);
 
+	CREATE INDEX IF NOT EXISTS idx_execution_components_execution
+		ON execution_components(execution_id);
+`
+
+const executionIndexSchema = `
 	CREATE INDEX IF NOT EXISTS idx_executions_repo_start
 		ON executions(repo_key, start_time DESC);
 	CREATE INDEX IF NOT EXISTS idx_executions_repo_status_end
 		ON executions(repo_key, status, end_time DESC);
 	CREATE INDEX IF NOT EXISTS idx_executions_status
 		ON executions(status);
-	CREATE INDEX IF NOT EXISTS idx_execution_components_execution
-		ON execution_components(execution_id);
 `
 
 type DB struct {
@@ -84,6 +87,17 @@ func Initialize(path string) (*DB, error) {
 			FOREIGN KEY (execution_id) REFERENCES executions(id)
 		);
 	` + componentSchema)
+	if err != nil {
+		return &DB{db}, err
+	}
+
+	hasRepoKey, err := columnExists(&DB{db}, "executions", "repo_key")
+	if err != nil {
+		return &DB{db}, err
+	}
+	if hasRepoKey {
+		_, err = db.Exec(executionIndexSchema)
+	}
 
 	return &DB{db}, err
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -5,6 +5,29 @@ import (
 	_ "modernc.org/sqlite" // pure-Go SQLite driver, no CGo required
 )
 
+const componentSchema = `
+	CREATE TABLE IF NOT EXISTS execution_components (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		execution_id TEXT NOT NULL,
+		component TEXT NOT NULL,
+		status TEXT NOT NULL,
+		start_time DATETIME,
+		end_time DATETIME,
+		error_message TEXT,
+		UNIQUE(execution_id, component),
+		FOREIGN KEY (execution_id) REFERENCES executions(id)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_executions_repo_start
+		ON executions(repo_key, start_time DESC);
+	CREATE INDEX IF NOT EXISTS idx_executions_repo_status_end
+		ON executions(repo_key, status, end_time DESC);
+	CREATE INDEX IF NOT EXISTS idx_executions_status
+		ON executions(status);
+	CREATE INDEX IF NOT EXISTS idx_execution_components_execution
+		ON execution_components(execution_id);
+`
+
 type DB struct {
 	*sql.DB
 }
@@ -60,7 +83,7 @@ func Initialize(path string) (*DB, error) {
 			message TEXT NOT NULL,
 			FOREIGN KEY (execution_id) REFERENCES executions(id)
 		);
-	`)
+	` + componentSchema)
 
 	return &DB{db}, err
 }

--- a/internal/db/execution_store.go
+++ b/internal/db/execution_store.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
+
+var monotonicTimeSuffix = regexp.MustCompile(` m=[+-][0-9]+(\.[0-9]+)?$`)
 
 const interruptedExecutionMessage = "previous server process ended before completion"
 
@@ -344,8 +347,8 @@ func nullableAggregateTime(value interface{}) (*time.Time, error) {
 	// lets the driver scan directly into time.Time. A Go time.Time persisted by
 	// the driver can retain its optional monotonic annotation in that text form;
 	// it is not part of a wall-clock timestamp and time.Parse cannot read it.
-	if monotonic := strings.LastIndex(raw, " m="); monotonic >= 0 {
-		raw = raw[:monotonic]
+	if suffix := monotonicTimeSuffix.FindStringIndex(raw); suffix != nil {
+		raw = raw[:suffix[0]]
 	}
 	for _, layout := range []string{
 		"2006-01-02 15:04:05.999999999 -0700 MST",

--- a/internal/db/execution_store.go
+++ b/internal/db/execution_store.go
@@ -246,6 +246,113 @@ func (d *DB) ActiveExecutionExists(ctx context.Context, repoKey string) (bool, e
 	return exists, nil
 }
 
+// RepositoryRunStats loads the latest execution and cumulative outcome counts
+// for every repository key in one indexed query.
+func (d *DB) RepositoryRunStats(ctx context.Context) (map[string]RepositoryRunStats, error) {
+	rows, err := d.QueryContext(ctx, `
+		WITH ranked AS (
+			SELECT id, repo_key, start_time, end_time, status, error_message,
+			       ROW_NUMBER() OVER (
+				   PARTITION BY repo_key ORDER BY start_time DESC, id DESC
+			       ) AS rn
+			FROM executions WHERE repo_key <> ''
+		), totals AS (
+			SELECT repo_key,
+			       COUNT(*) AS total_runs,
+			       COALESCE(SUM(status = 'completed'), 0) AS success_runs,
+			       COALESCE(SUM(status = 'failed'), 0) AS failed_runs
+			FROM executions WHERE repo_key <> '' GROUP BY repo_key
+		), successes AS (
+			SELECT repo_key, MAX(end_time) AS last_success
+			FROM executions
+			WHERE repo_key <> '' AND status = 'completed'
+			GROUP BY repo_key
+		)
+		SELECT ranked.id, ranked.repo_key, ranked.start_time, ranked.end_time,
+		       ranked.status, ranked.error_message, successes.last_success,
+		       totals.total_runs, totals.success_runs, totals.failed_runs
+		FROM ranked
+		JOIN totals USING (repo_key)
+		LEFT JOIN successes USING (repo_key)
+		WHERE ranked.rn = 1`)
+	if err != nil {
+		return nil, fmt.Errorf("query repository run stats: %w", err)
+	}
+	defer rows.Close()
+
+	stats := make(map[string]RepositoryRunStats)
+	for rows.Next() {
+		var (
+			key            string
+			latest         RepositoryRunStats
+			latestEnd      sql.NullTime
+			latestError    sql.NullString
+			lastSuccessRaw interface{}
+		)
+		if err := rows.Scan(
+			&latest.LatestExecutionID,
+			&key,
+			&latest.LatestStart,
+			&latestEnd,
+			&latest.LatestStatus,
+			&latestError,
+			&lastSuccessRaw,
+			&latest.TotalRuns,
+			&latest.SuccessRuns,
+			&latest.FailedRuns,
+		); err != nil {
+			return nil, fmt.Errorf("scan repository run stats: %w", err)
+		}
+		if latestEnd.Valid {
+			end := latestEnd.Time
+			latest.LatestEnd = &end
+		}
+		if latestError.Valid {
+			latest.LatestError = latestError.String
+		}
+		lastSuccess, err := nullableAggregateTime(lastSuccessRaw)
+		if err != nil {
+			return nil, fmt.Errorf("scan last success for repository %q: %w", key, err)
+		}
+		latest.LastSuccess = lastSuccess
+		stats[key] = latest
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate repository run stats: %w", err)
+	}
+	return stats, nil
+}
+
+func nullableAggregateTime(value interface{}) (*time.Time, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if parsed, ok := value.(time.Time); ok {
+		return &parsed, nil
+	}
+
+	var raw string
+	switch value := value.(type) {
+	case string:
+		raw = value
+	case []byte:
+		raw = string(value)
+	default:
+		return nil, fmt.Errorf("unsupported timestamp type %T", value)
+	}
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05.999999999-07:00",
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999",
+	} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return &parsed, nil
+		}
+	}
+	return nil, fmt.Errorf("unsupported timestamp %q", raw)
+}
+
 // ReconcileInterrupted marks executions and component rows left active by a
 // previous server process as failed.
 func (d *DB) ReconcileInterrupted(ctx context.Context, now time.Time) error {

--- a/internal/db/execution_store.go
+++ b/internal/db/execution_store.go
@@ -249,35 +249,40 @@ func (d *DB) ActiveExecutionExists(ctx context.Context, repoKey string) (bool, e
 	return exists, nil
 }
 
+const repositoryRunStatsQuery = `
+	WITH totals AS (
+		SELECT repo_key,
+		       COUNT(*) AS total_runs,
+		       COALESCE(SUM(status = 'completed'), 0) AS success_runs,
+		       COALESCE(SUM(status = 'failed'), 0) AS failed_runs
+		FROM executions INDEXED BY idx_executions_repo_status_end
+		WHERE repo_key <> ''
+		GROUP BY repo_key
+	)
+	SELECT latest.id, latest.repo_key, latest.start_time, latest.end_time,
+	       latest.status, latest.error_message,
+	       (
+		       SELECT successful.end_time
+		       FROM executions AS successful INDEXED BY idx_executions_repo_status_end
+		       WHERE successful.repo_key = totals.repo_key
+		         AND successful.status = 'completed'
+		       ORDER BY successful.end_time DESC
+		       LIMIT 1
+	       ) AS last_success,
+	       totals.total_runs, totals.success_runs, totals.failed_runs
+	FROM totals
+	JOIN executions AS latest ON latest.id = (
+		SELECT recent.id
+		FROM executions AS recent INDEXED BY idx_executions_repo_start
+		WHERE recent.repo_key = totals.repo_key
+		ORDER BY recent.start_time DESC, recent.id DESC
+		LIMIT 1
+	)`
+
 // RepositoryRunStats loads the latest execution and cumulative outcome counts
 // for every repository key in one indexed query.
 func (d *DB) RepositoryRunStats(ctx context.Context) (map[string]RepositoryRunStats, error) {
-	rows, err := d.QueryContext(ctx, `
-		WITH ranked AS (
-			SELECT id, repo_key, start_time, end_time, status, error_message,
-			       ROW_NUMBER() OVER (
-				   PARTITION BY repo_key ORDER BY start_time DESC, id DESC
-			       ) AS rn
-			FROM executions WHERE repo_key <> ''
-		), totals AS (
-			SELECT repo_key,
-			       COUNT(*) AS total_runs,
-			       COALESCE(SUM(status = 'completed'), 0) AS success_runs,
-			       COALESCE(SUM(status = 'failed'), 0) AS failed_runs
-			FROM executions WHERE repo_key <> '' GROUP BY repo_key
-		), successes AS (
-			SELECT repo_key, MAX(end_time) AS last_success
-			FROM executions
-			WHERE repo_key <> '' AND status = 'completed'
-			GROUP BY repo_key
-		)
-		SELECT ranked.id, ranked.repo_key, ranked.start_time, ranked.end_time,
-		       ranked.status, ranked.error_message, successes.last_success,
-		       totals.total_runs, totals.success_runs, totals.failed_runs
-		FROM ranked
-		JOIN totals USING (repo_key)
-		LEFT JOIN successes USING (repo_key)
-		WHERE ranked.rn = 1`)
+	rows, err := d.QueryContext(ctx, repositoryRunStatsQuery)
 	if err != nil {
 		return nil, fmt.Errorf("query repository run stats: %w", err)
 	}

--- a/internal/db/execution_store.go
+++ b/internal/db/execution_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -46,6 +47,47 @@ func (d *DB) CreatePendingExecutions(ctx context.Context, executions []PendingEx
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit create pending executions: %w", err)
+	}
+	return nil
+}
+
+// DiscardPendingExecutions atomically removes an unaccepted batch that was
+// committed but never published to the executor queue.
+func (d *DB) DiscardPendingExecutions(ctx context.Context, executionIDs []string) error {
+	if len(executionIDs) == 0 {
+		return nil
+	}
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin discard pending executions: %w", err)
+	}
+	defer tx.Rollback()
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(executionIDs)), ",")
+	args := make([]interface{}, len(executionIDs))
+	for i, executionID := range executionIDs {
+		args[i] = executionID
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM execution_components WHERE execution_id IN (`+placeholders+`)`, args...,
+	); err != nil {
+		return fmt.Errorf("discard pending execution components: %w", err)
+	}
+	result, err := tx.ExecContext(ctx,
+		`DELETE FROM executions WHERE status = 'pending' AND id IN (`+placeholders+`)`, args...,
+	)
+	if err != nil {
+		return fmt.Errorf("discard pending executions: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("inspect discarded pending executions: %w", err)
+	}
+	if deleted != int64(len(executionIDs)) {
+		return fmt.Errorf("expected %d pending execution rows, deleted %d", len(executionIDs), deleted)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit discard pending executions: %w", err)
 	}
 	return nil
 }

--- a/internal/db/execution_store.go
+++ b/internal/db/execution_store.go
@@ -340,6 +340,13 @@ func nullableAggregateTime(value interface{}) (*time.Time, error) {
 	default:
 		return nil, fmt.Errorf("unsupported timestamp type %T", value)
 	}
+	// SQLite aggregate expressions lose the DATETIME column type that normally
+	// lets the driver scan directly into time.Time. A Go time.Time persisted by
+	// the driver can retain its optional monotonic annotation in that text form;
+	// it is not part of a wall-clock timestamp and time.Parse cannot read it.
+	if monotonic := strings.LastIndex(raw, " m="); monotonic >= 0 {
+		raw = raw[:monotonic]
+	}
 	for _, layout := range []string{
 		"2006-01-02 15:04:05.999999999 -0700 MST",
 		"2006-01-02 15:04:05.999999999-07:00",

--- a/internal/db/execution_store.go
+++ b/internal/db/execution_store.go
@@ -9,6 +9,47 @@ import (
 
 const interruptedExecutionMessage = "previous server process ended before completion"
 
+// PendingExecution describes one execution and its component rows for atomic creation.
+type PendingExecution struct {
+	ID         string
+	JobName    string
+	RepoKey    string
+	StartTime  time.Time
+	Components []ComponentName
+}
+
+// CreatePendingExecutions creates a batch of pending executions and all of
+// their component rows atomically.
+func (d *DB) CreatePendingExecutions(ctx context.Context, executions []PendingExecution) error {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin create pending executions: %w", err)
+	}
+	defer tx.Rollback()
+
+	for _, execution := range executions {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO executions (id, job_name, repo_key, start_time, status)
+			VALUES (?, ?, ?, ?, ?)`,
+			execution.ID, execution.JobName, execution.RepoKey, execution.StartTime, ComponentPending,
+		); err != nil {
+			return fmt.Errorf("create pending execution %q: %w", execution.ID, err)
+		}
+		for _, component := range execution.Components {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO execution_components (execution_id, component, status) VALUES (?, ?, ?)`,
+				execution.ID, component, ComponentPending,
+			); err != nil {
+				return fmt.Errorf("create component %q for execution %q: %w", component, execution.ID, err)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit create pending executions: %w", err)
+	}
+	return nil
+}
+
 // CreateComponents creates pending component records for an execution.
 func (d *DB) CreateComponents(ctx context.Context, executionID string, components []ComponentName) error {
 	tx, err := d.BeginTx(ctx, nil)

--- a/internal/db/execution_store.go
+++ b/internal/db/execution_store.go
@@ -1,0 +1,167 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+const interruptedExecutionMessage = "previous server process ended before completion"
+
+// CreateComponents creates pending component records for an execution.
+func (d *DB) CreateComponents(ctx context.Context, executionID string, components []ComponentName) error {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin create components: %w", err)
+	}
+	defer tx.Rollback()
+
+	for _, component := range components {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO execution_components (execution_id, component, status) VALUES (?, ?, ?)`,
+			executionID, component, ComponentPending,
+		); err != nil {
+			return fmt.Errorf("create component %q for execution %q: %w", component, executionID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit create components: %w", err)
+	}
+	return nil
+}
+
+// StartComponent marks a component as running at startedAt.
+func (d *DB) StartComponent(ctx context.Context, executionID string, component ComponentName, startedAt time.Time) error {
+	_, err := d.ExecContext(ctx, `
+		UPDATE execution_components
+		SET status = ?, start_time = ?, end_time = NULL, error_message = NULL
+		WHERE execution_id = ? AND component = ?`,
+		ComponentRunning, startedAt, executionID, component,
+	)
+	if err != nil {
+		return fmt.Errorf("start component %q for execution %q: %w", component, executionID, err)
+	}
+	return nil
+}
+
+// FinishComponent records a component's terminal status and outcome details.
+func (d *DB) FinishComponent(ctx context.Context, executionID string, component ComponentName, status ComponentStatus, finishedAt time.Time, errorMessage string) error {
+	_, err := d.ExecContext(ctx, `
+		UPDATE execution_components
+		SET status = ?, end_time = ?, error_message = ?
+		WHERE execution_id = ? AND component = ?`,
+		status, finishedAt, errorMessage, executionID, component,
+	)
+	if err != nil {
+		return fmt.Errorf("finish component %q for execution %q: %w", component, executionID, err)
+	}
+	return nil
+}
+
+// ListComponents returns component execution records in display order.
+func (d *DB) ListComponents(ctx context.Context, executionID string) ([]ComponentExecution, error) {
+	rows, err := d.QueryContext(ctx, `
+		SELECT id, execution_id, component, status, start_time, end_time, error_message
+		FROM execution_components
+		WHERE execution_id = ?
+		ORDER BY CASE component
+			WHEN 'code' THEN 1
+			WHEN 'release' THEN 2
+			WHEN 'issues' THEN 3
+			WHEN 'wiki' THEN 4
+			WHEN 'discussion' THEN 5
+			ELSE 6
+		END, id`, executionID)
+	if err != nil {
+		return nil, fmt.Errorf("list components for execution %q: %w", executionID, err)
+	}
+	defer rows.Close()
+
+	components := make([]ComponentExecution, 0)
+	for rows.Next() {
+		var (
+			component ComponentExecution
+			startTime sql.NullTime
+			endTime   sql.NullTime
+			errorText sql.NullString
+		)
+		if err := rows.Scan(
+			&component.ID,
+			&component.ExecutionID,
+			&component.Component,
+			&component.Status,
+			&startTime,
+			&endTime,
+			&errorText,
+		); err != nil {
+			return nil, fmt.Errorf("scan component for execution %q: %w", executionID, err)
+		}
+		if startTime.Valid {
+			component.StartTime = &startTime.Time
+		}
+		if endTime.Valid {
+			component.EndTime = &endTime.Time
+		}
+		if errorText.Valid {
+			component.ErrorMessage = errorText.String
+		}
+		components = append(components, component)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate components for execution %q: %w", executionID, err)
+	}
+	return components, nil
+}
+
+// ExecutionExists reports whether an execution ID is known.
+func (d *DB) ExecutionExists(ctx context.Context, executionID string) (bool, error) {
+	var exists bool
+	if err := d.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM executions WHERE id = ?)`, executionID,
+	).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check execution %q: %w", executionID, err)
+	}
+	return exists, nil
+}
+
+// ActiveExecutionExists reports whether a repository has a pending or running execution.
+func (d *DB) ActiveExecutionExists(ctx context.Context, repoKey string) (bool, error) {
+	var exists bool
+	if err := d.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM executions
+			WHERE repo_key = ? AND status IN ('pending', 'running')
+		)`, repoKey,
+	).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check active execution for repository %q: %w", repoKey, err)
+	}
+	return exists, nil
+}
+
+// ReconcileInterrupted marks executions and component rows left active by a
+// previous server process as failed.
+func (d *DB) ReconcileInterrupted(ctx context.Context, now time.Time) error {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin interrupted execution reconciliation: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE execution_components
+		SET status = 'failed', end_time = ?, error_message = ?
+		WHERE status IN ('pending', 'running')`, now, interruptedExecutionMessage); err != nil {
+		return fmt.Errorf("reconcile active component executions: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE executions
+		SET status = 'failed', end_time = ?, error_message = ?
+		WHERE status IN ('pending', 'running')`, now, interruptedExecutionMessage); err != nil {
+		return fmt.Errorf("reconcile active executions: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit interrupted execution reconciliation: %w", err)
+	}
+	return nil
+}

--- a/internal/db/execution_store.go
+++ b/internal/db/execution_store.go
@@ -33,28 +33,52 @@ func (d *DB) CreateComponents(ctx context.Context, executionID string, component
 
 // StartComponent marks a component as running at startedAt.
 func (d *DB) StartComponent(ctx context.Context, executionID string, component ComponentName, startedAt time.Time) error {
-	_, err := d.ExecContext(ctx, `
+	result, err := d.ExecContext(ctx, `
 		UPDATE execution_components
 		SET status = ?, start_time = ?, end_time = NULL, error_message = NULL
-		WHERE execution_id = ? AND component = ?`,
-		ComponentRunning, startedAt, executionID, component,
+		WHERE execution_id = ? AND component = ? AND status = ?`,
+		ComponentRunning, startedAt, executionID, component, ComponentPending,
 	)
 	if err != nil {
 		return fmt.Errorf("start component %q for execution %q: %w", component, executionID, err)
 	}
-	return nil
+	return requireOneComponentRow(result, "start", executionID, component)
 }
 
 // FinishComponent records a component's terminal status and outcome details.
 func (d *DB) FinishComponent(ctx context.Context, executionID string, component ComponentName, status ComponentStatus, finishedAt time.Time, errorMessage string) error {
-	_, err := d.ExecContext(ctx, `
+	if !isTerminalComponentStatus(status) {
+		return fmt.Errorf("finish component %q for execution %q: invalid terminal status %q", component, executionID, status)
+	}
+
+	result, err := d.ExecContext(ctx, `
 		UPDATE execution_components
 		SET status = ?, end_time = ?, error_message = ?
-		WHERE execution_id = ? AND component = ?`,
-		status, finishedAt, errorMessage, executionID, component,
+		WHERE execution_id = ? AND component = ? AND status IN (?, ?)`,
+		status, finishedAt, errorMessage, executionID, component, ComponentPending, ComponentRunning,
 	)
 	if err != nil {
 		return fmt.Errorf("finish component %q for execution %q: %w", component, executionID, err)
+	}
+	return requireOneComponentRow(result, "finish", executionID, component)
+}
+
+func isTerminalComponentStatus(status ComponentStatus) bool {
+	switch status {
+	case ComponentCompleted, ComponentFailed, ComponentSkipped, ComponentCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func requireOneComponentRow(result sql.Result, action, executionID string, component ComponentName) error {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%s component %q for execution %q: inspect affected rows: %w", action, component, executionID, err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("%s component %q for execution %q: expected one pending or running row, updated %d", action, component, executionID, rows)
 	}
 	return nil
 }

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -36,6 +36,29 @@ func TestCreatePendingExecutionsRollsBackWholeBatchWhenLaterComponentInsertFails
 	require.Zero(t, componentCount)
 }
 
+func TestDiscardPendingExecutionsRollsBackWhenEveryExecutionIsNotPending(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	startedAt := time.Date(2026, time.September, 4, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, testDB.CreatePendingExecutions(ctx, []PendingExecution{
+		{ID: "pending", JobName: "pending", RepoKey: "github.com/acme/pending", StartTime: startedAt, Components: []ComponentName{ComponentCode}},
+		{ID: "running", JobName: "running", RepoKey: "github.com/acme/running", StartTime: startedAt, Components: []ComponentName{ComponentCode}},
+	}))
+	_, err = testDB.Exec(`UPDATE executions SET status = 'running' WHERE id = 'running'`)
+	require.NoError(t, err)
+
+	err = testDB.DiscardPendingExecutions(ctx, []string{"pending", "running"})
+	require.ErrorContains(t, err, "expected 2 pending execution rows, deleted 1")
+	var executionCount, componentCount int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&executionCount))
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM execution_components`).Scan(&componentCount))
+	require.Equal(t, 2, executionCount)
+	require.Equal(t, 2, componentCount)
+}
+
 func TestComponentStorePersistsTransitionsAndListsComponentsInDisplayOrder(t *testing.T) {
 	ctx := context.Background()
 	testDB, err := Initialize(":memory:")

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -14,7 +14,33 @@ func TestRepositoryExecutionLookupPlansUseRepositoryIndexes(t *testing.T) {
 	require.NoError(t, err)
 	defer testDB.Close()
 
-	rows, err := testDB.Query("EXPLAIN QUERY PLAN " + repositoryRunStatsQuery)
+	details := repositoryQueryPlanDetails(t, testDB, repositoryRunStatsQuery)
+	plan := strings.Join(details, "\n")
+	require.True(t, queryPlanHasKeyedSearch(
+		details, "recent", "idx_executions_repo_start", "repo_key=?",
+	), plan)
+	require.True(t, queryPlanHasKeyedSearch(
+		details, "successful", "idx_executions_repo_status_end", "repo_key=?", "status=?",
+	), plan)
+
+	queryWithoutSuccessfulIndex := strings.Replace(
+		repositoryRunStatsQuery,
+		"FROM executions AS successful INDEXED BY idx_executions_repo_status_end",
+		"FROM executions AS successful NOT INDEXED",
+		1,
+	)
+	require.NotEqual(t, repositoryRunStatsQuery, queryWithoutSuccessfulIndex)
+	misleadingDetails := repositoryQueryPlanDetails(t, testDB, queryWithoutSuccessfulIndex)
+	require.Contains(t, strings.Join(misleadingDetails, "\n"), "idx_executions_repo_status_end",
+		"the totals scan should keep the old whole-plan assertion misleading")
+	require.False(t, queryPlanHasKeyedSearch(
+		misleadingDetails, "successful", "idx_executions_repo_status_end", "repo_key=?", "status=?",
+	), strings.Join(misleadingDetails, "\n"))
+}
+
+func repositoryQueryPlanDetails(t *testing.T, testDB *DB, query string) []string {
+	t.Helper()
+	rows, err := testDB.Query("EXPLAIN QUERY PLAN " + query)
 	require.NoError(t, err)
 	defer rows.Close()
 
@@ -26,9 +52,30 @@ func TestRepositoryExecutionLookupPlansUseRepositoryIndexes(t *testing.T) {
 		details = append(details, detail)
 	}
 	require.NoError(t, rows.Err())
-	plan := strings.Join(details, "\n")
-	require.Contains(t, plan, "idx_executions_repo_start", plan)
-	require.Contains(t, plan, "idx_executions_repo_status_end", plan)
+	return details
+}
+
+func queryPlanHasKeyedSearch(details []string, alias, index string, keyTerms ...string) bool {
+	searchPrefix := "SEARCH " + strings.ToUpper(alias) + " "
+	plainIndex := " USING INDEX " + strings.ToUpper(index)
+	coveringIndex := " USING COVERING INDEX " + strings.ToUpper(index)
+	for _, detail := range details {
+		normalized := strings.ToUpper(strings.Join(strings.Fields(detail), " "))
+		if !strings.Contains(normalized, searchPrefix) {
+			continue
+		}
+		if !strings.Contains(normalized, plainIndex) && !strings.Contains(normalized, coveringIndex) {
+			return false
+		}
+		compact := strings.ReplaceAll(normalized, " ", "")
+		for _, term := range keyTerms {
+			if !strings.Contains(compact, strings.ToUpper(strings.ReplaceAll(term, " ", ""))) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func TestCreatePendingExecutionsRollsBackWholeBatchWhenLaterComponentInsertFails(t *testing.T) {

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -105,6 +105,37 @@ func TestExecutionExistenceQueriesUseExactExecutionAndRepositoryKeys(t *testing.
 	require.False(t, active)
 }
 
+func TestStartComponentRejectsMissingAndNonPendingRows(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	startedAt := time.Date(2026, time.September, 3, 10, 0, 0, 0, time.UTC)
+	insertExecution(t, testDB, "exec-start-transitions", "github.com/acme/widgets", ComponentPending)
+
+	require.Error(t, testDB.StartComponent(ctx, "exec-start-transitions", ComponentCode, startedAt))
+	require.NoError(t, testDB.CreateComponents(ctx, "exec-start-transitions", []ComponentName{ComponentCode}))
+	require.NoError(t, testDB.StartComponent(ctx, "exec-start-transitions", ComponentCode, startedAt))
+	require.Error(t, testDB.StartComponent(ctx, "exec-start-transitions", ComponentCode, startedAt.Add(time.Minute)))
+}
+
+func TestFinishComponentRejectsMissingNonterminalAndAlreadyTerminalRows(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	finishedAt := time.Date(2026, time.September, 3, 10, 2, 0, 0, time.UTC)
+	insertExecution(t, testDB, "exec-finish-transitions", "github.com/acme/widgets", ComponentPending)
+	require.NoError(t, testDB.CreateComponents(ctx, "exec-finish-transitions", []ComponentName{ComponentCode}))
+
+	require.Error(t, testDB.FinishComponent(ctx, "exec-finish-transitions", ComponentWiki, ComponentCompleted, finishedAt, ""))
+	require.Error(t, testDB.FinishComponent(ctx, "exec-finish-transitions", ComponentCode, ComponentRunning, finishedAt, ""))
+	require.NoError(t, testDB.FinishComponent(ctx, "exec-finish-transitions", ComponentCode, ComponentFailed, finishedAt, "interrupted"))
+	require.Error(t, testDB.FinishComponent(ctx, "exec-finish-transitions", ComponentCode, ComponentCompleted, finishedAt, ""))
+}
+
 func insertExecution(t *testing.T, testDB *DB, id, repoKey string, status ComponentStatus) {
 	t.Helper()
 	_, err := testDB.Exec(

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -156,6 +156,54 @@ func TestExecutionExistenceQueriesUseExactExecutionAndRepositoryKeys(t *testing.
 	require.False(t, active)
 }
 
+func TestRepositoryRunStatsReturnsLatestRowsSuccessTimesAndCumulativeCounts(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	base := time.Date(2026, time.September, 4, 8, 0, 0, 0, time.UTC)
+	insertRepositoryRun(t, testDB, "alpha-success", "github.com/acme/alpha", base, ptrTime(base.Add(10*time.Minute)), "completed", nil)
+	insertRepositoryRun(t, testDB, "alpha-failure", "github.com/acme/alpha", base.Add(time.Hour), ptrTime(base.Add(time.Hour+5*time.Minute)), "failed", ptrString("network unavailable"))
+	insertRepositoryRun(t, testDB, "beta-running", "github.com/acme/beta", base.Add(2*time.Hour), nil, "running", nil)
+	insertRepositoryRun(t, testDB, "tie-a", "github.com/acme/tied", base.Add(3*time.Hour), ptrTime(base.Add(3*time.Hour+time.Minute)), "completed", nil)
+	insertRepositoryRun(t, testDB, "tie-z", "github.com/acme/tied", base.Add(3*time.Hour), ptrTime(base.Add(3*time.Hour+2*time.Minute)), "failed", ptrString("tie winner"))
+	insertRepositoryRun(t, testDB, "legacy", "", base.Add(4*time.Hour), nil, "completed", nil)
+
+	stats, err := testDB.RepositoryRunStats(ctx)
+	require.NoError(t, err)
+	require.Len(t, stats, 3, "rows without a repository key stay valid but are excluded from repository stats")
+
+	alpha := stats["github.com/acme/alpha"]
+	require.Equal(t, "alpha-failure", alpha.LatestExecutionID)
+	require.Equal(t, "failed", alpha.LatestStatus)
+	require.Equal(t, base.Add(time.Hour), alpha.LatestStart)
+	require.NotNil(t, alpha.LatestEnd)
+	require.Equal(t, base.Add(time.Hour+5*time.Minute), *alpha.LatestEnd)
+	require.Equal(t, "network unavailable", alpha.LatestError)
+	require.NotNil(t, alpha.LastSuccess)
+	require.Equal(t, base.Add(10*time.Minute), *alpha.LastSuccess)
+	require.Equal(t, int64(2), alpha.TotalRuns)
+	require.Equal(t, int64(1), alpha.SuccessRuns)
+	require.Equal(t, int64(1), alpha.FailedRuns)
+
+	beta := stats["github.com/acme/beta"]
+	require.Equal(t, "beta-running", beta.LatestExecutionID)
+	require.Equal(t, "running", beta.LatestStatus)
+	require.Nil(t, beta.LatestEnd)
+	require.Nil(t, beta.LastSuccess)
+	require.Zero(t, beta.SuccessRuns)
+	require.Zero(t, beta.FailedRuns)
+
+	tied := stats["github.com/acme/tied"]
+	require.Equal(t, "tie-z", tied.LatestExecutionID, "descending execution ID breaks equal-start ties")
+	require.Equal(t, "failed", tied.LatestStatus)
+	require.Equal(t, "tie winner", tied.LatestError)
+	require.NotNil(t, tied.LastSuccess)
+	require.Equal(t, base.Add(3*time.Hour+time.Minute), *tied.LastSuccess)
+	require.Equal(t, int64(2), tied.TotalRuns)
+}
+
 func TestStartComponentRejectsMissingAndNonPendingRows(t *testing.T) {
 	ctx := context.Background()
 	testDB, err := Initialize(":memory:")
@@ -195,3 +243,16 @@ func insertExecution(t *testing.T, testDB *DB, id, repoKey string, status Compon
 	)
 	require.NoError(t, err)
 }
+
+func insertRepositoryRun(t *testing.T, testDB *DB, id, repoKey string, start time.Time, end *time.Time, status string, message *string) {
+	t.Helper()
+	_, err := testDB.Exec(
+		`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, "test-job", repoKey, start, end, status, message,
+	)
+	require.NoError(t, err)
+}
+
+func ptrTime(value time.Time) *time.Time { return &value }
+
+func ptrString(value string) *string { return &value }

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -204,6 +204,23 @@ func TestRepositoryRunStatsReturnsLatestRowsSuccessTimesAndCumulativeCounts(t *t
 	require.Equal(t, int64(2), tied.TotalRuns)
 }
 
+func TestRepositoryRunStatsParsesSQLiteAggregateTimeWithMonotonicSuffix(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	start := time.Now()
+	end := start.Add(time.Minute)
+	insertRepositoryRun(t, testDB, "monotonic-success", "github.com/acme/monotonic", start, &end, "completed", nil)
+
+	stats, err := testDB.RepositoryRunStats(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, stats["github.com/acme/monotonic"].LastSuccess)
+	got := *stats["github.com/acme/monotonic"].LastSuccess
+	require.Equal(t, end.Round(0), got.Round(0))
+}
+
 func TestStartComponentRejectsMissingAndNonPendingRows(t *testing.T) {
 	ctx := context.Background()
 	testDB, err := Initialize(":memory:")

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -2,11 +2,34 @@ package db
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestRepositoryExecutionLookupPlansUseRepositoryIndexes(t *testing.T) {
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	rows, err := testDB.Query("EXPLAIN QUERY PLAN " + repositoryRunStatsQuery)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	plan := strings.Join(details, "\n")
+	require.Contains(t, plan, "idx_executions_repo_start", plan)
+	require.Contains(t, plan, "idx_executions_repo_status_end", plan)
+}
 
 func TestCreatePendingExecutionsRollsBackWholeBatchWhenLaterComponentInsertFails(t *testing.T) {
 	ctx := context.Background()

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -8,6 +8,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCreatePendingExecutionsRollsBackWholeBatchWhenLaterComponentInsertFails(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	_, err = testDB.Exec(`
+		CREATE TRIGGER reject_beta_component
+		BEFORE INSERT ON execution_components
+		WHEN NEW.execution_id = 'beta'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced beta component failure');
+		END;`)
+	require.NoError(t, err)
+	startedAt := time.Date(2026, time.September, 4, 9, 0, 0, 0, time.UTC)
+	err = testDB.CreatePendingExecutions(ctx, []PendingExecution{
+		{ID: "alpha", JobName: "alpha", RepoKey: "github.com/acme/alpha", StartTime: startedAt, Components: []ComponentName{ComponentCode}},
+		{ID: "beta", JobName: "beta", RepoKey: "github.com/acme/beta", StartTime: startedAt, Components: []ComponentName{ComponentCode}},
+	})
+	require.ErrorContains(t, err, "forced beta component failure")
+
+	var executionCount, componentCount int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&executionCount))
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM execution_components`).Scan(&componentCount))
+	require.Zero(t, executionCount)
+	require.Zero(t, componentCount)
+}
+
 func TestComponentStorePersistsTransitionsAndListsComponentsInDisplayOrder(t *testing.T) {
 	ctx := context.Background()
 	testDB, err := Initialize(":memory:")

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -221,6 +221,37 @@ func TestRepositoryRunStatsParsesSQLiteAggregateTimeWithMonotonicSuffix(t *testi
 	require.Equal(t, end.Round(0), got.Round(0))
 }
 
+func TestNullableAggregateTimeAcceptsOnlyCompleteMonotonicSuffixes(t *testing.T) {
+	base := time.Date(2026, time.September, 4, 12, 34, 56, 789000000, time.FixedZone("CST", 8*60*60))
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "positive integer", raw: "2026-09-04 12:34:56.789 +0800 CST m=+123"},
+		{name: "positive fractional", raw: "2026-09-04 12:34:56.789 +0800 CST m=+123.45"},
+		{name: "negative integer", raw: "2026-09-04 12:34:56.789 +0800 CST m=-123"},
+		{name: "negative fractional", raw: "2026-09-04 12:34:56.789 +0800 CST m=-123.45"},
+		{name: "missing sign", raw: "2026-09-04 12:34:56.789 +0800 CST m=123", wantErr: true},
+		{name: "missing digits", raw: "2026-09-04 12:34:56.789 +0800 CST m=+", wantErr: true},
+		{name: "trailing text", raw: "2026-09-04 12:34:56.789 +0800 CST m=+123 trailing", wantErr: true},
+		{name: "extra decimal", raw: "2026-09-04 12:34:56.789 +0800 CST m=+123.4.5", wantErr: true},
+		{name: "embedded annotation", raw: "2026-09-04 12:34:56.789 +0800 CST m=+123 extra", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := nullableAggregateTime(tc.raw)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.True(t, base.Equal(*got))
+		})
+	}
+}
+
 func TestStartComponentRejectsMissingAndNonPendingRows(t *testing.T) {
 	ctx := context.Background()
 	testDB, err := Initialize(":memory:")

--- a/internal/db/execution_store_test.go
+++ b/internal/db/execution_store_test.go
@@ -1,0 +1,115 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComponentStorePersistsTransitionsAndListsComponentsInDisplayOrder(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	start := time.Date(2026, time.September, 3, 10, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Minute)
+	insertExecution(t, testDB, "exec-components", "github.com/acme/widgets", ComponentPending)
+
+	require.NoError(t, testDB.CreateComponents(ctx, "exec-components", []ComponentName{ComponentWiki, ComponentCode}))
+	require.NoError(t, testDB.StartComponent(ctx, "exec-components", ComponentCode, start))
+	require.NoError(t, testDB.FinishComponent(ctx, "exec-components", ComponentCode, ComponentCompleted, end, ""))
+	require.NoError(t, testDB.FinishComponent(ctx, "exec-components", ComponentWiki, ComponentSkipped, end, "wiki disabled"))
+
+	components, err := testDB.ListComponents(ctx, "exec-components")
+	require.NoError(t, err)
+	require.Len(t, components, 2)
+	require.Equal(t, ComponentCode, components[0].Component)
+	require.Equal(t, ComponentCompleted, components[0].Status)
+	require.Equal(t, start, *components[0].StartTime)
+	require.Equal(t, end, *components[0].EndTime)
+	require.Empty(t, components[0].ErrorMessage)
+	require.Equal(t, ComponentWiki, components[1].Component)
+	require.Equal(t, ComponentSkipped, components[1].Status)
+	require.Nil(t, components[1].StartTime)
+	require.Equal(t, end, *components[1].EndTime)
+	require.Equal(t, "wiki disabled", components[1].ErrorMessage)
+}
+
+func TestReconcileInterruptedFailsActiveExecutionsAndComponents(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	fixedNow := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	insertExecution(t, testDB, "exec-pending", "github.com/acme/pending", ComponentPending)
+	insertExecution(t, testDB, "exec-running", "github.com/acme/running", ComponentRunning)
+	require.NoError(t, testDB.CreateComponents(ctx, "exec-pending", []ComponentName{ComponentCode}))
+	require.NoError(t, testDB.CreateComponents(ctx, "exec-running", []ComponentName{ComponentWiki}))
+	require.NoError(t, testDB.StartComponent(ctx, "exec-running", ComponentWiki, fixedNow.Add(-time.Minute)))
+
+	require.NoError(t, testDB.ReconcileInterrupted(ctx, fixedNow))
+
+	for _, id := range []string{"exec-pending", "exec-running"} {
+		var status, message string
+		var end time.Time
+		require.NoError(t, testDB.QueryRow(
+			`SELECT status, end_time, error_message FROM executions WHERE id = ?`, id,
+		).Scan(&status, &end, &message))
+		require.Equal(t, string(ComponentFailed), status)
+		require.Equal(t, fixedNow, end)
+		require.Equal(t, "previous server process ended before completion", message)
+
+		components, err := testDB.ListComponents(ctx, id)
+		require.NoError(t, err)
+		require.Len(t, components, 1)
+		require.Equal(t, ComponentFailed, components[0].Status)
+		require.Equal(t, fixedNow, *components[0].EndTime)
+		require.Equal(t, "previous server process ended before completion", components[0].ErrorMessage)
+	}
+}
+
+func TestExecutionExistenceQueriesUseExactExecutionAndRepositoryKeys(t *testing.T) {
+	ctx := context.Background()
+	testDB, err := Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	insertExecution(t, testDB, "done", "github.com/acme/widgets", ComponentCompleted)
+	insertExecution(t, testDB, "pending", "github.com/acme/widgets", ComponentPending)
+	insertExecution(t, testDB, "running", "github.com/acme/widgets", ComponentRunning)
+	insertExecution(t, testDB, "other", "github.com/acme/widgets-copy", ComponentRunning)
+	insertExecution(t, testDB, "completed-only", "github.com/acme/completed-only", ComponentCompleted)
+
+	exists, err := testDB.ExecutionExists(ctx, "done")
+	require.NoError(t, err)
+	require.True(t, exists)
+	exists, err = testDB.ExecutionExists(ctx, "unknown")
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	active, err := testDB.ActiveExecutionExists(ctx, "github.com/acme/widgets")
+	require.NoError(t, err)
+	require.True(t, active)
+	active, err = testDB.ActiveExecutionExists(ctx, "github.com/acme/widgets-copy")
+	require.NoError(t, err)
+	require.True(t, active)
+	active, err = testDB.ActiveExecutionExists(ctx, "github.com/acme/completed-only")
+	require.NoError(t, err)
+	require.False(t, active)
+	active, err = testDB.ActiveExecutionExists(ctx, "github.com/acme/widget")
+	require.NoError(t, err)
+	require.False(t, active)
+}
+
+func insertExecution(t *testing.T, testDB *DB, id, repoKey string, status ComponentStatus) {
+	t.Helper()
+	_, err := testDB.Exec(
+		`INSERT INTO executions (id, job_name, repo_key, start_time, status) VALUES (?, ?, ?, ?, ?)`,
+		id, "test-job", repoKey, time.Date(2026, time.September, 3, 9, 0, 0, 0, time.UTC), status,
+	)
+	require.NoError(t, err)
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -15,7 +15,7 @@ func Migrate(d *DB) error {
 			return fmt.Errorf("add executions.repo_key: %w", err)
 		}
 	}
-	if _, err := d.Exec(componentSchema); err != nil {
+	if _, err := d.Exec(componentSchema + executionIndexSchema); err != nil {
 		return fmt.Errorf("add component execution schema: %w", err)
 	}
 	return nil

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -3,8 +3,8 @@ package db
 import "fmt"
 
 // Migrate upgrades an existing database to the current schema. Additive-only:
-// it adds the repo_key column to executions when missing and never backfills or
-// drops data. Call once at server startup (after Initialize).
+// it adds missing schema without backfilling, rewriting, or dropping data. Call
+// once at server startup (after Initialize).
 func Migrate(d *DB) error {
 	has, err := columnExists(d, "executions", "repo_key")
 	if err != nil {
@@ -14,6 +14,9 @@ func Migrate(d *DB) error {
 		if _, err := d.Exec(`ALTER TABLE executions ADD COLUMN repo_key TEXT NOT NULL DEFAULT ''`); err != nil {
 			return fmt.Errorf("add executions.repo_key: %w", err)
 		}
+	}
+	if _, err := d.Exec(componentSchema); err != nil {
+		return fmt.Errorf("add component execution schema: %w", err)
 	}
 	return nil
 }

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestInitializeCreatesTables verifies that Initialize creates the executions
@@ -13,6 +14,9 @@ func TestInitializeCreatesTables(t *testing.T) {
 	testDB, err := Initialize(":memory:")
 	assert.NoError(t, err)
 	defer testDB.Close()
+	require.NoError(t, Migrate(testDB))
+	require.NoError(t, Migrate(testDB))
+	assertComponentSchemaObjects(t, testDB)
 
 	// executions table should exist and accept inserts
 	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, start_time, status) VALUES (?, ?, ?, ?)`,
@@ -82,7 +86,9 @@ func TestMigrateAddsRepoKeyColumn(t *testing.T) {
 		"old", "repo-a", time.Now(), "completed")
 	assert.NoError(t, err)
 
-	assert.NoError(t, Migrate(testDB))
+	require.NoError(t, Migrate(testDB))
+	require.NoError(t, Migrate(testDB))
+	assertComponentSchemaObjects(t, testDB)
 
 	// Column now exists; legacy row's key stays empty (no backfill).
 	var key string
@@ -104,4 +110,21 @@ func TestMigrateIsIdempotent(t *testing.T) {
 
 	assert.NoError(t, Migrate(testDB))
 	assert.NoError(t, Migrate(testDB))
+}
+
+func assertComponentSchemaObjects(t *testing.T, testDB *DB) {
+	t.Helper()
+	for _, name := range []string{
+		"execution_components",
+		"idx_executions_repo_start",
+		"idx_executions_repo_status_end",
+		"idx_executions_status",
+		"idx_execution_components_execution",
+	} {
+		var got string
+		require.NoError(t, testDB.QueryRow(
+			`SELECT name FROM sqlite_master WHERE name = ?`, name,
+		).Scan(&got))
+		require.Equal(t, name, got)
+	}
 }

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"database/sql"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ func TestInitializeCreatesTables(t *testing.T) {
 	testDB, err := Initialize(":memory:")
 	assert.NoError(t, err)
 	defer testDB.Close()
+	assertComponentSchemaObjects(t, testDB)
 	require.NoError(t, Migrate(testDB))
 	require.NoError(t, Migrate(testDB))
 	assertComponentSchemaObjects(t, testDB)
@@ -100,6 +103,33 @@ func TestMigrateAddsRepoKeyColumn(t *testing.T) {
 	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, status) VALUES (?, ?, ?, ?, ?)`,
 		"new", "repo-b", "github.com/b/b", time.Now(), "running")
 	assert.NoError(t, err)
+}
+
+func TestInitializeThenMigrateUpgradesLegacyFileDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	legacyDB, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	_, err = legacyDB.Exec(`
+		CREATE TABLE executions (
+			id TEXT PRIMARY KEY,
+			job_name TEXT NOT NULL,
+			start_time DATETIME NOT NULL,
+			end_time DATETIME,
+			status TEXT NOT NULL,
+			error_message TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`)
+	require.NoError(t, err)
+	require.NoError(t, legacyDB.Close())
+
+	testDB, err := Initialize(path)
+	if testDB != nil {
+		defer testDB.Close()
+	}
+	require.NoError(t, err)
+	require.NoError(t, Migrate(testDB))
+	require.NoError(t, Migrate(testDB))
+	assertComponentSchemaObjects(t, testDB)
 }
 
 // TestMigrateIsIdempotent verifies Migrate on a fresh (already current) DB is a no-op.

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -4,15 +4,45 @@ import (
 	"time"
 )
 
+type ComponentName string
+
+type ComponentStatus string
+
+const (
+	ComponentCode       ComponentName = "code"
+	ComponentRelease    ComponentName = "release"
+	ComponentIssue      ComponentName = "issues"
+	ComponentWiki       ComponentName = "wiki"
+	ComponentDiscussion ComponentName = "discussion"
+
+	ComponentPending   ComponentStatus = "pending"
+	ComponentRunning   ComponentStatus = "running"
+	ComponentCompleted ComponentStatus = "completed"
+	ComponentFailed    ComponentStatus = "failed"
+	ComponentSkipped   ComponentStatus = "skipped"
+	ComponentCancelled ComponentStatus = "cancelled"
+)
+
 // Execution represents a job execution record
 type Execution struct {
-	ID           string     `json:"id"`
-	JobName      string     `json:"job_name"`
-	StartTime    time.Time  `json:"start_time"`
-	EndTime      time.Time  `json:"end_time"`
-	Status       string     `json:"status"`
-	ErrorMessage string     `json:"error_message"`
-	CreatedAt    time.Time  `json:"created_at"`
+	ID           string    `json:"id"`
+	JobName      string    `json:"job_name"`
+	StartTime    time.Time `json:"start_time"`
+	EndTime      time.Time `json:"end_time"`
+	Status       string    `json:"status"`
+	ErrorMessage string    `json:"error_message"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// ComponentExecution records an individual component's outcome within an execution.
+type ComponentExecution struct {
+	ID           int64           `json:"id"`
+	ExecutionID  string          `json:"execution_id"`
+	Component    ComponentName   `json:"component"`
+	Status       ComponentStatus `json:"status"`
+	StartTime    *time.Time      `json:"start_time"`
+	EndTime      *time.Time      `json:"end_time"`
+	ErrorMessage string          `json:"error_message"`
 }
 
 // Log represents a log entry for an execution

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -34,6 +34,18 @@ type Execution struct {
 	CreatedAt    time.Time `json:"created_at"`
 }
 
+type RepositoryRunStats struct {
+	LatestExecutionID string
+	LatestStatus      string
+	LatestStart       time.Time
+	LatestEnd         *time.Time
+	LatestError       string
+	LastSuccess       *time.Time
+	TotalRuns         int64
+	SuccessRuns       int64
+	FailedRuns        int64
+}
+
 // ComponentExecution records an individual component's outcome within an execution.
 type ComponentExecution struct {
 	ID           int64           `json:"id"`

--- a/internal/discussion/discussion.go
+++ b/internal/discussion/discussion.go
@@ -262,7 +262,7 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 		ui.Printf("The latest update time among all discussions is: %s", lastUpdate)
 	}
 
-	cfg := config.GetIns()
+	cfg := config.GetExecutionConfig(ctx)
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: cfg.GitHubToken},
 	)
@@ -280,7 +280,7 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 	// Fetch discussion list
 	for {
 		var query discussionsQuery
-		err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+		err := retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
 			permit, acquireErr := githubapi.Acquire(ctx, "graphql")
 			if acquireErr != nil {
 				return acquireErr
@@ -333,7 +333,7 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 			// Fetch comments
 			for {
 				var commentsQuery commentsQuery
-				err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+				err := retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
 					permit, acquireErr := githubapi.Acquire(ctx, "graphql")
 					if acquireErr != nil {
 						return acquireErr
@@ -373,7 +373,7 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 					// Fetch replies
 					for {
 						var repliesQuery repliesQuery
-						err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+						err := retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
 							permit, acquireErr := githubapi.Acquire(ctx, "graphql")
 							if acquireErr != nil {
 								return acquireErr

--- a/internal/executor/components.go
+++ b/internal/executor/components.go
@@ -1,0 +1,57 @@
+package executor
+
+import (
+	"context"
+
+	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/discussion"
+	"github.com/wnarutou/gitrieve/internal/issue"
+	"github.com/wnarutou/gitrieve/internal/release"
+	"github.com/wnarutou/gitrieve/internal/repository"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+	"github.com/wnarutou/gitrieve/internal/wiki"
+)
+
+type SyncFunc func(context.Context, typedef.Repository, []typedef.MultiStorage) error
+
+type Runners struct {
+	Code       SyncFunc
+	Release    SyncFunc
+	Issue      SyncFunc
+	Wiki       SyncFunc
+	Discussion SyncFunc
+}
+
+type component struct {
+	name db.ComponentName
+	run  SyncFunc
+}
+
+func defaultRunners() Runners {
+	return Runners{
+		Code: func(ctx context.Context, repo typedef.Repository, storages []typedef.MultiStorage) error {
+			return repository.Sync(ctx, repo, false, storages)
+		},
+		Release:    release.DownloadAllAssets,
+		Issue:      issue.Sync,
+		Wiki:       wiki.Sync,
+		Discussion: discussion.Sync,
+	}
+}
+
+func componentPlan(repo typedef.Repository, runners Runners) []component {
+	components := []component{{name: db.ComponentCode, run: runners.Code}}
+	if repo.DownloadReleases {
+		components = append(components, component{name: db.ComponentRelease, run: runners.Release})
+	}
+	if repo.DownloadIssues {
+		components = append(components, component{name: db.ComponentIssue, run: runners.Issue})
+	}
+	if repo.DownloadWiki {
+		components = append(components, component{name: db.ComponentWiki, run: runners.Wiki})
+	}
+	if repo.DownloadDiscussion {
+		components = append(components, component{name: db.ComponentDiscussion, run: runners.Discussion})
+	}
+	return components
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -172,9 +172,7 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 		// Write the final log line BEFORE the terminal status update so the SSE
 		// log stream (which emits "done" as soon as it sees a terminal status)
 		// does not flush before this row is committed and drop it.
-		ui.Printf("Job was cancelled")
-		e.cancelComponents(jobID, plan, 0, ctx.Err())
-		e.updateJobStatus(jobID, string(StatusCancelled), "")
+		e.finishCancellation(jobID, plan, 0, ctx.Err())
 		return
 	}
 
@@ -196,11 +194,10 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 	}
 
 	failures := make([]string, 0)
+	allComponentsTerminal := true
 	for i, planned := range plan {
 		if ctx.Err() != nil {
-			e.cancelComponents(jobID, plan, i, ctx.Err())
-			ui.Printf("Job was cancelled")
-			e.updateJobStatus(jobID, string(StatusCancelled), "")
+			e.finishCancellation(jobID, plan, i, ctx.Err())
 			return
 		}
 
@@ -208,7 +205,12 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 			message := fmt.Sprintf("persist running state: %v", err)
 			failures = append(failures, componentFailure(planned.name, message))
 			ui.Errorf("Failed to start %s: %v", planned.name, err)
-			e.finishAfterStoreFailure(jobID, planned.name, message)
+			if fallbackErr := e.finishAfterStoreFailure(jobID, planned.name, message); fallbackErr != nil {
+				fallbackMessage := fmt.Sprintf("persist failed fallback: %v", fallbackErr)
+				failures = append(failures, componentFailure(planned.name, fallbackMessage))
+				ui.Errorf("Failed to record %s store failure: %v", planned.name, fallbackErr)
+				allComponentsTerminal = false
+			}
 			continue
 		}
 
@@ -216,10 +218,8 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 			ui.Printf("Downloading %s", componentLogName(planned.name))
 		}
 		runErr := planned.run(ctx, job, storages)
-		if cancelErr := componentCancellation(ctx, runErr); cancelErr != nil {
-			e.cancelComponents(jobID, plan, i, cancelErr)
-			ui.Printf("Job was cancelled")
-			e.updateJobStatus(jobID, string(StatusCancelled), "")
+		if cancelErr := componentCancellation(ctx); cancelErr != nil {
+			e.finishCancellation(jobID, plan, i, cancelErr)
 			return
 		}
 
@@ -240,18 +240,27 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 			message := fmt.Sprintf("persist %s state: %v", status, err)
 			failures = append(failures, componentFailure(planned.name, message))
 			ui.Errorf("Failed to finish %s: %v", planned.name, err)
-			e.finishAfterStoreFailure(jobID, planned.name, message)
+			if fallbackErr := e.finishAfterStoreFailure(jobID, planned.name, message); fallbackErr != nil {
+				fallbackMessage := fmt.Sprintf("persist failed fallback: %v", fallbackErr)
+				failures = append(failures, componentFailure(planned.name, fallbackMessage))
+				ui.Errorf("Failed to record %s store failure: %v", planned.name, fallbackErr)
+				allComponentsTerminal = false
+			}
 		}
 	}
 
+	if !allComponentsTerminal {
+		ui.Errorf("Job cannot be finalized while component rows remain active")
+		return
+	}
 	if len(failures) != 0 {
-		e.updateJobStatus(jobID, string(StatusFailed), strings.Join(failures, "; "))
+		e.finishExecution(jobID, StatusFailed, strings.Join(failures, "; "))
 		return
 	}
 
 	// Final log line before the terminal status update (see note above).
 	ui.Printf("Job completed successfully")
-	e.updateJobStatus(jobID, string(StatusCompleted), "")
+	e.finishExecution(jobID, StatusCompleted, "")
 }
 
 func componentFailure(name db.ComponentName, message string) string {
@@ -262,14 +271,8 @@ func componentFailure(name db.ComponentName, message string) string {
 	return fmt.Sprintf("%s: %s", label, message)
 }
 
-func componentCancellation(ctx context.Context, runErr error) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-	if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
-		return runErr
-	}
-	return nil
+func componentCancellation(ctx context.Context) error {
+	return ctx.Err()
 }
 
 func componentLogName(name db.ComponentName) string {
@@ -279,18 +282,55 @@ func componentLogName(name db.ComponentName) string {
 	return string(name)
 }
 
-func (e *Executor) cancelComponents(jobID string, plan []component, first int, cancelErr error) {
+func (e *Executor) finishCancellation(jobID string, plan []component, first int, cancelErr error) {
+	failures, allTerminal := e.cancelComponents(jobID, plan, first, cancelErr)
+	ui.Printf("Job was cancelled")
+	if !allTerminal {
+		ui.Errorf("Job cannot be finalized while component rows remain active")
+		return
+	}
+	if len(failures) != 0 {
+		e.finishExecution(jobID, StatusFailed, strings.Join(failures, "; "))
+		return
+	}
+	e.finishExecution(jobID, StatusCancelled, "")
+}
+
+func (e *Executor) cancelComponents(jobID string, plan []component, first int, cancelErr error) ([]string, bool) {
+	failures := make([]string, 0)
+	allTerminal := true
 	message := cancelErr.Error()
 	for _, planned := range plan[first:] {
 		if err := e.db.FinishComponent(context.Background(), jobID, planned.name, db.ComponentCancelled, time.Now(), message); err != nil {
 			ui.Errorf("Failed to cancel %s: %v", planned.name, err)
+			persistenceMessage := fmt.Sprintf("persist cancelled state: %v", err)
+			failures = append(failures, componentFailure(planned.name, persistenceMessage))
+			if fallbackErr := e.finishAfterStoreFailure(jobID, planned.name, persistenceMessage); fallbackErr != nil {
+				fallbackMessage := fmt.Sprintf("persist failed fallback: %v", fallbackErr)
+				failures = append(failures, componentFailure(planned.name, fallbackMessage))
+				ui.Errorf("Failed to record %s cancellation store failure: %v", planned.name, fallbackErr)
+				allTerminal = false
+			}
 		}
 	}
+	return failures, allTerminal
 }
 
-func (e *Executor) finishAfterStoreFailure(jobID string, name db.ComponentName, message string) {
-	if err := e.db.FinishComponent(context.Background(), jobID, name, db.ComponentFailed, time.Now(), message); err != nil {
-		ui.Errorf("Failed to record %s store failure: %v", name, err)
+func (e *Executor) finishAfterStoreFailure(jobID string, name db.ComponentName, message string) error {
+	return e.db.FinishComponent(context.Background(), jobID, name, db.ComponentFailed, time.Now(), message)
+}
+
+func (e *Executor) finishExecution(jobID string, status ExecutionStatus, errorMessage string) {
+	if err := e.updateJobStatus(jobID, string(status), errorMessage); err != nil {
+		ui.Errorf("Failed to finish job as %s: %v", status, err)
+		if status == StatusFailed {
+			return
+		}
+
+		failureMessage := fmt.Sprintf("persist %s execution state: %v", status, err)
+		if fallbackErr := e.updateJobStatus(jobID, string(StatusFailed), failureMessage); fallbackErr != nil {
+			ui.Errorf("Failed to record overall execution store failure: %v", fallbackErr)
+		}
 	}
 }
 
@@ -309,21 +349,35 @@ func (e *Executor) CancelJob(jobID string) error {
 }
 
 func (e *Executor) updateJobStatus(jobID string, status string, errorMessage string) error {
-	var err error
+	var (
+		result interface {
+			RowsAffected() (int64, error)
+		}
+		err error
+	)
 	if status == string(StatusPending) || status == string(StatusRunning) {
-		_, err = e.db.Exec(`
+		result, err = e.db.Exec(`
 			UPDATE executions SET status = ?, error_message = ?
 			WHERE id = ?
 		`, status, errorMessage, jobID)
 	} else {
 		endTime := time.Now()
-		_, err = e.db.Exec(`
+		result, err = e.db.Exec(`
 			UPDATE executions SET status = ?, error_message = ?, end_time = ?
 			WHERE id = ?
 		`, status, errorMessage, endTime, jobID)
 	}
-
-	return err
+	if err != nil {
+		return fmt.Errorf("update execution %q to %q: %w", jobID, status, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update execution %q to %q: inspect affected rows: %w", jobID, status, err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("update execution %q to %q: expected one row, updated %d", jobID, status, rows)
+	}
+	return nil
 }
 
 func (e *Executor) IsJobRunning(jobID string) bool {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -62,6 +62,16 @@ type RepositoryNoLongerEligibleError struct {
 	RepositoryKey string
 }
 
+// RepositoryExpansionEmptyError is an enqueue failure: a configured user/org
+// expanded successfully but currently contains no concrete repositories.
+type RepositoryExpansionEmptyError struct {
+	RepositoryKey string
+}
+
+func (e *RepositoryExpansionEmptyError) Error() string {
+	return fmt.Sprintf("repository %q expansion returned no concrete repositories", e.RepositoryKey)
+}
+
 func (e *RepositoryNoLongerEligibleError) Error() string {
 	return fmt.Sprintf("repository %q is no longer eligible", e.RepositoryKey)
 }
@@ -306,9 +316,20 @@ func (e *Executor) executeJobFromSnapshot(admissionCtx context.Context, runtime 
 	}
 
 	if e.expander != nil {
-		return e.submitBatch(admissionCtx, runtime, repo, e.expander(repo), expectedGeneration, eligible)
+		repositories := e.expander(repo)
+		if len(repositories) == 0 {
+			return nil, &RepositoryExpansionEmptyError{RepositoryKey: repo.Key()}
+		}
+		return e.submitBatch(admissionCtx, runtime, repo, repositories, expectedGeneration, eligible)
 	}
-	return e.submitBatch(admissionCtx, runtime, repo, expandRepos(runtime.executionContext(admissionCtx), repo), expectedGeneration, eligible)
+	repositories, err := expandRepos(runtime.executionContext(admissionCtx), repo)
+	if err != nil {
+		return nil, err
+	}
+	if len(repositories) == 0 {
+		return nil, &RepositoryExpansionEmptyError{RepositoryKey: repo.Key()}
+	}
+	return e.submitBatch(admissionCtx, runtime, repo, repositories, expectedGeneration, eligible)
 }
 
 // submitBatch reserves, preflights, and persists every concrete repository

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -4,20 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/wnarutou/gitrieve/internal/config"
-	"github.com/wnarutou/gitrieve/internal/db"
-	"github.com/wnarutou/gitrieve/internal/discussion"
-	"github.com/wnarutou/gitrieve/internal/issue"
-	"github.com/wnarutou/gitrieve/internal/logger"
-	"github.com/wnarutou/gitrieve/internal/release"
-	"github.com/wnarutou/gitrieve/internal/repository"
-	"github.com/wnarutou/gitrieve/internal/typedef"
-	"github.com/wnarutou/gitrieve/internal/ui"
-	"github.com/wnarutou/gitrieve/internal/wiki"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/logger"
+	"github.com/wnarutou/gitrieve/internal/repository"
+	"github.com/wnarutou/gitrieve/internal/syncresult"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+	"github.com/wnarutou/gitrieve/internal/ui"
 )
 
 type ExecutionStatus string
@@ -38,11 +37,16 @@ type JobContext struct {
 type Executor struct {
 	db          *db.DB
 	cfg         atomic.Pointer[config.Config]
+	runners     Runners
 	runningJobs map[string]*JobContext
 	mu          sync.RWMutex
 }
 
 func NewExecutor(logger *logger.Logger, db *db.DB, cfg *config.Config) *Executor {
+	return NewExecutorWithRunners(logger, db, cfg, defaultRunners())
+}
+
+func NewExecutorWithRunners(logger *logger.Logger, db *db.DB, cfg *config.Config, runners Runners) *Executor {
 	// Side effect: re-points the package-global ui sink so executor log output
 	// is persisted to the DB. Only the server process constructs an Executor;
 	// the CLI and daemon never do, so their stdout-only ui output is unchanged.
@@ -51,6 +55,7 @@ func NewExecutor(logger *logger.Logger, db *db.DB, cfg *config.Config) *Executor
 	}
 	exec := &Executor{
 		db:          db,
+		runners:     runners,
 		runningJobs: make(map[string]*JobContext),
 	}
 	exec.cfg.Store(cfg)
@@ -107,6 +112,7 @@ func (e *Executor) launchJob(job typedef.Repository) (string, error) {
 	// Generate job ID
 	jobID := uuid.New().String()
 	startTime := time.Now()
+	plan := componentPlan(job, e.runners)
 
 	// Create execution record: job_name 保存展示名快照，repo_key 是身份键。
 	_, err := e.db.Exec(`
@@ -115,6 +121,18 @@ func (e *Executor) launchJob(job typedef.Repository) (string, error) {
 	`, jobID, job.Name, job.Key(), startTime, string(StatusPending))
 	if err != nil {
 		return "", fmt.Errorf("failed to create execution record: %w", err)
+	}
+
+	componentNames := make([]db.ComponentName, len(plan))
+	for i := range plan {
+		componentNames[i] = plan[i].name
+	}
+	if err := e.db.CreateComponents(context.Background(), jobID, componentNames); err != nil {
+		message := fmt.Sprintf("create component records: %v", err)
+		if statusErr := e.updateJobStatus(jobID, string(StatusFailed), message); statusErr != nil {
+			return "", fmt.Errorf("%s; mark execution failed: %w", message, statusErr)
+		}
+		return "", errors.New(message)
 	}
 
 	// Create cancellable context
@@ -132,12 +150,12 @@ func (e *Executor) launchJob(job typedef.Repository) (string, error) {
 	e.updateJobStatus(jobID, string(StatusRunning), "")
 
 	// Execute async
-	go e.executeAsync(ctx, jobID, job)
+	go e.executeAsync(ctx, jobID, job, plan)
 
 	return jobID, nil
 }
 
-func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.Repository) {
+func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.Repository, plan []component) {
 	unbind := ui.Bind(jobID, job.Name)
 	defer unbind()
 
@@ -155,6 +173,7 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 		// log stream (which emits "done" as soon as it sees a terminal status)
 		// does not flush before this row is committed and drop it.
 		ui.Printf("Job was cancelled")
+		e.cancelComponents(jobID, plan, 0, ctx.Err())
 		e.updateJobStatus(jobID, string(StatusCancelled), "")
 		return
 	}
@@ -176,57 +195,103 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 		}
 	}
 
-	// Execute repository sync (code). The metadata/content components below run
-	// even if this fails, mirroring the daemon's independent per-repo jobs, so a
-	// partial archive is still attempted. When the caller cancels, Sync returns
-	// promptly with the context error; skip the "failed" log in that case.
-	codeErr := repository.Sync(ctx, job, false, storages)
-	if codeErr != nil && ctx.Err() == nil {
-		ui.Errorf("Code sync failed: %v", codeErr)
+	failures := make([]string, 0)
+	for i, planned := range plan {
+		if ctx.Err() != nil {
+			e.cancelComponents(jobID, plan, i, ctx.Err())
+			ui.Printf("Job was cancelled")
+			e.updateJobStatus(jobID, string(StatusCancelled), "")
+			return
+		}
+
+		if err := e.db.StartComponent(context.Background(), jobID, planned.name, time.Now()); err != nil {
+			message := fmt.Sprintf("persist running state: %v", err)
+			failures = append(failures, componentFailure(planned.name, message))
+			ui.Errorf("Failed to start %s: %v", planned.name, err)
+			e.finishAfterStoreFailure(jobID, planned.name, message)
+			continue
+		}
+
+		if planned.name != db.ComponentCode {
+			ui.Printf("Downloading %s", componentLogName(planned.name))
+		}
+		runErr := planned.run(ctx, job, storages)
+		if cancelErr := componentCancellation(ctx, runErr); cancelErr != nil {
+			e.cancelComponents(jobID, plan, i, cancelErr)
+			ui.Printf("Job was cancelled")
+			e.updateJobStatus(jobID, string(StatusCancelled), "")
+			return
+		}
+
+		status := db.ComponentCompleted
+		errorMessage := ""
+		if reason, skipped := syncresult.SkippedReason(runErr); skipped {
+			status = db.ComponentSkipped
+			errorMessage = reason
+			ui.Printf("Skipping %s: %s", componentLogName(planned.name), reason)
+		} else if runErr != nil {
+			status = db.ComponentFailed
+			errorMessage = runErr.Error()
+			failures = append(failures, componentFailure(planned.name, errorMessage))
+			ui.Errorf("Failed to download %s: %v", componentLogName(planned.name), runErr)
+		}
+
+		if err := e.db.FinishComponent(context.Background(), jobID, planned.name, status, time.Now(), errorMessage); err != nil {
+			message := fmt.Sprintf("persist %s state: %v", status, err)
+			failures = append(failures, componentFailure(planned.name, message))
+			ui.Errorf("Failed to finish %s: %v", planned.name, err)
+			e.finishAfterStoreFailure(jobID, planned.name, message)
+		}
 	}
 
-	// Download the configured metadata/content components. Best-effort: a
-	// component may legitimately fail (e.g. a repo with no wiki), so failures
-	// are logged as errors but the job status reflects only the code sync.
-	e.downloadComponents(ctx, job, storages)
+	if len(failures) != 0 {
+		e.updateJobStatus(jobID, string(StatusFailed), strings.Join(failures, "; "))
+		return
+	}
 
-	if ctx.Err() != nil {
-		// Final log line before the terminal status update (see note above).
-		ui.Printf("Job was cancelled")
-		e.updateJobStatus(jobID, string(StatusCancelled), "")
-		return
-	}
-	if codeErr != nil {
-		e.updateJobStatus(jobID, string(StatusFailed), codeErr.Error())
-		return
-	}
 	// Final log line before the terminal status update (see note above).
 	ui.Printf("Job completed successfully")
 	e.updateJobStatus(jobID, string(StatusCompleted), "")
 }
 
-// downloadComponents runs the per-repository metadata/content syncs enabled in
-// the config (releases, issues, wiki, discussions), mirroring what the daemon
-// schedules. Each runs independently; progress and failures are logged via ui
-// so they surface in the job's log stream.
-func (e *Executor) downloadComponents(ctx context.Context, job typedef.Repository, storages []typedef.MultiStorage) {
-	run := func(name string, enabled bool, fn func() error) {
-		if !enabled || ctx.Err() != nil {
-			return
-		}
-		ui.Printf("Downloading %s", name)
-		if err := fn(); err != nil {
-			if ctx.Err() != nil {
-				ui.Printf("%s download cancelled", name)
-			} else {
-				ui.Errorf("Failed to download %s: %v", name, err)
-			}
+func componentFailure(name db.ComponentName, message string) string {
+	label := string(name)
+	if name == db.ComponentIssue {
+		label = "issue"
+	}
+	return fmt.Sprintf("%s: %s", label, message)
+}
+
+func componentCancellation(ctx context.Context, runErr error) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if errors.Is(runErr, context.Canceled) || errors.Is(runErr, context.DeadlineExceeded) {
+		return runErr
+	}
+	return nil
+}
+
+func componentLogName(name db.ComponentName) string {
+	if name == db.ComponentRelease {
+		return "releases"
+	}
+	return string(name)
+}
+
+func (e *Executor) cancelComponents(jobID string, plan []component, first int, cancelErr error) {
+	message := cancelErr.Error()
+	for _, planned := range plan[first:] {
+		if err := e.db.FinishComponent(context.Background(), jobID, planned.name, db.ComponentCancelled, time.Now(), message); err != nil {
+			ui.Errorf("Failed to cancel %s: %v", planned.name, err)
 		}
 	}
-	run("releases", job.DownloadReleases, func() error { return release.DownloadAllAssets(ctx, job, storages) })
-	run("issues", job.DownloadIssues, func() error { return issue.Sync(ctx, job, storages) })
-	run("wiki", job.DownloadWiki, func() error { return wiki.Sync(ctx, job, storages) })
-	run("discussion", job.DownloadDiscussion, func() error { return discussion.Sync(ctx, job, storages) })
+}
+
+func (e *Executor) finishAfterStoreFailure(jobID string, name db.ComponentName, message string) {
+	if err := e.db.FinishComponent(context.Background(), jobID, name, db.ComponentFailed, time.Now(), message); err != nil {
+		ui.Errorf("Failed to record %s store failure: %v", name, err)
+	}
 }
 
 func (e *Executor) CancelJob(jobID string) error {
@@ -240,9 +305,7 @@ func (e *Executor) CancelJob(jobID string) error {
 	}
 
 	jobCtx.CancelFunc()
-
-	// Update status in database
-	return e.updateJobStatus(jobID, string(StatusCancelled), "")
+	return nil
 }
 
 func (e *Executor) updateJobStatus(jobID string, status string, errorMessage string) error {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/logger"
 	"github.com/wnarutou/gitrieve/internal/repository"
 	"github.com/wnarutou/gitrieve/internal/syncresult"
@@ -49,6 +50,20 @@ type queuedJob struct {
 type preparedJob struct {
 	queued     *queuedJob
 	jobContext *JobContext
+}
+
+// EligibilityCheck runs after the Executor has reserved all concrete
+// repositories but before any pending execution is persisted or published.
+type EligibilityCheck func(context.Context, *RuntimeConfigSnapshot, typedef.Repository) (bool, error)
+
+// RepositoryNoLongerEligibleError distinguishes a completed eligibility
+// change from admission/storage failures for bulk response accounting.
+type RepositoryNoLongerEligibleError struct {
+	RepositoryKey string
+}
+
+func (e *RepositoryNoLongerEligibleError) Error() string {
+	return fmt.Sprintf("repository %q is no longer eligible", e.RepositoryKey)
 }
 
 type executionStore interface {
@@ -88,9 +103,11 @@ type Executor struct {
 // Callers can inspect cloned repository values but cannot mutate the published
 // configuration or its normalized-key index.
 type RuntimeConfigSnapshot struct {
-	config       *config.Config
-	generation   uint64
-	repositories map[string]typedef.Repository
+	config          *config.Config
+	executionConfig *config.ExecutionSnapshot
+	githubAPIScope  *githubapi.Scope
+	generation      uint64
+	repositories    map[string]typedef.Repository
 }
 
 func buildRuntimeConfigSnapshot(cfg *config.Config) *RuntimeConfigSnapshot {
@@ -104,7 +121,12 @@ func buildRuntimeConfigSnapshot(cfg *config.Config) *RuntimeConfigSnapshot {
 			}
 		}
 	}
-	return &RuntimeConfigSnapshot{config: cloned, repositories: indexed}
+	return &RuntimeConfigSnapshot{
+		config:          cloned,
+		executionConfig: config.NewExecutionSnapshot(cloned),
+		githubAPIScope:  githubapi.NewScope(config.GitHubAPIConfigFrom(cloned)),
+		repositories:    indexed,
+	}
 }
 
 func cloneRuntimeConfig(cfg *config.Config) *config.Config {
@@ -167,6 +189,14 @@ func (s *RuntimeConfigSnapshot) SyncHealthThresholds() (time.Duration, time.Dura
 		return 0, 0
 	}
 	return s.config.SyncOverdueGrace, s.config.SyncStuckThreshold
+}
+
+func (s *RuntimeConfigSnapshot) executionContext(parent context.Context) context.Context {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx := config.WithExecutionSnapshot(parent, s.executionConfig)
+	return githubapi.WithScope(ctx, s.githubAPIScope)
 }
 
 func NewExecutor(logger *logger.Logger, db *db.DB, cfg *config.Config) *Executor {
@@ -234,13 +264,13 @@ var ErrConfigGenerationChanged = errors.New("executor configuration generation c
 
 // expandRepos 是把 user/org 条目展开为具体仓库的 seam：生产用 repository.Expand，
 // 测试注入 fake，避免真实 GitHub 调用。
-var expandRepos = repository.Expand
+var expandRepos = repository.ExpandContext
 
 // ExecuteJob 按仓库身份键（规范化 URL）在配置中定位条目并执行。type=repo 产生
 // 一条 execution 并返回单元素 jobID；type=user/org 先在任务内展开为具体仓库，
 // 每个具体仓库独立执行（各自 jobID / execution / 日志流 / 可取消）。
 func (e *Executor) ExecuteJob(repoKey string) ([]string, error) {
-	return e.executeJobFromSnapshot(context.Background(), e.runtime.Load(), repoKey, nil)
+	return e.executeJobFromSnapshot(context.Background(), e.runtime.Load(), repoKey, nil, nil)
 }
 
 func (e *Executor) ExecuteJobAtGeneration(repoKey string, generation uint64) ([]string, error) {
@@ -255,27 +285,38 @@ func (e *Executor) ExecuteJobAtGenerationContext(ctx context.Context, repoKey st
 	if runtime == nil || runtime.generation != generation {
 		return nil, ErrConfigGenerationChanged
 	}
-	return e.executeJobFromSnapshot(ctx, runtime, repoKey, &generation)
+	return e.executeJobFromSnapshot(ctx, runtime, repoKey, &generation, nil)
 }
 
-func (e *Executor) executeJobFromSnapshot(admissionCtx context.Context, runtime *RuntimeConfigSnapshot, repoKey string, expectedGeneration *uint64) ([]string, error) {
+// ExecuteJobAtGenerationIfEligibleContext is the bulk admission path. It
+// reserves first, evaluates eligible while ownership is held, then persists
+// and publishes only when the callback still accepts the repository.
+func (e *Executor) ExecuteJobAtGenerationIfEligibleContext(ctx context.Context, repoKey string, generation uint64, eligible EligibilityCheck) ([]string, error) {
+	runtime := e.runtime.Load()
+	if runtime == nil || runtime.generation != generation {
+		return nil, ErrConfigGenerationChanged
+	}
+	return e.executeJobFromSnapshot(ctx, runtime, repoKey, &generation, eligible)
+}
+
+func (e *Executor) executeJobFromSnapshot(admissionCtx context.Context, runtime *RuntimeConfigSnapshot, repoKey string, expectedGeneration *uint64, eligible EligibilityCheck) ([]string, error) {
 	repo, found := runtime.Repository(repoKey)
 	if !found {
 		return nil, ErrRepositoryNotFound
 	}
 
 	if e.expander != nil {
-		return e.submitBatch(admissionCtx, runtime, e.expander(repo), expectedGeneration)
+		return e.submitBatch(admissionCtx, runtime, repo, e.expander(repo), expectedGeneration, eligible)
 	}
-	return e.submitBatch(admissionCtx, runtime, expandRepos(repo), expectedGeneration)
+	return e.submitBatch(admissionCtx, runtime, repo, expandRepos(runtime.executionContext(admissionCtx), repo), expectedGeneration, eligible)
 }
 
 // submitBatch reserves, preflights, and persists every concrete repository
 // before atomically publishing any of them to the dispatcher.
-func (e *Executor) submitBatch(admissionCtx context.Context, runtime *RuntimeConfigSnapshot, repositories []typedef.Repository, expectedGeneration *uint64) ([]string, error) {
+func (e *Executor) submitBatch(admissionCtx context.Context, runtime *RuntimeConfigSnapshot, configured typedef.Repository, repositories []typedef.Repository, expectedGeneration *uint64, eligible EligibilityCheck) ([]string, error) {
 	prepared := make([]*preparedJob, len(repositories))
 	for i, repo := range repositories {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(runtime.executionContext(context.Background()))
 		jobID := uuid.New().String()
 		plan := componentPlan(repo, e.runners)
 		prepared[i] = &preparedJob{
@@ -304,6 +345,20 @@ func (e *Executor) submitBatch(admissionCtx context.Context, runtime *RuntimeCon
 	if err := e.preflightBatch(admissionCtx, prepared); err != nil {
 		e.releaseBatch(prepared, nil)
 		return nil, err
+	}
+	if eligible != nil {
+		stillEligible, err := eligible(admissionCtx, runtime, cloneRuntimeRepository(configured))
+		if err == nil {
+			err = admissionCtx.Err()
+		}
+		if err != nil {
+			e.releaseBatch(prepared, nil)
+			return nil, err
+		}
+		if !stillEligible {
+			e.releaseBatch(prepared, nil)
+			return nil, &RepositoryNoLongerEligibleError{RepositoryKey: configured.Key()}
+		}
 	}
 	if err := e.persistBatch(admissionCtx, prepared); err != nil {
 		e.releaseBatch(prepared, nil)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -55,7 +55,7 @@ type preparedJob struct {
 type executionStore interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	ActiveExecutionExists(context.Context, string) (bool, error)
-	CreateComponents(context.Context, string, []db.ComponentName) error
+	CreatePendingExecutions(context.Context, []db.PendingExecution) error
 	StartComponent(context.Context, string, db.ComponentName, time.Time) error
 	FinishComponent(context.Context, string, db.ComponentName, db.ComponentStatus, time.Time, string) error
 }
@@ -78,6 +78,7 @@ type Executor struct {
 	dispatcherDone    chan struct{}
 	closeDone         chan struct{}
 	closeErr          error
+	closeWaiters      int
 	workers           sync.WaitGroup
 }
 
@@ -192,7 +193,8 @@ func (e *Executor) submitBatch(repositories []typedef.Repository) ([]string, err
 		return nil, err
 	}
 	if err := e.persistBatch(prepared); err != nil {
-		return nil, errors.Join(err, e.abortBatch(prepared, StatusFailed, err.Error()))
+		e.releaseBatch(prepared)
+		return nil, err
 	}
 
 	e.queueMu.Lock()
@@ -253,23 +255,25 @@ func (e *Executor) preflightBatch(prepared []*preparedJob) error {
 }
 
 func (e *Executor) persistBatch(prepared []*preparedJob) error {
-	for _, job := range prepared {
-		_, err := e.db.Exec(`
-			INSERT INTO executions (id, job_name, repo_key, start_time, status)
-			VALUES (?, ?, ?, ?, ?)
-		`, job.queued.id, job.queued.repo.Name, job.jobContext.repoKey, time.Now(), string(StatusPending))
-		if err != nil {
-			return fmt.Errorf("failed to create execution record: %w", err)
-		}
-		job.executionCreated = true
-
+	executions := make([]db.PendingExecution, len(prepared))
+	for i, job := range prepared {
 		componentNames := make([]db.ComponentName, len(job.queued.plan))
-		for i := range job.queued.plan {
-			componentNames[i] = job.queued.plan[i].name
+		for componentIndex := range job.queued.plan {
+			componentNames[componentIndex] = job.queued.plan[componentIndex].name
 		}
-		if err := e.db.CreateComponents(context.Background(), job.queued.id, componentNames); err != nil {
-			return fmt.Errorf("create component records: %w", err)
+		executions[i] = db.PendingExecution{
+			ID:         job.queued.id,
+			JobName:    job.queued.repo.Name,
+			RepoKey:    job.jobContext.repoKey,
+			StartTime:  time.Now(),
+			Components: componentNames,
 		}
+	}
+	if err := e.db.CreatePendingExecutions(context.Background(), executions); err != nil {
+		return fmt.Errorf("create pending execution batch: %w", err)
+	}
+	for _, job := range prepared {
+		job.executionCreated = true
 		job.componentsCreated = true
 	}
 	return nil
@@ -635,10 +639,13 @@ func (e *Executor) finishQueuedCancellation(job *queuedJob) {
 func (e *Executor) Close() error {
 	e.queueMu.Lock()
 	if e.closed {
+		e.closeWaiters++
+		e.queueCond.Broadcast()
 		done := e.closeDone
 		e.queueMu.Unlock()
 		<-done
 		e.queueMu.Lock()
+		e.closeWaiters--
 		err := e.closeErr
 		e.queueMu.Unlock()
 		return err

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -60,9 +60,11 @@ type executionStore interface {
 }
 
 type Executor struct {
-	db      executionStore
-	cfg     atomic.Pointer[config.Config]
-	runners Runners
+	db             executionStore
+	runtime        atomic.Pointer[RuntimeConfigSnapshot]
+	nextGeneration atomic.Uint64
+	runners        Runners
+	expander       func(typedef.Repository) []typedef.Repository
 
 	queueMu           sync.Mutex
 	queueCond         *sync.Cond
@@ -81,11 +83,88 @@ type Executor struct {
 	workers           sync.WaitGroup
 }
 
+// RuntimeConfigSnapshot is an immutable Executor configuration generation.
+// Callers can inspect cloned repository values but cannot mutate the published
+// configuration or its normalized-key index.
+type RuntimeConfigSnapshot struct {
+	config       *config.Config
+	generation   uint64
+	repositories map[string]typedef.Repository
+}
+
+func buildRuntimeConfigSnapshot(cfg *config.Config) *RuntimeConfigSnapshot {
+	cloned := cloneRuntimeConfig(cfg)
+	indexed := make(map[string]typedef.Repository)
+	if cloned != nil {
+		indexed = make(map[string]typedef.Repository, len(cloned.Repository))
+		for _, repository := range cloned.Repository {
+			if key := repository.Key(); key != "" {
+				indexed[key] = repository
+			}
+		}
+	}
+	return &RuntimeConfigSnapshot{config: cloned, repositories: indexed}
+}
+
+func cloneRuntimeConfig(cfg *config.Config) *config.Config {
+	if cfg == nil {
+		return nil
+	}
+	cloned := *cfg
+	cloned.Repository = make([]typedef.Repository, len(cfg.Repository))
+	for i, repository := range cfg.Repository {
+		cloned.Repository[i] = cloneRuntimeRepository(repository)
+	}
+	cloned.Storage = append([]typedef.MultiStorage(nil), cfg.Storage...)
+	return &cloned
+}
+
+func cloneRuntimeRepository(repository typedef.Repository) typedef.Repository {
+	repository.Storage = append([]string(nil), repository.Storage...)
+	return repository
+}
+
+func (s *RuntimeConfigSnapshot) Generation() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.generation
+}
+
+func (s *RuntimeConfigSnapshot) Repository(repositoryKey string) (typedef.Repository, bool) {
+	if s == nil {
+		return typedef.Repository{}, false
+	}
+	repository, found := s.repositories[typedef.NormalizeURL(repositoryKey)]
+	if !found {
+		return typedef.Repository{}, false
+	}
+	return cloneRuntimeRepository(repository), true
+}
+
+func (s *RuntimeConfigSnapshot) Repositories() []typedef.Repository {
+	if s == nil || s.config == nil {
+		return nil
+	}
+	repositories := make([]typedef.Repository, len(s.config.Repository))
+	for i, repository := range s.config.Repository {
+		repositories[i] = cloneRuntimeRepository(repository)
+	}
+	return repositories
+}
+
+func (s *RuntimeConfigSnapshot) SyncHealthThresholds() (time.Duration, time.Duration) {
+	if s == nil || s.config == nil {
+		return 0, 0
+	}
+	return s.config.SyncOverdueGrace, s.config.SyncStuckThreshold
+}
+
 func NewExecutor(logger *logger.Logger, db *db.DB, cfg *config.Config) *Executor {
 	return NewExecutorWithRunners(logger, db, cfg, defaultRunners())
 }
 
-func NewExecutorWithRunners(logger *logger.Logger, db *db.DB, cfg *config.Config, runners Runners) *Executor {
+func NewExecutorWithRunners(logger *logger.Logger, db *db.DB, cfg *config.Config, runners Runners, expanders ...func(typedef.Repository) []typedef.Repository) *Executor {
 	// Side effect: re-points the package-global ui sink so executor log output
 	// is persisted to the DB. Only the server process constructs an Executor;
 	// the CLI and daemon never do, so their stdout-only ui output is unchanged.
@@ -101,8 +180,13 @@ func NewExecutorWithRunners(logger *logger.Logger, db *db.DB, cfg *config.Config
 		dispatcherDone: make(chan struct{}),
 		closeDone:      make(chan struct{}),
 	}
+	if len(expanders) > 0 {
+		exec.expander = expanders[0]
+	}
 	exec.queueCond = sync.NewCond(&exec.queueMu)
-	exec.cfg.Store(cfg)
+	runtime := buildRuntimeConfigSnapshot(cfg)
+	runtime.generation = exec.nextGeneration.Add(1)
+	exec.runtime.Store(runtime)
 	return exec
 }
 
@@ -117,24 +201,27 @@ func concurrencyLimit(cfg *config.Config) int {
 	return int(cfg.ConcurrencyNum)
 }
 
-// RefreshConfig repoints the executor at a new config instance. Called by the
-// server's config-reload endpoint after the config file is re-read. e.cfg is an
-// atomic pointer: concurrent reads (ExecuteJob's repository lookup and the
-// async executeAsync goroutine's storage lookup) observe either the old or the
-// new config in its entirety, never a torn read, so this is safe to call while
-// jobs are running.
+// RefreshConfig defensively clones and indexes cfg before atomically publishing
+// one immutable runtime generation.
 func (e *Executor) RefreshConfig(cfg *config.Config) {
+	runtime := buildRuntimeConfigSnapshot(cfg)
 	e.queueMu.Lock()
-	e.cfg.Store(cfg)
-	e.limit = concurrencyLimit(cfg)
+	runtime.generation = e.nextGeneration.Add(1)
+	e.limit = concurrencyLimit(runtime.config)
+	e.runtime.Store(runtime)
 	e.queueCond.Broadcast()
 	e.queueMu.Unlock()
+}
+
+func (e *Executor) RuntimeConfigSnapshot() *RuntimeConfigSnapshot {
+	return e.runtime.Load()
 }
 
 // ErrRepositoryNotFound 表示配置中找不到匹配该身份键的仓库条目。
 var ErrRepositoryNotFound = errors.New("repository not found in configuration")
 var ErrRepositoryActive = errors.New("repository is already active")
 var ErrExecutorClosed = errors.New("executor is closed")
+var ErrConfigGenerationChanged = errors.New("executor configuration generation changed")
 
 // expandRepos 是把 user/org 条目展开为具体仓库的 seam：生产用 repository.Expand，
 // 测试注入 fake，避免真实 GitHub 调用。
@@ -144,21 +231,26 @@ var expandRepos = repository.Expand
 // 一条 execution 并返回单元素 jobID；type=user/org 先在任务内展开为具体仓库，
 // 每个具体仓库独立执行（各自 jobID / execution / 日志流 / 可取消）。
 func (e *Executor) ExecuteJob(repoKey string) ([]string, error) {
-	var repo typedef.Repository
-	found := false
-	if cfg := e.cfg.Load(); cfg != nil {
-		for _, r := range cfg.Repository {
-			if r.Matches(repoKey) {
-				repo = r
-				found = true
-				break
-			}
-		}
+	return e.executeJobFromSnapshot(e.runtime.Load(), repoKey)
+}
+
+func (e *Executor) ExecuteJobAtGeneration(repoKey string, generation uint64) ([]string, error) {
+	runtime := e.runtime.Load()
+	if runtime == nil || runtime.generation != generation {
+		return nil, ErrConfigGenerationChanged
 	}
+	return e.executeJobFromSnapshot(runtime, repoKey)
+}
+
+func (e *Executor) executeJobFromSnapshot(runtime *RuntimeConfigSnapshot, repoKey string) ([]string, error) {
+	repo, found := runtime.Repository(repoKey)
 	if !found {
 		return nil, ErrRepositoryNotFound
 	}
 
+	if e.expander != nil {
+		return e.submitBatch(e.expander(repo))
+	}
 	return e.submitBatch(expandRepos(repo))
 }
 
@@ -394,9 +486,9 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 
 	// Get storages
 	var storages []typedef.MultiStorage
-	if cfg := e.cfg.Load(); cfg != nil {
+	if runtime := e.runtime.Load(); runtime != nil && runtime.config != nil {
 		for _, storageName := range job.Storage {
-			for _, s := range cfg.Storage {
+			for _, s := range runtime.config.Storage {
 				if s.Name == storageName {
 					storages = append(storages, typedef.MultiStorage{
 						Storage: typedef.Storage{

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
@@ -44,8 +45,23 @@ type queuedJob struct {
 	plan []component
 }
 
+type preparedJob struct {
+	queued            *queuedJob
+	jobContext        *JobContext
+	executionCreated  bool
+	componentsCreated bool
+}
+
+type executionStore interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	ActiveExecutionExists(context.Context, string) (bool, error)
+	CreateComponents(context.Context, string, []db.ComponentName) error
+	StartComponent(context.Context, string, db.ComponentName, time.Time) error
+	FinishComponent(context.Context, string, db.ComponentName, db.ComponentStatus, time.Time, string) error
+}
+
 type Executor struct {
-	db      *db.DB
+	db      executionStore
 	cfg     atomic.Pointer[config.Config]
 	runners Runners
 
@@ -56,6 +72,7 @@ type Executor struct {
 	activeByRepo      map[string]string
 	running           int
 	limit             int
+	inflight          int
 	closed            bool
 	dispatcherStarted bool
 	dispatcherDone    chan struct{}
@@ -92,6 +109,10 @@ func NewExecutorWithRunners(logger *logger.Logger, db *db.DB, cfg *config.Config
 func concurrencyLimit(cfg *config.Config) int {
 	if cfg == nil || cfg.ConcurrencyNum == 0 {
 		return 3
+	}
+	maxInt := int(^uint(0) >> 1)
+	if cfg.ConcurrencyNum > uint(maxInt) {
+		return maxInt
 	}
 	return int(cfg.ConcurrencyNum)
 }
@@ -138,81 +159,169 @@ func (e *Executor) ExecuteJob(repoKey string) ([]string, error) {
 		return nil, ErrRepositoryNotFound
 	}
 
-	jobIDs := make([]string, 0, 1)
-	for _, concrete := range expandRepos(repo) {
-		jobID, err := e.launchJob(concrete)
-		if err != nil {
-			return nil, err
+	return e.submitBatch(expandRepos(repo))
+}
+
+// submitBatch reserves, preflights, and persists every concrete repository
+// before atomically publishing any of them to the dispatcher.
+func (e *Executor) submitBatch(repositories []typedef.Repository) ([]string, error) {
+	prepared := make([]*preparedJob, len(repositories))
+	for i, repo := range repositories {
+		ctx, cancel := context.WithCancel(context.Background())
+		jobID := uuid.New().String()
+		plan := componentPlan(repo, e.runners)
+		prepared[i] = &preparedJob{
+			queued: &queuedJob{id: jobID, repo: repo, ctx: ctx, plan: plan},
+			jobContext: &JobContext{
+				Ctx:        ctx,
+				CancelFunc: cancel,
+				done:       make(chan struct{}),
+				repoKey:    repo.Key(),
+			},
 		}
-		jobIDs = append(jobIDs, jobID)
 	}
+
+	if err := e.reserveBatch(prepared); err != nil {
+		for _, job := range prepared {
+			job.jobContext.CancelFunc()
+		}
+		return nil, err
+	}
+	if err := e.preflightBatch(prepared); err != nil {
+		e.releaseBatch(prepared)
+		return nil, err
+	}
+	if err := e.persistBatch(prepared); err != nil {
+		return nil, errors.Join(err, e.abortBatch(prepared, StatusFailed, err.Error()))
+	}
+
+	e.queueMu.Lock()
+	if e.closed {
+		e.queueMu.Unlock()
+		return nil, errors.Join(ErrExecutorClosed, e.abortBatch(prepared, StatusCancelled, context.Canceled.Error()))
+	}
+	jobIDs := make([]string, len(prepared))
+	for i, job := range prepared {
+		jobIDs[i] = job.queued.id
+		e.jobs[job.queued.id] = job.jobContext
+		e.pending = append(e.pending, job.queued)
+	}
+	e.inflight--
+	if len(prepared) != 0 {
+		e.startDispatcherLocked()
+	}
+	e.queueCond.Broadcast()
+	e.queueMu.Unlock()
 	return jobIDs, nil
 }
 
-// launchJob 为单个具体仓库创建 execution 记录并异步执行。
-func (e *Executor) launchJob(job typedef.Repository) (string, error) {
-	// Generate job ID
-	jobID := uuid.New().String()
-	startTime := time.Now()
-	plan := componentPlan(job, e.runners)
-	repoKey := job.Key()
-
+func (e *Executor) reserveBatch(prepared []*preparedJob) error {
 	e.queueMu.Lock()
 	defer e.queueMu.Unlock()
 	if e.closed {
-		return "", ErrExecutorClosed
+		return ErrExecutorClosed
 	}
-	if _, active := e.activeByRepo[repoKey]; active {
-		return "", ErrRepositoryActive
-	}
-	active, err := e.db.ActiveExecutionExists(context.Background(), repoKey)
-	if err != nil {
-		return "", fmt.Errorf("check active execution: %w", err)
-	}
-	if active {
-		return "", ErrRepositoryActive
-	}
-	e.activeByRepo[repoKey] = jobID
-
-	// Create execution record: job_name 保存展示名快照，repo_key 是身份键。
-	_, err = e.db.Exec(`
-		INSERT INTO executions (id, job_name, repo_key, start_time, status)
-		VALUES (?, ?, ?, ?, ?)
-	`, jobID, job.Name, repoKey, startTime, string(StatusPending))
-	if err != nil {
-		delete(e.activeByRepo, repoKey)
-		return "", fmt.Errorf("failed to create execution record: %w", err)
-	}
-
-	componentNames := make([]db.ComponentName, len(plan))
-	for i := range plan {
-		componentNames[i] = plan[i].name
-	}
-	if err := e.db.CreateComponents(context.Background(), jobID, componentNames); err != nil {
-		message := fmt.Sprintf("create component records: %v", err)
-		if statusErr := e.updateJobStatus(jobID, string(StatusFailed), message); statusErr != nil {
-			delete(e.activeByRepo, repoKey)
-			return "", fmt.Errorf("%s; mark execution failed: %w", message, statusErr)
+	seen := make(map[string]struct{}, len(prepared))
+	for _, job := range prepared {
+		repoKey := job.jobContext.repoKey
+		if _, duplicate := seen[repoKey]; duplicate {
+			return ErrRepositoryActive
 		}
-		delete(e.activeByRepo, repoKey)
-		return "", errors.New(message)
+		seen[repoKey] = struct{}{}
+		if _, active := e.activeByRepo[repoKey]; active {
+			return ErrRepositoryActive
+		}
 	}
-
-	// Create cancellable context
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Store the context and enqueue while the repository reservation is held.
-	e.jobs[jobID] = &JobContext{
-		Ctx:        ctx,
-		CancelFunc: cancel,
-		done:       make(chan struct{}),
-		repoKey:    repoKey,
+	for _, job := range prepared {
+		e.activeByRepo[job.jobContext.repoKey] = job.queued.id
 	}
-	e.pending = append(e.pending, &queuedJob{id: jobID, repo: job, ctx: ctx, plan: plan})
-	e.startDispatcherLocked()
+	e.inflight++
+	return nil
+}
+
+func (e *Executor) preflightBatch(prepared []*preparedJob) error {
+	for _, job := range prepared {
+		active, err := e.db.ActiveExecutionExists(context.Background(), job.jobContext.repoKey)
+		if err != nil {
+			return fmt.Errorf("check active execution: %w", err)
+		}
+		if active {
+			return ErrRepositoryActive
+		}
+	}
+	return nil
+}
+
+func (e *Executor) persistBatch(prepared []*preparedJob) error {
+	for _, job := range prepared {
+		_, err := e.db.Exec(`
+			INSERT INTO executions (id, job_name, repo_key, start_time, status)
+			VALUES (?, ?, ?, ?, ?)
+		`, job.queued.id, job.queued.repo.Name, job.jobContext.repoKey, time.Now(), string(StatusPending))
+		if err != nil {
+			return fmt.Errorf("failed to create execution record: %w", err)
+		}
+		job.executionCreated = true
+
+		componentNames := make([]db.ComponentName, len(job.queued.plan))
+		for i := range job.queued.plan {
+			componentNames[i] = job.queued.plan[i].name
+		}
+		if err := e.db.CreateComponents(context.Background(), job.queued.id, componentNames); err != nil {
+			return fmt.Errorf("create component records: %w", err)
+		}
+		job.componentsCreated = true
+	}
+	return nil
+}
+
+func (e *Executor) abortBatch(prepared []*preparedJob, status ExecutionStatus, message string) error {
+	var errs []error
+	for _, job := range prepared {
+		job.jobContext.CancelFunc()
+		if !job.executionCreated {
+			continue
+		}
+		allComponentsTerminal := true
+		if job.componentsCreated {
+			componentStatus := db.ComponentFailed
+			componentMessage := message
+			if status == StatusCancelled {
+				componentStatus = db.ComponentCancelled
+				componentMessage = context.Canceled.Error()
+			}
+			for _, planned := range job.queued.plan {
+				if err := e.db.FinishComponent(context.Background(), job.queued.id, planned.name, componentStatus, time.Now(), componentMessage); err != nil {
+					allComponentsTerminal = false
+					errs = append(errs, err)
+				}
+			}
+		}
+		if allComponentsTerminal {
+			executionMessage := message
+			if status == StatusCancelled {
+				executionMessage = ""
+			}
+			if err := e.updateJobStatus(job.queued.id, string(status), executionMessage); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	e.releaseBatch(prepared)
+	return errors.Join(errs...)
+}
+
+func (e *Executor) releaseBatch(prepared []*preparedJob) {
+	e.queueMu.Lock()
+	for _, job := range prepared {
+		job.jobContext.CancelFunc()
+		if e.activeByRepo[job.jobContext.repoKey] == job.queued.id {
+			delete(e.activeByRepo, job.jobContext.repoKey)
+		}
+	}
+	e.inflight--
 	e.queueCond.Broadcast()
-
-	return jobID, nil
+	e.queueMu.Unlock()
 }
 
 func (e *Executor) startDispatcherLocked() {
@@ -469,8 +578,14 @@ func (e *Executor) CancelJob(jobID string) error {
 	}
 	jobCtx, exists := e.jobs[jobID]
 	if !exists {
-		// Job might not be running, try to update status anyway
+		// Account the persistence operation so Close cannot let the server close
+		// SQLite underneath it, but do not hold queueMu during the DB call.
+		e.inflight++
+		e.queueMu.Unlock()
 		err := e.updateJobStatus(jobID, string(StatusCancelled), "")
+		e.queueMu.Lock()
+		e.inflight--
+		e.queueCond.Broadcast()
 		e.queueMu.Unlock()
 		return err
 	}
@@ -564,6 +679,9 @@ func (e *Executor) Close() error {
 	e.workers.Wait()
 
 	e.queueMu.Lock()
+	for e.inflight != 0 {
+		e.queueCond.Wait()
+	}
 	close(e.closeDone)
 	err := e.closeErr
 	e.queueMu.Unlock()

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -263,7 +263,11 @@ func (e *Executor) RefreshConfig(cfg *config.Config) {
 }
 
 func (e *Executor) RuntimeConfigSnapshot() *RuntimeConfigSnapshot {
-	return e.runtime.Load()
+	var runtime *RuntimeConfigSnapshot
+	githubapi.ReadPublication(func() {
+		runtime = e.runtime.Load()
+	})
+	return runtime
 }
 
 // ErrRepositoryNotFound 表示配置中找不到匹配该身份键的仓库条目。
@@ -280,7 +284,7 @@ var expandRepos = repository.ExpandContext
 // 一条 execution 并返回单元素 jobID；type=user/org 先在任务内展开为具体仓库，
 // 每个具体仓库独立执行（各自 jobID / execution / 日志流 / 可取消）。
 func (e *Executor) ExecuteJob(repoKey string) ([]string, error) {
-	return e.executeJobFromSnapshot(context.Background(), e.runtime.Load(), repoKey, nil, nil)
+	return e.executeJobFromSnapshot(context.Background(), e.RuntimeConfigSnapshot(), repoKey, nil, nil)
 }
 
 func (e *Executor) ExecuteJobAtGeneration(repoKey string, generation uint64) ([]string, error) {
@@ -291,7 +295,7 @@ func (e *Executor) ExecuteJobAtGeneration(repoKey string, generation uint64) ([]
 // preflight and persistence. Once published, the job owns an independent
 // cancellation context and is not tied to the HTTP request lifetime.
 func (e *Executor) ExecuteJobAtGenerationContext(ctx context.Context, repoKey string, generation uint64) ([]string, error) {
-	runtime := e.runtime.Load()
+	runtime := e.RuntimeConfigSnapshot()
 	if runtime == nil || runtime.generation != generation {
 		return nil, ErrConfigGenerationChanged
 	}
@@ -302,7 +306,7 @@ func (e *Executor) ExecuteJobAtGenerationContext(ctx context.Context, repoKey st
 // reserves first, evaluates eligible while ownership is held, then persists
 // and publishes only when the callback still accepts the repository.
 func (e *Executor) ExecuteJobAtGenerationIfEligibleContext(ctx context.Context, repoKey string, generation uint64, eligible EligibilityCheck) ([]string, error) {
-	runtime := e.runtime.Load()
+	runtime := e.RuntimeConfigSnapshot()
 	if runtime == nil || runtime.generation != generation {
 		return nil, ErrConfigGenerationChanged
 	}
@@ -437,6 +441,18 @@ func (s *RuntimeConfigSnapshot) resolveStorages(names []string) []typedef.MultiS
 }
 
 func (e *Executor) reserveBatch(ctx context.Context, prepared []*preparedJob, expectedGeneration *uint64) error {
+	var result error
+	githubapi.ReadPublication(func() {
+		result = e.reserveBatchWithinPublication(ctx, prepared, expectedGeneration)
+	})
+	return result
+}
+
+// reserveBatchWithinPublication takes queueMu only after the publication read
+// gate. The unified writer uses the same order (publication write gate, then
+// queueMu), preventing the queue/publication inversion while keeping the gate
+// away from database and network work.
+func (e *Executor) reserveBatchWithinPublication(ctx context.Context, prepared []*preparedJob, expectedGeneration *uint64) error {
 	e.queueMu.Lock()
 	defer e.queueMu.Unlock()
 	if err := ctx.Err(); err != nil {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -32,14 +32,36 @@ const (
 type JobContext struct {
 	Ctx        context.Context
 	CancelFunc context.CancelFunc
+	done       chan struct{}
+	repoKey    string
+	cancelled  bool
+}
+
+type queuedJob struct {
+	id   string
+	repo typedef.Repository
+	ctx  context.Context
+	plan []component
 }
 
 type Executor struct {
-	db          *db.DB
-	cfg         atomic.Pointer[config.Config]
-	runners     Runners
-	runningJobs map[string]*JobContext
-	mu          sync.RWMutex
+	db      *db.DB
+	cfg     atomic.Pointer[config.Config]
+	runners Runners
+
+	queueMu           sync.Mutex
+	queueCond         *sync.Cond
+	pending           []*queuedJob
+	jobs              map[string]*JobContext
+	activeByRepo      map[string]string
+	running           int
+	limit             int
+	closed            bool
+	dispatcherStarted bool
+	dispatcherDone    chan struct{}
+	closeDone         chan struct{}
+	closeErr          error
+	workers           sync.WaitGroup
 }
 
 func NewExecutor(logger *logger.Logger, db *db.DB, cfg *config.Config) *Executor {
@@ -54,12 +76,24 @@ func NewExecutorWithRunners(logger *logger.Logger, db *db.DB, cfg *config.Config
 		ui.SetSink(logger)
 	}
 	exec := &Executor{
-		db:          db,
-		runners:     runners,
-		runningJobs: make(map[string]*JobContext),
+		db:             db,
+		runners:        runners,
+		jobs:           make(map[string]*JobContext),
+		activeByRepo:   make(map[string]string),
+		limit:          concurrencyLimit(cfg),
+		dispatcherDone: make(chan struct{}),
+		closeDone:      make(chan struct{}),
 	}
+	exec.queueCond = sync.NewCond(&exec.queueMu)
 	exec.cfg.Store(cfg)
 	return exec
+}
+
+func concurrencyLimit(cfg *config.Config) int {
+	if cfg == nil || cfg.ConcurrencyNum == 0 {
+		return 3
+	}
+	return int(cfg.ConcurrencyNum)
 }
 
 // RefreshConfig repoints the executor at a new config instance. Called by the
@@ -69,11 +103,17 @@ func NewExecutorWithRunners(logger *logger.Logger, db *db.DB, cfg *config.Config
 // new config in its entirety, never a torn read, so this is safe to call while
 // jobs are running.
 func (e *Executor) RefreshConfig(cfg *config.Config) {
+	e.queueMu.Lock()
 	e.cfg.Store(cfg)
+	e.limit = concurrencyLimit(cfg)
+	e.queueCond.Broadcast()
+	e.queueMu.Unlock()
 }
 
 // ErrRepositoryNotFound 表示配置中找不到匹配该身份键的仓库条目。
 var ErrRepositoryNotFound = errors.New("repository not found in configuration")
+var ErrRepositoryActive = errors.New("repository is already active")
+var ErrExecutorClosed = errors.New("executor is closed")
 
 // expandRepos 是把 user/org 条目展开为具体仓库的 seam：生产用 repository.Expand，
 // 测试注入 fake，避免真实 GitHub 调用。
@@ -85,11 +125,13 @@ var expandRepos = repository.Expand
 func (e *Executor) ExecuteJob(repoKey string) ([]string, error) {
 	var repo typedef.Repository
 	found := false
-	for _, r := range e.cfg.Load().Repository {
-		if r.Matches(repoKey) {
-			repo = r
-			found = true
-			break
+	if cfg := e.cfg.Load(); cfg != nil {
+		for _, r := range cfg.Repository {
+			if r.Matches(repoKey) {
+				repo = r
+				found = true
+				break
+			}
 		}
 	}
 	if !found {
@@ -113,13 +155,32 @@ func (e *Executor) launchJob(job typedef.Repository) (string, error) {
 	jobID := uuid.New().String()
 	startTime := time.Now()
 	plan := componentPlan(job, e.runners)
+	repoKey := job.Key()
+
+	e.queueMu.Lock()
+	defer e.queueMu.Unlock()
+	if e.closed {
+		return "", ErrExecutorClosed
+	}
+	if _, active := e.activeByRepo[repoKey]; active {
+		return "", ErrRepositoryActive
+	}
+	active, err := e.db.ActiveExecutionExists(context.Background(), repoKey)
+	if err != nil {
+		return "", fmt.Errorf("check active execution: %w", err)
+	}
+	if active {
+		return "", ErrRepositoryActive
+	}
+	e.activeByRepo[repoKey] = jobID
 
 	// Create execution record: job_name 保存展示名快照，repo_key 是身份键。
-	_, err := e.db.Exec(`
+	_, err = e.db.Exec(`
 		INSERT INTO executions (id, job_name, repo_key, start_time, status)
 		VALUES (?, ?, ?, ?, ?)
-	`, jobID, job.Name, job.Key(), startTime, string(StatusPending))
+	`, jobID, job.Name, repoKey, startTime, string(StatusPending))
 	if err != nil {
+		delete(e.activeByRepo, repoKey)
 		return "", fmt.Errorf("failed to create execution record: %w", err)
 	}
 
@@ -130,40 +191,104 @@ func (e *Executor) launchJob(job typedef.Repository) (string, error) {
 	if err := e.db.CreateComponents(context.Background(), jobID, componentNames); err != nil {
 		message := fmt.Sprintf("create component records: %v", err)
 		if statusErr := e.updateJobStatus(jobID, string(StatusFailed), message); statusErr != nil {
+			delete(e.activeByRepo, repoKey)
 			return "", fmt.Errorf("%s; mark execution failed: %w", message, statusErr)
 		}
+		delete(e.activeByRepo, repoKey)
 		return "", errors.New(message)
 	}
 
 	// Create cancellable context
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Store job context
-	e.mu.Lock()
-	e.runningJobs[jobID] = &JobContext{
+	// Store the context and enqueue while the repository reservation is held.
+	e.jobs[jobID] = &JobContext{
 		Ctx:        ctx,
 		CancelFunc: cancel,
+		done:       make(chan struct{}),
+		repoKey:    repoKey,
 	}
-	e.mu.Unlock()
-
-	// Update status to running
-	e.updateJobStatus(jobID, string(StatusRunning), "")
-
-	// Execute async
-	go e.executeAsync(ctx, jobID, job, plan)
+	e.pending = append(e.pending, &queuedJob{id: jobID, repo: job, ctx: ctx, plan: plan})
+	e.startDispatcherLocked()
+	e.queueCond.Broadcast()
 
 	return jobID, nil
+}
+
+func (e *Executor) startDispatcherLocked() {
+	if e.dispatcherStarted {
+		return
+	}
+	e.dispatcherStarted = true
+	go e.dispatch()
+}
+
+func (e *Executor) dispatch() {
+	defer close(e.dispatcherDone)
+	for {
+		e.queueMu.Lock()
+		for !e.closed && (len(e.pending) == 0 || e.running >= e.limit) {
+			e.queueCond.Wait()
+		}
+		if e.closed {
+			e.queueMu.Unlock()
+			return
+		}
+
+		job := e.pending[0]
+		e.pending[0] = nil
+		e.pending = e.pending[1:]
+		e.running++
+		e.workers.Add(1)
+		e.queueMu.Unlock()
+
+		go e.runAdmitted(job)
+	}
+}
+
+func (e *Executor) runAdmitted(job *queuedJob) {
+	defer e.workers.Done()
+	defer e.completeRunningJob(job.id, job.repo.Key())
+
+	if err := e.updateJobStatus(job.id, string(StatusRunning), ""); err != nil {
+		e.finishAdmissionFailure(job, err)
+		return
+	}
+	e.executeAsync(job.ctx, job.id, job.repo, job.plan)
+}
+
+func (e *Executor) finishAdmissionFailure(job *queuedJob, admissionErr error) {
+	message := fmt.Sprintf("persist running execution state: %v", admissionErr)
+	allTerminal := true
+	for _, planned := range job.plan {
+		if err := e.db.FinishComponent(context.Background(), job.id, planned.name, db.ComponentFailed, time.Now(), message); err != nil {
+			allTerminal = false
+			ui.Errorf("Failed to record %s admission failure: %v", planned.name, err)
+		}
+	}
+	if allTerminal {
+		e.finishExecution(job.id, StatusFailed, message)
+	}
+}
+
+func (e *Executor) completeRunningJob(jobID, repoKey string) {
+	e.queueMu.Lock()
+	jobCtx := e.jobs[jobID]
+	delete(e.jobs, jobID)
+	if e.activeByRepo[repoKey] == jobID {
+		delete(e.activeByRepo, repoKey)
+	}
+	e.running--
+	if jobCtx != nil {
+		close(jobCtx.done)
+	}
+	e.queueCond.Broadcast()
+	e.queueMu.Unlock()
 }
 
 func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.Repository, plan []component) {
 	unbind := ui.Bind(jobID, job.Name)
 	defer unbind()
-
-	defer func() {
-		e.mu.Lock()
-		delete(e.runningJobs, jobID)
-		e.mu.Unlock()
-	}()
 
 	ui.Printf("Starting job execution")
 
@@ -178,17 +303,19 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 
 	// Get storages
 	var storages []typedef.MultiStorage
-	for _, storageName := range job.Storage {
-		for _, s := range e.cfg.Load().Storage {
-			if s.Name == storageName {
-				storages = append(storages, typedef.MultiStorage{
-					Storage: typedef.Storage{
-						Name: s.Name,
-						Type: s.Type,
-						Path: s.Path,
-					},
-				})
-				break
+	if cfg := e.cfg.Load(); cfg != nil {
+		for _, storageName := range job.Storage {
+			for _, s := range cfg.Storage {
+				if s.Name == storageName {
+					storages = append(storages, typedef.MultiStorage{
+						Storage: typedef.Storage{
+							Name: s.Name,
+							Type: s.Type,
+							Path: s.Path,
+						},
+					})
+					break
+				}
 			}
 		}
 	}
@@ -335,17 +462,112 @@ func (e *Executor) finishExecution(jobID string, status ExecutionStatus, errorMe
 }
 
 func (e *Executor) CancelJob(jobID string) error {
-	e.mu.RLock()
-	jobCtx, exists := e.runningJobs[jobID]
-	e.mu.RUnlock()
-
+	e.queueMu.Lock()
+	if e.closed {
+		e.queueMu.Unlock()
+		return ErrExecutorClosed
+	}
+	jobCtx, exists := e.jobs[jobID]
 	if !exists {
 		// Job might not be running, try to update status anyway
-		return e.updateJobStatus(jobID, string(StatusCancelled), "")
+		err := e.updateJobStatus(jobID, string(StatusCancelled), "")
+		e.queueMu.Unlock()
+		return err
 	}
 
-	jobCtx.CancelFunc()
+	for i, pending := range e.pending {
+		if pending.id != jobID {
+			continue
+		}
+		e.pending = append(e.pending[:i], e.pending[i+1:]...)
+		e.signalCancellationLocked(jobCtx)
+		delete(e.jobs, jobID)
+		if e.activeByRepo[jobCtx.repoKey] == jobID {
+			delete(e.activeByRepo, jobCtx.repoKey)
+		}
+		e.workers.Add(1)
+		e.queueCond.Broadcast()
+		e.queueMu.Unlock()
+
+		defer e.workers.Done()
+		e.finishQueuedCancellation(pending)
+		close(jobCtx.done)
+		return nil
+	}
+
+	e.signalCancellationLocked(jobCtx)
+	e.queueMu.Unlock()
 	return nil
+}
+
+func (e *Executor) signalCancellationLocked(jobCtx *JobContext) {
+	if jobCtx.cancelled {
+		return
+	}
+	jobCtx.cancelled = true
+	jobCtx.CancelFunc()
+}
+
+func (e *Executor) finishQueuedCancellation(job *queuedJob) {
+	unbind := ui.Bind(job.id, job.repo.Name)
+	defer unbind()
+	e.finishCancellation(job.id, job.plan, 0, context.Canceled)
+}
+
+// Close stops admission, terminalizes queued jobs without invoking their
+// runners, signals every running job once, and waits for all executor-owned
+// goroutines and persistence work to finish.
+func (e *Executor) Close() error {
+	e.queueMu.Lock()
+	if e.closed {
+		done := e.closeDone
+		e.queueMu.Unlock()
+		<-done
+		e.queueMu.Lock()
+		err := e.closeErr
+		e.queueMu.Unlock()
+		return err
+	}
+
+	e.closed = true
+	pending := e.pending
+	e.pending = nil
+	pendingContexts := make(map[string]*JobContext, len(pending))
+	for _, job := range pending {
+		jobCtx := e.jobs[job.id]
+		if jobCtx == nil {
+			continue
+		}
+		pendingContexts[job.id] = jobCtx
+		e.signalCancellationLocked(jobCtx)
+		delete(e.jobs, job.id)
+		if e.activeByRepo[jobCtx.repoKey] == job.id {
+			delete(e.activeByRepo, jobCtx.repoKey)
+		}
+	}
+	for _, jobCtx := range e.jobs {
+		e.signalCancellationLocked(jobCtx)
+	}
+	dispatcherStarted := e.dispatcherStarted
+	e.queueCond.Broadcast()
+	e.queueMu.Unlock()
+
+	for _, job := range pending {
+		e.finishQueuedCancellation(job)
+		if jobCtx := pendingContexts[job.id]; jobCtx != nil {
+			close(jobCtx.done)
+		}
+	}
+	if dispatcherStarted {
+		<-e.dispatcherDone
+	}
+	e.workers.Wait()
+
+	e.queueMu.Lock()
+	close(e.closeDone)
+	err := e.closeErr
+	e.queueMu.Unlock()
+	return err
 }
 
 func (e *Executor) updateJobStatus(jobID string, status string, errorMessage string) error {
@@ -381,8 +603,8 @@ func (e *Executor) updateJobStatus(jobID string, status string, errorMessage str
 }
 
 func (e *Executor) IsJobRunning(jobID string) bool {
-	e.mu.RLock()
-	_, exists := e.runningJobs[jobID]
-	e.mu.RUnlock()
+	e.queueMu.Lock()
+	_, exists := e.jobs[jobID]
+	e.queueMu.Unlock()
 	return exists
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -46,16 +46,15 @@ type queuedJob struct {
 }
 
 type preparedJob struct {
-	queued            *queuedJob
-	jobContext        *JobContext
-	executionCreated  bool
-	componentsCreated bool
+	queued     *queuedJob
+	jobContext *JobContext
 }
 
 type executionStore interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	ActiveExecutionExists(context.Context, string) (bool, error)
 	CreatePendingExecutions(context.Context, []db.PendingExecution) error
+	DiscardPendingExecutions(context.Context, []string) error
 	StartComponent(context.Context, string, db.ComponentName, time.Time) error
 	FinishComponent(context.Context, string, db.ComponentName, db.ComponentStatus, time.Time, string) error
 }
@@ -189,18 +188,23 @@ func (e *Executor) submitBatch(repositories []typedef.Repository) ([]string, err
 		return nil, err
 	}
 	if err := e.preflightBatch(prepared); err != nil {
-		e.releaseBatch(prepared)
+		e.releaseBatch(prepared, nil)
 		return nil, err
 	}
 	if err := e.persistBatch(prepared); err != nil {
-		e.releaseBatch(prepared)
+		e.releaseBatch(prepared, nil)
 		return nil, err
 	}
 
 	e.queueMu.Lock()
 	if e.closed {
 		e.queueMu.Unlock()
-		return nil, errors.Join(ErrExecutorClosed, e.abortBatch(prepared, StatusCancelled, context.Canceled.Error()))
+		discardErr := e.discardBatch(prepared)
+		e.releaseBatch(prepared, discardErr)
+		if discardErr != nil {
+			return nil, errors.Join(ErrExecutorClosed, discardErr)
+		}
+		return nil, ErrExecutorClosed
 	}
 	jobIDs := make([]string, len(prepared))
 	for i, job := range prepared {
@@ -272,51 +276,25 @@ func (e *Executor) persistBatch(prepared []*preparedJob) error {
 	if err := e.db.CreatePendingExecutions(context.Background(), executions); err != nil {
 		return fmt.Errorf("create pending execution batch: %w", err)
 	}
-	for _, job := range prepared {
-		job.executionCreated = true
-		job.componentsCreated = true
+	return nil
+}
+
+func (e *Executor) discardBatch(prepared []*preparedJob) error {
+	executionIDs := make([]string, len(prepared))
+	for i, job := range prepared {
+		executionIDs[i] = job.queued.id
+	}
+	if err := e.db.DiscardPendingExecutions(context.Background(), executionIDs); err != nil {
+		return fmt.Errorf("discard unaccepted execution batch: %w", err)
 	}
 	return nil
 }
 
-func (e *Executor) abortBatch(prepared []*preparedJob, status ExecutionStatus, message string) error {
-	var errs []error
-	for _, job := range prepared {
-		job.jobContext.CancelFunc()
-		if !job.executionCreated {
-			continue
-		}
-		allComponentsTerminal := true
-		if job.componentsCreated {
-			componentStatus := db.ComponentFailed
-			componentMessage := message
-			if status == StatusCancelled {
-				componentStatus = db.ComponentCancelled
-				componentMessage = context.Canceled.Error()
-			}
-			for _, planned := range job.queued.plan {
-				if err := e.db.FinishComponent(context.Background(), job.queued.id, planned.name, componentStatus, time.Now(), componentMessage); err != nil {
-					allComponentsTerminal = false
-					errs = append(errs, err)
-				}
-			}
-		}
-		if allComponentsTerminal {
-			executionMessage := message
-			if status == StatusCancelled {
-				executionMessage = ""
-			}
-			if err := e.updateJobStatus(job.queued.id, string(status), executionMessage); err != nil {
-				errs = append(errs, err)
-			}
-		}
-	}
-	e.releaseBatch(prepared)
-	return errors.Join(errs...)
-}
-
-func (e *Executor) releaseBatch(prepared []*preparedJob) {
+func (e *Executor) releaseBatch(prepared []*preparedJob, closeErr error) {
 	e.queueMu.Lock()
+	if closeErr != nil {
+		e.closeErr = errors.Join(e.closeErr, closeErr)
+	}
 	for _, job := range prepared {
 		job.jobContext.CancelFunc()
 		if e.activeByRepo[job.jobContext.repoKey] == job.queued.id {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -39,10 +39,11 @@ type JobContext struct {
 }
 
 type queuedJob struct {
-	id   string
-	repo typedef.Repository
-	ctx  context.Context
-	plan []component
+	id       string
+	repo     typedef.Repository
+	storages []typedef.MultiStorage
+	ctx      context.Context
+	plan     []component
 }
 
 type preparedJob struct {
@@ -153,6 +154,14 @@ func (s *RuntimeConfigSnapshot) Repositories() []typedef.Repository {
 	return repositories
 }
 
+// Config returns a defensive copy of this immutable runtime generation.
+func (s *RuntimeConfigSnapshot) Config() *config.Config {
+	if s == nil {
+		return nil
+	}
+	return cloneRuntimeConfig(s.config)
+}
+
 func (s *RuntimeConfigSnapshot) SyncHealthThresholds() (time.Duration, time.Duration) {
 	if s == nil || s.config == nil {
 		return 0, 0
@@ -231,39 +240,52 @@ var expandRepos = repository.Expand
 // 一条 execution 并返回单元素 jobID；type=user/org 先在任务内展开为具体仓库，
 // 每个具体仓库独立执行（各自 jobID / execution / 日志流 / 可取消）。
 func (e *Executor) ExecuteJob(repoKey string) ([]string, error) {
-	return e.executeJobFromSnapshot(e.runtime.Load(), repoKey)
+	return e.executeJobFromSnapshot(context.Background(), e.runtime.Load(), repoKey, nil)
 }
 
 func (e *Executor) ExecuteJobAtGeneration(repoKey string, generation uint64) ([]string, error) {
+	return e.ExecuteJobAtGenerationContext(context.Background(), repoKey, generation)
+}
+
+// ExecuteJobAtGenerationContext admits a generation-bound job using ctx for
+// preflight and persistence. Once published, the job owns an independent
+// cancellation context and is not tied to the HTTP request lifetime.
+func (e *Executor) ExecuteJobAtGenerationContext(ctx context.Context, repoKey string, generation uint64) ([]string, error) {
 	runtime := e.runtime.Load()
 	if runtime == nil || runtime.generation != generation {
 		return nil, ErrConfigGenerationChanged
 	}
-	return e.executeJobFromSnapshot(runtime, repoKey)
+	return e.executeJobFromSnapshot(ctx, runtime, repoKey, &generation)
 }
 
-func (e *Executor) executeJobFromSnapshot(runtime *RuntimeConfigSnapshot, repoKey string) ([]string, error) {
+func (e *Executor) executeJobFromSnapshot(admissionCtx context.Context, runtime *RuntimeConfigSnapshot, repoKey string, expectedGeneration *uint64) ([]string, error) {
 	repo, found := runtime.Repository(repoKey)
 	if !found {
 		return nil, ErrRepositoryNotFound
 	}
 
 	if e.expander != nil {
-		return e.submitBatch(e.expander(repo))
+		return e.submitBatch(admissionCtx, runtime, e.expander(repo), expectedGeneration)
 	}
-	return e.submitBatch(expandRepos(repo))
+	return e.submitBatch(admissionCtx, runtime, expandRepos(repo), expectedGeneration)
 }
 
 // submitBatch reserves, preflights, and persists every concrete repository
 // before atomically publishing any of them to the dispatcher.
-func (e *Executor) submitBatch(repositories []typedef.Repository) ([]string, error) {
+func (e *Executor) submitBatch(admissionCtx context.Context, runtime *RuntimeConfigSnapshot, repositories []typedef.Repository, expectedGeneration *uint64) ([]string, error) {
 	prepared := make([]*preparedJob, len(repositories))
 	for i, repo := range repositories {
 		ctx, cancel := context.WithCancel(context.Background())
 		jobID := uuid.New().String()
 		plan := componentPlan(repo, e.runners)
 		prepared[i] = &preparedJob{
-			queued: &queuedJob{id: jobID, repo: repo, ctx: ctx, plan: plan},
+			queued: &queuedJob{
+				id:       jobID,
+				repo:     repo,
+				storages: runtime.resolveStorages(repo.Storage),
+				ctx:      ctx,
+				plan:     plan,
+			},
 			jobContext: &JobContext{
 				Ctx:        ctx,
 				CancelFunc: cancel,
@@ -273,22 +295,31 @@ func (e *Executor) submitBatch(repositories []typedef.Repository) ([]string, err
 		}
 	}
 
-	if err := e.reserveBatch(prepared); err != nil {
+	if err := e.reserveBatch(admissionCtx, prepared, expectedGeneration); err != nil {
 		for _, job := range prepared {
 			job.jobContext.CancelFunc()
 		}
 		return nil, err
 	}
-	if err := e.preflightBatch(prepared); err != nil {
+	if err := e.preflightBatch(admissionCtx, prepared); err != nil {
 		e.releaseBatch(prepared, nil)
 		return nil, err
 	}
-	if err := e.persistBatch(prepared); err != nil {
+	if err := e.persistBatch(admissionCtx, prepared); err != nil {
 		e.releaseBatch(prepared, nil)
 		return nil, err
 	}
 
 	e.queueMu.Lock()
+	if err := admissionCtx.Err(); err != nil {
+		e.queueMu.Unlock()
+		discardErr := e.discardBatch(prepared)
+		e.releaseBatch(prepared, discardErr)
+		if discardErr != nil {
+			return nil, errors.Join(err, discardErr)
+		}
+		return nil, err
+	}
 	if e.closed {
 		e.queueMu.Unlock()
 		discardErr := e.discardBatch(prepared)
@@ -313,9 +344,34 @@ func (e *Executor) submitBatch(repositories []typedef.Repository) ([]string, err
 	return jobIDs, nil
 }
 
-func (e *Executor) reserveBatch(prepared []*preparedJob) error {
+func (s *RuntimeConfigSnapshot) resolveStorages(names []string) []typedef.MultiStorage {
+	if s == nil || s.config == nil || len(names) == 0 {
+		return nil
+	}
+	storages := make([]typedef.MultiStorage, 0, len(names))
+	for _, name := range names {
+		for _, storage := range s.config.Storage {
+			if storage.Name == name {
+				storages = append(storages, storage)
+				break
+			}
+		}
+	}
+	return storages
+}
+
+func (e *Executor) reserveBatch(ctx context.Context, prepared []*preparedJob, expectedGeneration *uint64) error {
 	e.queueMu.Lock()
 	defer e.queueMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if expectedGeneration != nil {
+		runtime := e.runtime.Load()
+		if runtime == nil || runtime.generation != *expectedGeneration {
+			return ErrConfigGenerationChanged
+		}
+	}
 	if e.closed {
 		return ErrExecutorClosed
 	}
@@ -337,9 +393,9 @@ func (e *Executor) reserveBatch(prepared []*preparedJob) error {
 	return nil
 }
 
-func (e *Executor) preflightBatch(prepared []*preparedJob) error {
+func (e *Executor) preflightBatch(ctx context.Context, prepared []*preparedJob) error {
 	for _, job := range prepared {
-		active, err := e.db.ActiveExecutionExists(context.Background(), job.jobContext.repoKey)
+		active, err := e.db.ActiveExecutionExists(ctx, job.jobContext.repoKey)
 		if err != nil {
 			return fmt.Errorf("check active execution: %w", err)
 		}
@@ -350,7 +406,7 @@ func (e *Executor) preflightBatch(prepared []*preparedJob) error {
 	return nil
 }
 
-func (e *Executor) persistBatch(prepared []*preparedJob) error {
+func (e *Executor) persistBatch(ctx context.Context, prepared []*preparedJob) error {
 	executions := make([]db.PendingExecution, len(prepared))
 	for i, job := range prepared {
 		componentNames := make([]db.ComponentName, len(job.queued.plan))
@@ -365,7 +421,7 @@ func (e *Executor) persistBatch(prepared []*preparedJob) error {
 			Components: componentNames,
 		}
 	}
-	if err := e.db.CreatePendingExecutions(context.Background(), executions); err != nil {
+	if err := e.db.CreatePendingExecutions(ctx, executions); err != nil {
 		return fmt.Errorf("create pending execution batch: %w", err)
 	}
 	return nil
@@ -437,7 +493,7 @@ func (e *Executor) runAdmitted(job *queuedJob) {
 		e.finishAdmissionFailure(job, err)
 		return
 	}
-	e.executeAsync(job.ctx, job.id, job.repo, job.plan)
+	e.executeAsync(job.ctx, job.id, job.repo, job.storages, job.plan)
 }
 
 func (e *Executor) finishAdmissionFailure(job *queuedJob, admissionErr error) {
@@ -469,7 +525,7 @@ func (e *Executor) completeRunningJob(jobID, repoKey string) {
 	e.queueMu.Unlock()
 }
 
-func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.Repository, plan []component) {
+func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.Repository, storages []typedef.MultiStorage, plan []component) {
 	unbind := ui.Bind(jobID, job.Name)
 	defer unbind()
 
@@ -482,25 +538,6 @@ func (e *Executor) executeAsync(ctx context.Context, jobID string, job typedef.R
 		// does not flush before this row is committed and drop it.
 		e.finishCancellation(jobID, plan, 0, ctx.Err())
 		return
-	}
-
-	// Get storages
-	var storages []typedef.MultiStorage
-	if runtime := e.runtime.Load(); runtime != nil && runtime.config != nil {
-		for _, storageName := range job.Storage {
-			for _, s := range runtime.config.Storage {
-				if s.Name == storageName {
-					storages = append(storages, typedef.MultiStorage{
-						Storage: typedef.Storage{
-							Name: s.Name,
-							Type: s.Type,
-							Path: s.Path,
-						},
-					})
-					break
-				}
-			}
-		}
 	}
 
 	failures := make([]string, 0)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/logger"
 	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
@@ -807,7 +808,7 @@ func TestExecuteJobExpandsOrgIntoMultipleJobs(t *testing.T) {
 
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
-	expandRepos = func(repo typedef.Repository) []typedef.Repository {
+	expandRepos = func(_ context.Context, repo typedef.Repository) []typedef.Repository {
 		return []typedef.Repository{
 			{Name: "alpha", URL: "github.com/acme/alpha"},
 			{Name: "beta", URL: "github.com/acme/beta"},
@@ -984,6 +985,130 @@ func TestQueuedJobUsesStorageFromAcceptedRuntimeGeneration(t *testing.T) {
 	waitForJob(t, exec, jobIDs[0])
 }
 
+func TestQueuedJobUsesOneCompleteAcceptedConfigGeneration(t *testing.T) {
+	type observation struct {
+		component string
+		cfg       *config.Config
+		api       githubapi.Config
+		storages  []typedef.MultiStorage
+	}
+
+	blockerEntered := make(chan struct{})
+	blockerRelease := make(chan struct{})
+	observed := make(chan observation, 5)
+	record := func(component string) SyncFunc {
+		return func(ctx context.Context, repo typedef.Repository, storages []typedef.MultiStorage) error {
+			if component == "code" && repo.Name == "blocker" {
+				close(blockerEntered)
+				<-blockerRelease
+				return nil
+			}
+			apiConfig, ok := githubapi.ConfigFromContext(ctx)
+			require.True(t, ok, "%s runner has no frozen GitHub API coordinator", component)
+			observed <- observation{
+				component: component,
+				cfg:       config.GetExecutionConfig(ctx),
+				api:       apiConfig,
+				storages:  append([]typedef.MultiStorage(nil), storages...),
+			}
+			return nil
+		}
+	}
+	runners := Runners{
+		Code:       record("code"),
+		Release:    record("release"),
+		Issue:      record("issue"),
+		Wiki:       record("wiki"),
+		Discussion: record("discussion"),
+	}
+	oldConfig := &config.Config{
+		Repository: []typedef.Repository{
+			{Name: "blocker", URL: "github.com/acme/blocker"},
+			{
+				Name:               "target",
+				URL:                "github.com/acme/target",
+				Storage:            []string{"archive"},
+				DownloadReleases:   true,
+				DownloadIssues:     true,
+				DownloadWiki:       true,
+				DownloadDiscussion: true,
+			},
+		},
+		Storage: []typedef.MultiStorage{{
+			Storage:         typedef.Storage{Name: "archive", Type: "s3", Path: "old-path"},
+			Endpoint:        "old-endpoint",
+			Bucket:          "old-bucket",
+			Region:          "old-region",
+			AccessKeyID:     "old-access",
+			SecretAccessKey: "old-secret",
+		}},
+		GitHubToken:                 "old-token",
+		ConcurrencyNum:              1,
+		ReleaseSizeLimit:            101,
+		ReleaseNumLimit:             102,
+		RetryMaxCount:               103,
+		RetryBaseDelay:              104 * time.Millisecond,
+		SyncOverdueGrace:            105 * time.Minute,
+		SyncStuckThreshold:          106 * time.Hour,
+		GitHubAPIConcurrency:        107,
+		GitHubMinRequestInterval:    108 * time.Millisecond,
+		GitHubLowRemainingThreshold: 109,
+		GitHubScheduleJitter:        110 * time.Millisecond,
+	}
+	previousGlobal := config.GetIns()
+	config.SetIns(oldConfig)
+	t.Cleanup(func() { config.SetIns(previousGlobal) })
+	exec, _ := newTestExecutorForConfig(t, oldConfig, runners)
+
+	blockerIDs, err := exec.ExecuteJob("github.com/acme/blocker")
+	require.NoError(t, err)
+	<-blockerEntered
+	targetIDs, err := exec.ExecuteJob("github.com/acme/target")
+	require.NoError(t, err)
+
+	newConfig := config.Clone(oldConfig)
+	newConfig.GitHubToken = "new-token"
+	newConfig.ConcurrencyNum = 2
+	newConfig.ReleaseSizeLimit = 201
+	newConfig.ReleaseNumLimit = 202
+	newConfig.RetryMaxCount = 203
+	newConfig.RetryBaseDelay = 204 * time.Millisecond
+	newConfig.SyncOverdueGrace = 205 * time.Minute
+	newConfig.SyncStuckThreshold = 206 * time.Hour
+	newConfig.GitHubAPIConcurrency = 207
+	newConfig.GitHubMinRequestInterval = 208 * time.Millisecond
+	newConfig.GitHubLowRemainingThreshold = 209
+	newConfig.GitHubScheduleJitter = 210 * time.Millisecond
+	newConfig.Storage[0].Path = "new-path"
+	newConfig.Storage[0].Endpoint = "new-endpoint"
+	newConfig.Storage[0].Bucket = "new-bucket"
+	newConfig.Storage[0].Region = "new-region"
+	newConfig.Storage[0].AccessKeyID = "new-access"
+	newConfig.Storage[0].SecretAccessKey = "new-secret"
+	exec.RefreshConfig(newConfig)
+	config.SetIns(newConfig)
+	close(blockerRelease)
+
+	wantStorage := oldConfig.Storage[0]
+	seen := make(map[string]bool)
+	for range 5 {
+		got := <-observed
+		seen[got.component] = true
+		require.Equal(t, oldConfig, got.cfg, "%s runner mixed configuration generations", got.component)
+		require.Equal(t, githubapi.Config{
+			Concurrency:           oldConfig.GitHubAPIConcurrency,
+			MinRequestInterval:    oldConfig.GitHubMinRequestInterval,
+			LowRemainingThreshold: oldConfig.GitHubLowRemainingThreshold,
+		}, got.api, "%s runner selected the wrong GitHub coordinator", got.component)
+		require.Equal(t, []typedef.MultiStorage{wantStorage}, got.storages)
+	}
+	require.Equal(t, map[string]bool{
+		"code": true, "release": true, "issue": true, "wiki": true, "discussion": true,
+	}, seen)
+	waitForJob(t, exec, blockerIDs[0])
+	waitForJob(t, exec, targetIDs[0])
+}
+
 func TestExecuteJobAtGenerationContextDiscardsCommitWhenCancelledBeforePublish(t *testing.T) {
 	var runnerCalls atomic.Int32
 	runners := noOpRunners()
@@ -1029,6 +1154,62 @@ func TestExecuteJobAtGenerationContextDiscardsCommitWhenCancelledBeforePublish(t
 	require.Len(t, jobIDs, 1)
 	waitForJob(t, exec, jobIDs[0])
 	require.Equal(t, int32(1), runnerCalls.Load())
+}
+
+func TestReservedEligibilityRejectionIsTypedAndReleasesAdmission(t *testing.T) {
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name: "repo",
+		URL:  "github.com/acme/repo",
+	}, noOpRunners())
+	runtime := exec.RuntimeConfigSnapshot()
+
+	jobIDs, err := exec.ExecuteJobAtGenerationIfEligibleContext(
+		context.Background(),
+		"github.com/acme/repo",
+		runtime.Generation(),
+		func(_ context.Context, admitted *RuntimeConfigSnapshot, repo typedef.Repository) (bool, error) {
+			require.Equal(t, runtime.Generation(), admitted.Generation())
+			require.Equal(t, "github.com/acme/repo", repo.Key())
+			return false, nil
+		},
+	)
+	var noLongerEligible *RepositoryNoLongerEligibleError
+	require.ErrorAs(t, err, &noLongerEligible)
+	require.Equal(t, "github.com/acme/repo", noLongerEligible.RepositoryKey)
+	require.Empty(t, jobIDs)
+	require.Empty(t, executionStatusCounts(t, testDB))
+
+	jobIDs, err = exec.ExecuteJob("github.com/acme/repo")
+	require.NoError(t, err, "eligibility rejection must release the repository reservation")
+	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
+}
+
+func TestReservedEligibilityCancellationReleasesAdmissionWithoutPersistence(t *testing.T) {
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name: "repo",
+		URL:  "github.com/acme/repo",
+	}, noOpRunners())
+	runtime := exec.RuntimeConfigSnapshot()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	jobIDs, err := exec.ExecuteJobAtGenerationIfEligibleContext(
+		ctx,
+		"github.com/acme/repo",
+		runtime.Generation(),
+		func(context.Context, *RuntimeConfigSnapshot, typedef.Repository) (bool, error) {
+			cancel()
+			return false, context.Canceled
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, jobIDs)
+	require.Empty(t, executionStatusCounts(t, testDB))
+
+	jobIDs, err = exec.ExecuteJob("github.com/acme/repo")
+	require.NoError(t, err, "cancelled eligibility must release the repository reservation")
+	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
 }
 
 func TestExecuteJobLimitsActualRunnerConcurrencyAndKeepsOverflowPending(t *testing.T) {
@@ -1352,7 +1533,7 @@ func TestExecuteJobExpandedBatchIsAtomicWhenSecondRepositoryIsActive(t *testing.
 
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
-	expandRepos = func(typedef.Repository) []typedef.Repository {
+	expandRepos = func(context.Context, typedef.Repository) []typedef.Repository {
 		return []typedef.Repository{
 			{Name: "alpha", URL: "github.com/acme/alpha"},
 			{Name: "beta", URL: "github.com/acme/beta"},
@@ -1394,7 +1575,7 @@ func TestExecuteJobExpandedBatchRollsBackAllRowsWhenLaterPersistenceFails(t *tes
 
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
-	expandRepos = func(typedef.Repository) []typedef.Repository {
+	expandRepos = func(context.Context, typedef.Repository) []typedef.Repository {
 		return []typedef.Repository{
 			{Name: "alpha", URL: "github.com/acme/alpha"},
 			{Name: "beta", URL: "github.com/acme/beta"},
@@ -1433,7 +1614,7 @@ func TestExecuteJobRejectsDuplicateKeysWithinExpandedBatchBeforePersistence(t *t
 	}}}, noOpRunners())
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
-	expandRepos = func(typedef.Repository) []typedef.Repository {
+	expandRepos = func(context.Context, typedef.Repository) []typedef.Repository {
 		return []typedef.Repository{
 			{Name: "alpha", URL: "https://github.com/acme/alpha"},
 			{Name: "alpha-copy", URL: "github.com/acme/alpha/"},

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -106,6 +106,15 @@ type blockingExecutionStore struct {
 	finishOnce        sync.Once
 }
 
+type discardFailingStore struct {
+	*blockingExecutionStore
+	err error
+}
+
+func (s *discardFailingStore) DiscardPendingExecutions(context.Context, []string) error {
+	return s.err
+}
+
 func (s *blockingExecutionStore) Exec(query string, args ...interface{}) (sql.Result, error) {
 	if s.execEntered != nil {
 		s.execOnce.Do(func() { close(s.execEntered) })
@@ -129,6 +138,10 @@ func (s *blockingExecutionStore) CreatePendingExecutions(ctx context.Context, ex
 		<-s.componentsRelease
 	}
 	return err
+}
+
+func (s *blockingExecutionStore) DiscardPendingExecutions(ctx context.Context, executionIDs []string) error {
+	return s.delegate.DiscardPendingExecutions(ctx, executionIDs)
 }
 
 func (s *blockingExecutionStore) StartComponent(ctx context.Context, executionID string, component db.ComponentName, startedAt time.Time) error {
@@ -1382,7 +1395,7 @@ func TestClosePreventsDispatcherAdmissionWhileRunningWorkerFinishes(t *testing.T
 	}
 }
 
-func TestCloseWinningAfterPersistencePreventsPostCloseRunner(t *testing.T) {
+func TestExecuteJobCloseAfterCommitBeforePublishDiscardsBatch(t *testing.T) {
 	runnerEntered := make(chan struct{}, 1)
 	runners := noOpRunners()
 	runners.Code = func(context.Context, typedef.Repository, []typedef.MultiStorage) error {
@@ -1390,6 +1403,14 @@ func TestCloseWinningAfterPersistencePreventsPostCloseRunner(t *testing.T) {
 		return nil
 	}
 	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 1), runners)
+	_, err := testDB.Exec(`
+		CREATE TRIGGER reject_component_terminal_update
+		BEFORE UPDATE OF status ON execution_components
+		WHEN NEW.status IN ('cancelled', 'failed', 'completed', 'skipped')
+		BEGIN
+			SELECT RAISE(FAIL, 'forced component terminal update failure');
+		END;`)
+	require.NoError(t, err)
 	componentsRelease := make(chan struct{})
 	var releaseOnce sync.Once
 	t.Cleanup(func() { releaseOnce.Do(func() { close(componentsRelease) }) })
@@ -1425,13 +1446,87 @@ func TestCloseWinningAfterPersistencePreventsPostCloseRunner(t *testing.T) {
 	require.ErrorIs(t, result.err, ErrExecutorClosed)
 	require.Empty(t, result.ids)
 	require.NoError(t, <-closeResult)
-	var active int
-	require.NoError(t, testDB.QueryRow(`
-		SELECT COUNT(*) FROM executions WHERE status IN ('pending', 'running')`).Scan(&active))
-	require.Zero(t, active)
+	var executionCount, componentCount int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&executionCount))
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM execution_components`).Scan(&componentCount))
+	require.Zero(t, executionCount)
+	require.Zero(t, componentCount)
+	exec.queueMu.Lock()
+	require.Empty(t, exec.activeByRepo)
+	require.Zero(t, exec.inflight)
+	exec.queueMu.Unlock()
 	select {
 	case <-runnerEntered:
 		t.Fatal("runner started after Close won the publish race")
+	default:
+	}
+
+	_, err = testDB.Exec(`DROP TRIGGER reject_component_terminal_update`)
+	require.NoError(t, err)
+	fresh := NewExecutorWithRunners(nil, testDB, repositoryConfig(1, 1), runners)
+	t.Cleanup(func() { require.NoError(t, fresh.Close()) })
+	retryIDs, err := fresh.ExecuteJob("github.com/test/repo-0")
+	require.NoError(t, err)
+	require.Len(t, retryIDs, 1)
+	select {
+	case <-runnerEntered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("fresh executor did not start the discarded repository")
+	}
+}
+
+func TestExecuteJobDiscardFailureReachesSubmitterAndClose(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testDB.Close()) })
+	runnerEntered := make(chan struct{}, 1)
+	runners := noOpRunners()
+	runners.Code = func(context.Context, typedef.Repository, []typedef.MultiStorage) error {
+		runnerEntered <- struct{}{}
+		return nil
+	}
+	exec := NewExecutorWithRunners(nil, testDB, repositoryConfig(1, 1), runners)
+	componentsRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(componentsRelease) }) })
+	discardErr := errors.New("forced pending batch discard failure")
+	store := &discardFailingStore{
+		blockingExecutionStore: &blockingExecutionStore{
+			delegate:          testDB,
+			componentsEntered: make(chan struct{}),
+			componentsRelease: componentsRelease,
+		},
+		err: discardErr,
+	}
+	exec.db = store
+	type executeResult struct {
+		ids []string
+		err error
+	}
+	submitResult := make(chan executeResult, 1)
+	go func() {
+		ids, submitErr := exec.ExecuteJob("github.com/test/repo-0")
+		submitResult <- executeResult{ids: ids, err: submitErr}
+	}()
+	<-store.componentsEntered
+
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- exec.Close() }()
+	<-executorClosedSignal(exec)
+	releaseOnce.Do(func() { close(componentsRelease) })
+
+	result := <-submitResult
+	require.Empty(t, result.ids)
+	require.ErrorIs(t, result.err, ErrExecutorClosed)
+	require.ErrorIs(t, result.err, discardErr)
+	require.ErrorIs(t, <-closeResult, discardErr)
+	exec.queueMu.Lock()
+	require.Empty(t, exec.activeByRepo)
+	require.Zero(t, exec.inflight)
+	exec.queueMu.Unlock()
+	select {
+	case <-runnerEntered:
+		t.Fatal("runner started after Close won with a discard failure")
 	default:
 	}
 }

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -906,6 +906,131 @@ func TestExecuteJobAtGenerationRejectsConfigPublishedAfterRecheck(t *testing.T) 
 	waitForJob(t, exec, jobIDs[0])
 }
 
+func TestExecuteJobAtGenerationRejectsRefreshBetweenLookupAndReservation(t *testing.T) {
+	expansionEntered := make(chan struct{})
+	expansionRelease := make(chan struct{})
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	exec := NewExecutorWithRunners(
+		logger.NewLogger(testDB),
+		testDB,
+		&config.Config{Repository: []typedef.Repository{{Name: "old", URL: "github.com/acme/old"}}},
+		noOpRunners(),
+		func(repo typedef.Repository) []typedef.Repository {
+			close(expansionEntered)
+			<-expansionRelease
+			return []typedef.Repository{repo}
+		},
+	)
+	t.Cleanup(func() {
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+
+	checked := exec.RuntimeConfigSnapshot()
+	type result struct {
+		ids []string
+		err error
+	}
+	resultReady := make(chan result, 1)
+	go func() {
+		ids, executeErr := exec.ExecuteJobAtGeneration("github.com/acme/old", checked.Generation())
+		resultReady <- result{ids: ids, err: executeErr}
+	}()
+
+	<-expansionEntered
+	exec.RefreshConfig(&config.Config{Repository: []typedef.Repository{{Name: "new", URL: "github.com/acme/new"}}})
+	close(expansionRelease)
+
+	got := <-resultReady
+	require.ErrorIs(t, got.err, ErrConfigGenerationChanged)
+	require.Empty(t, got.ids)
+	require.Empty(t, executionStatusCounts(t, testDB))
+}
+
+func TestQueuedJobUsesStorageFromAcceptedRuntimeGeneration(t *testing.T) {
+	storagesSeen := make(chan []typedef.MultiStorage, 1)
+	runners := noOpRunners()
+	runners.Code = func(_ context.Context, _ typedef.Repository, storages []typedef.MultiStorage) error {
+		storagesSeen <- storages
+		return nil
+	}
+	cfg := &config.Config{
+		Repository: []typedef.Repository{{Name: "repo", URL: "github.com/acme/repo", Storage: []string{"archive"}}},
+		Storage:    []typedef.MultiStorage{{Storage: typedef.Storage{Name: "archive", Type: "file", Path: "old"}}},
+	}
+	exec, testDB := newTestExecutorForConfig(t, cfg, runners)
+	execEntered := make(chan struct{})
+	execRelease := make(chan struct{})
+	exec.db = &blockingExecutionStore{
+		delegate:    testDB,
+		execEntered: execEntered,
+		execRelease: execRelease,
+	}
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme/repo")
+	require.NoError(t, err)
+	require.Len(t, jobIDs, 1)
+	<-execEntered
+	exec.RefreshConfig(&config.Config{
+		Repository: []typedef.Repository{{Name: "repo", URL: "github.com/acme/repo", Storage: []string{"archive"}}},
+		Storage:    []typedef.MultiStorage{{Storage: typedef.Storage{Name: "archive", Type: "file", Path: "new"}}},
+	})
+	close(execRelease)
+
+	storages := <-storagesSeen
+	require.Len(t, storages, 1)
+	require.Equal(t, "old", storages[0].Path)
+	waitForJob(t, exec, jobIDs[0])
+}
+
+func TestExecuteJobAtGenerationContextDiscardsCommitWhenCancelledBeforePublish(t *testing.T) {
+	var runnerCalls atomic.Int32
+	runners := noOpRunners()
+	runners.Code = func(context.Context, typedef.Repository, []typedef.MultiStorage) error {
+		runnerCalls.Add(1)
+		return nil
+	}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name: "repo",
+		URL:  "github.com/acme/repo",
+	}, runners)
+	componentsEntered := make(chan struct{})
+	componentsRelease := make(chan struct{})
+	exec.db = &blockingExecutionStore{
+		delegate:          testDB,
+		componentsEntered: componentsEntered,
+		componentsRelease: componentsRelease,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	generation := exec.RuntimeConfigSnapshot().Generation()
+	type result struct {
+		ids []string
+		err error
+	}
+	resultReady := make(chan result, 1)
+	go func() {
+		ids, executeErr := exec.ExecuteJobAtGenerationContext(ctx, "github.com/acme/repo", generation)
+		resultReady <- result{ids: ids, err: executeErr}
+	}()
+
+	<-componentsEntered
+	cancel()
+	close(componentsRelease)
+	got := <-resultReady
+	require.ErrorIs(t, got.err, context.Canceled)
+	require.Empty(t, got.ids)
+	require.Empty(t, executionStatusCounts(t, testDB))
+	require.Zero(t, runnerCalls.Load())
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme/repo")
+	require.NoError(t, err, "cancelled persistence must release repository ownership")
+	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
+	require.Equal(t, int32(1), runnerCalls.Load())
+}
+
 func TestExecuteJobLimitsActualRunnerConcurrencyAndKeepsOverflowPending(t *testing.T) {
 	blocker := newBlockingRunner(6)
 	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(2, 6), blocker.runners())

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -99,6 +99,11 @@ type blockingExecutionStore struct {
 	componentsEntered chan struct{}
 	componentsRelease chan struct{}
 	componentsOnce    sync.Once
+
+	finishExecutionID string
+	finishEntered     chan struct{}
+	finishRelease     chan struct{}
+	finishOnce        sync.Once
 }
 
 func (s *blockingExecutionStore) Exec(query string, args ...interface{}) (sql.Result, error) {
@@ -117,8 +122,8 @@ func (s *blockingExecutionStore) ActiveExecutionExists(ctx context.Context, repo
 	return s.delegate.ActiveExecutionExists(ctx, repoKey)
 }
 
-func (s *blockingExecutionStore) CreateComponents(ctx context.Context, executionID string, components []db.ComponentName) error {
-	err := s.delegate.CreateComponents(ctx, executionID, components)
+func (s *blockingExecutionStore) CreatePendingExecutions(ctx context.Context, executions []db.PendingExecution) error {
+	err := s.delegate.CreatePendingExecutions(ctx, executions)
 	if err == nil && s.componentsEntered != nil {
 		s.componentsOnce.Do(func() { close(s.componentsEntered) })
 		<-s.componentsRelease
@@ -131,7 +136,12 @@ func (s *blockingExecutionStore) StartComponent(ctx context.Context, executionID
 }
 
 func (s *blockingExecutionStore) FinishComponent(ctx context.Context, executionID string, component db.ComponentName, status db.ComponentStatus, finishedAt time.Time, errorMessage string) error {
-	return s.delegate.FinishComponent(ctx, executionID, component, status, finishedAt, errorMessage)
+	err := s.delegate.FinishComponent(ctx, executionID, component, status, finishedAt, errorMessage)
+	if err == nil && executionID == s.finishExecutionID {
+		s.finishOnce.Do(func() { close(s.finishEntered) })
+		<-s.finishRelease
+	}
+	return err
 }
 
 func newBlockingRunner(capacity int) *blockingRunner {
@@ -187,6 +197,19 @@ func executorClosedSignal(exec *Executor) <-chan struct{} {
 		close(closed)
 	}()
 	return closed
+}
+
+func executorCloseWaiterSignal(exec *Executor) <-chan struct{} {
+	waiting := make(chan struct{})
+	go func() {
+		exec.queueMu.Lock()
+		for exec.closeWaiters == 0 {
+			exec.queueCond.Wait()
+		}
+		exec.queueMu.Unlock()
+		close(waiting)
+	}()
+	return waiting
 }
 
 func repositoryConfig(limit uint, count int) *config.Config {
@@ -1149,7 +1172,7 @@ func TestExecuteJobExpandedBatchIsAtomicWhenSecondRepositoryIsActive(t *testing.
 	}
 }
 
-func TestExecuteJobExpandedBatchTerminalizesEarlierRowsWhenLaterPersistenceFails(t *testing.T) {
+func TestExecuteJobExpandedBatchRollsBackAllRowsWhenLaterPersistenceFails(t *testing.T) {
 	runnerEntered := make(chan string, 2)
 	runners := noOpRunners()
 	runners.Code = func(ctx context.Context, repo typedef.Repository, _ []typedef.MultiStorage) error {
@@ -1181,16 +1204,27 @@ func TestExecuteJobExpandedBatchTerminalizesEarlierRowsWhenLaterPersistenceFails
 	jobIDs, err := exec.ExecuteJob("github.com/acme")
 	require.ErrorContains(t, err, "forced beta component failure")
 	require.Empty(t, jobIDs)
-	require.Equal(t, map[string]int{"failed": 2}, executionStatusCounts(t, testDB))
-	var activeComponents int
-	require.NoError(t, testDB.QueryRow(`
-		SELECT COUNT(*) FROM execution_components WHERE status IN ('pending', 'running')`).Scan(&activeComponents))
-	require.Zero(t, activeComponents)
+	require.Empty(t, executionStatusCounts(t, testDB))
+	var componentCount int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM execution_components`).Scan(&componentCount))
+	require.Zero(t, componentCount)
+	exec.queueMu.Lock()
+	require.Empty(t, exec.activeByRepo)
+	require.Zero(t, exec.inflight)
+	exec.queueMu.Unlock()
 	select {
 	case repoKey := <-runnerEntered:
 		t.Fatalf("failed expanded batch started hidden work for %s", repoKey)
 	default:
 	}
+
+	_, err = testDB.Exec(`DROP TRIGGER reject_beta_component`)
+	require.NoError(t, err)
+	retryIDs, err := exec.ExecuteJob("github.com/acme")
+	require.NoError(t, err)
+	require.Len(t, retryIDs, 2)
+	requireRunnerEntry(t, runnerEntered)
+	requireRunnerEntry(t, runnerEntered)
 }
 
 func TestExecuteJobRejectsDuplicateKeysWithinExpandedBatchBeforePersistence(t *testing.T) {
@@ -1281,16 +1315,11 @@ func TestConcurrentCloseCallersWaitForSameCompletion(t *testing.T) {
 	require.NoError(t, err)
 	<-runnerEntered
 
-	start := make(chan struct{})
 	results := make(chan error, 2)
-	for i := 0; i < 2; i++ {
-		go func() {
-			<-start
-			results <- exec.Close()
-		}()
-	}
-	close(start)
+	go func() { results <- exec.Close() }()
 	<-runnerCancelled
+	go func() { results <- exec.Close() }()
+	<-executorCloseWaiterSignal(exec)
 	select {
 	case err := <-results:
 		t.Fatalf("Close returned before worker completion: %v", err)
@@ -1299,6 +1328,58 @@ func TestConcurrentCloseCallersWaitForSameCompletion(t *testing.T) {
 	close(releaseRunner)
 	require.NoError(t, <-results)
 	require.NoError(t, <-results)
+}
+
+func TestClosePreventsDispatcherAdmissionWhileRunningWorkerFinishes(t *testing.T) {
+	runnerEntered := make(chan string, 2)
+	releaseFirst := make(chan struct{})
+	runners := noOpRunners()
+	runners.Code = func(_ context.Context, repo typedef.Repository, _ []typedef.MultiStorage) error {
+		runnerEntered <- repo.Key()
+		if repo.Key() == "github.com/test/repo-0" {
+			<-releaseFirst
+		}
+		return nil
+	}
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 2), runners)
+	firstIDs, err := exec.ExecuteJob("github.com/test/repo-0")
+	require.NoError(t, err)
+	require.Equal(t, "github.com/test/repo-0", requireRunnerEntry(t, runnerEntered))
+	secondIDs, err := exec.ExecuteJob("github.com/test/repo-1")
+	require.NoError(t, err)
+
+	finishRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(finishRelease) }) })
+	store := &blockingExecutionStore{
+		delegate:          testDB,
+		finishExecutionID: firstIDs[0],
+		finishEntered:     make(chan struct{}),
+		finishRelease:     finishRelease,
+	}
+	exec.db = store
+	close(releaseFirst)
+	<-store.finishEntered
+
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- exec.Close() }()
+	<-executorClosedSignal(exec)
+	select {
+	case repoKey := <-runnerEntered:
+		t.Fatalf("queued repository entered runner after Close won: %s", repoKey)
+	default:
+	}
+	releaseOnce.Do(func() { close(finishRelease) })
+	require.NoError(t, <-closeResult)
+	require.Equal(t, map[string]int{"cancelled": 1, "completed": 1}, executionStatusCounts(t, testDB))
+	for _, jobID := range append(firstIDs, secondIDs...) {
+		require.False(t, exec.IsJobRunning(jobID))
+	}
+	select {
+	case repoKey := <-runnerEntered:
+		t.Fatalf("queued repository entered runner during shutdown: %s", repoKey)
+	default:
+	}
 }
 
 func TestCloseWinningAfterPersistencePreventsPostCloseRunner(t *testing.T) {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -365,6 +365,87 @@ func TestExecuteJobCancelStoreFailureFallsBackToFailedComponentAndOverall(t *tes
 	)
 }
 
+func TestExecuteJobCancelFailedFallbackRejectionLeavesOverallActive(t *testing.T) {
+	issueStarted := make(chan struct{})
+	runners := noOpRunners()
+	runners.Issue = func(ctx context.Context, _ typedef.Repository, _ []typedef.MultiStorage) error {
+		close(issueStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:           "test-repo",
+		URL:            "github.com/test/repo",
+		DownloadIssues: true,
+		DownloadWiki:   true,
+	}, runners)
+	_, err := testDB.Exec(`
+		CREATE TRIGGER fail_issue_cancellation_and_fallback
+		BEFORE UPDATE OF status ON execution_components
+		WHEN OLD.component = 'issues' AND NEW.status IN ('cancelled', 'failed')
+		BEGIN
+			SELECT RAISE(FAIL, 'forced cancellation and fallback failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	<-issueStarted
+	require.NoError(t, exec.CancelJob(jobIDs[0]))
+	waitForJob(t, exec, jobIDs[0])
+
+	require.False(t, exec.IsJobRunning(jobIDs[0]))
+	requireExecution(t, testDB, jobIDs[0], StatusRunning, "")
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+		expectedComponent{db.ComponentIssue, db.ComponentRunning, ""},
+		expectedComponent{db.ComponentWiki, db.ComponentCancelled, "context canceled"},
+	)
+}
+
+func TestExecuteJobCancelledOverallStoreFailureFallsBackToFailed(t *testing.T) {
+	issueStarted := make(chan struct{})
+	runners := noOpRunners()
+	runners.Issue = func(ctx context.Context, _ typedef.Repository, _ []typedef.MultiStorage) error {
+		close(issueStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:           "test-repo",
+		URL:            "github.com/test/repo",
+		DownloadIssues: true,
+		DownloadWiki:   true,
+	}, runners)
+	_, err := testDB.Exec(`
+		CREATE TRIGGER fail_execution_cancellation
+		BEFORE UPDATE OF status ON executions
+		WHEN NEW.status = 'cancelled'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced overall cancellation failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	<-issueStarted
+	require.NoError(t, exec.CancelJob(jobIDs[0]))
+	waitForJob(t, exec, jobIDs[0])
+
+	persistenceMessage := fmt.Sprintf(
+		`persist cancelled execution state: update execution %q to "cancelled": constraint failed: forced overall cancellation failure (1811)`,
+		jobIDs[0],
+	)
+	requireExecution(t, testDB, jobIDs[0], StatusFailed, persistenceMessage)
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+		expectedComponent{db.ComponentIssue, db.ComponentCancelled, "context canceled"},
+		expectedComponent{db.ComponentWiki, db.ComponentCancelled, "context canceled"},
+	)
+}
+
 func TestExecuteJobComponentStoreFailurePreventsCompletedOverall(t *testing.T) {
 	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
 		Name:         "test-repo",
@@ -420,6 +501,48 @@ func TestExecuteJobOverallTerminalStoreFailureFallsBackToFailed(t *testing.T) {
 	requireComponents(t, testDB, jobIDs[0],
 		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
 	)
+}
+
+func TestExecuteJobFailedOverallFallbackRejectionIsDurablyLogged(t *testing.T) {
+	exec, testDB := newTestExecutor(t)
+	_, err := testDB.Exec(`
+		CREATE TRIGGER fail_execution_completion_before_fallback
+		BEFORE UPDATE OF status ON executions
+		WHEN NEW.status = 'completed'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced overall completion failure');
+		END;
+
+		CREATE TRIGGER fail_execution_failed_fallback
+		BEFORE UPDATE OF status ON executions
+		WHEN NEW.status = 'failed'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced overall failed fallback failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	waitForJob(t, exec, jobIDs[0])
+
+	require.False(t, exec.IsJobRunning(jobIDs[0]))
+	requireExecution(t, testDB, jobIDs[0], StatusRunning, "")
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+	)
+
+	wantLog := fmt.Sprintf(
+		`Failed to record overall execution store failure: update execution %q to "failed": constraint failed: forced overall failed fallback failure (1811)`,
+		jobIDs[0],
+	)
+	var count int
+	require.NoError(t, testDB.QueryRow(`
+		SELECT COUNT(*) FROM logs
+		WHERE execution_id = ? AND level = 'error' AND message = ?`,
+		jobIDs[0], wantLog,
+	).Scan(&count))
+	require.Equal(t, 1, count)
 }
 
 func TestExecuteJobCreatesRecord(t *testing.T) {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -402,6 +402,18 @@ func TestExecuteJobCancelFailedFallbackRejectionLeavesOverallActive(t *testing.T
 		expectedComponent{db.ComponentIssue, db.ComponentRunning, ""},
 		expectedComponent{db.ComponentWiki, db.ComponentCancelled, "context canceled"},
 	)
+
+	wantFallbackLog := fmt.Sprintf(
+		`Failed to record issues cancellation store failure: finish component "issues" for execution %q: constraint failed: forced cancellation and fallback failure (1811)`,
+		jobIDs[0],
+	)
+	var fallbackLogCount int
+	require.NoError(t, testDB.QueryRow(`
+		SELECT COUNT(*) FROM logs
+		WHERE execution_id = ? AND level = 'error' AND message = ?`,
+		jobIDs[0], wantFallbackLog,
+	).Scan(&fallbackLogCount))
+	require.Equal(t, 1, fallbackLogCount)
 }
 
 func TestExecuteJobCancelledOverallStoreFailureFallsBackToFailed(t *testing.T) {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -771,10 +771,11 @@ func TestExecuteJobCreatesRecord(t *testing.T) {
 }
 
 func TestExecuteJobUnknownRepository(t *testing.T) {
-	exec, _ := newTestExecutor(t)
+	exec, testDB := newTestExecutor(t)
 
 	_, err := exec.ExecuteJob("does-not-exist")
-	assert.Error(t, err)
+	require.ErrorIs(t, err, ErrRepositoryNotFound)
+	require.Empty(t, executionStatusCounts(t, testDB))
 }
 
 func TestCancelNonRunningJob(t *testing.T) {
@@ -800,9 +801,9 @@ func TestExecuteJobWritesRepoKey(t *testing.T) {
 
 func TestExecuteJobExpandsOrgIntoMultipleJobs(t *testing.T) {
 	exec, testDB := newTestExecutor(t)
-	exec.cfg.Load().Repository = []typedef.Repository{
+	exec.RefreshConfig(&config.Config{Repository: []typedef.Repository{
 		{Name: "acme", URL: "https://github.com/acme", Type: typedef.TypeOrg, OrgName: "acme"},
-	}
+	}})
 
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
@@ -839,6 +840,67 @@ func TestRefreshConfigRepointsExecutor(t *testing.T) {
 	require.Error(t, err)
 
 	jobIDs, err := exec.ExecuteJob("github.com/other/repo")
+	require.NoError(t, err)
+	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
+}
+
+func TestRuntimeConfigSnapshotDefensivelyCopiesAndIndexesRepositories(t *testing.T) {
+	cfg := &config.Config{SyncOverdueGrace: time.Minute, SyncStuckThreshold: time.Hour, Repository: []typedef.Repository{{
+		Name:    "original",
+		URL:     "https://github.com/acme/original.git",
+		Storage: []string{"archive"},
+	}}}
+	exec, _ := newTestExecutorForConfig(t, cfg, noOpRunners())
+
+	snapshot := exec.RuntimeConfigSnapshot()
+	cfg.Repository[0].URL = "github.com/acme/changed"
+	cfg.Repository[0].Storage[0] = "changed"
+	cfg.SyncOverdueGrace = 2 * time.Minute
+	cfg.SyncStuckThreshold = 2 * time.Hour
+
+	repository, found := snapshot.Repository("github.com/acme/original")
+	require.True(t, found)
+	require.Equal(t, "https://github.com/acme/original.git", repository.URL)
+	require.Equal(t, []string{"archive"}, repository.Storage)
+	repository.Storage[0] = "caller mutation"
+	repositories := snapshot.Repositories()
+	repositories[0].URL = "caller mutation"
+
+	repository, found = exec.RuntimeConfigSnapshot().Repository("https://github.com/acme/original")
+	require.True(t, found)
+	require.Equal(t, "https://github.com/acme/original.git", repository.URL)
+	require.Equal(t, []string{"archive"}, repository.Storage)
+	overdueGrace, stuckThreshold := exec.RuntimeConfigSnapshot().SyncHealthThresholds()
+	require.Equal(t, time.Minute, overdueGrace)
+	require.Equal(t, time.Hour, stuckThreshold)
+	_, found = exec.RuntimeConfigSnapshot().Repository("github.com/acme/changed")
+	require.False(t, found)
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme/original")
+	require.NoError(t, err)
+	waitForJob(t, exec, jobIDs[0])
+}
+
+func TestExecuteJobAtGenerationRejectsConfigPublishedAfterRecheck(t *testing.T) {
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name: "old",
+		URL:  "github.com/acme/old",
+	}, noOpRunners())
+	checked := exec.RuntimeConfigSnapshot()
+	exec.RefreshConfig(&config.Config{Repository: []typedef.Repository{{
+		Name: "new",
+		URL:  "github.com/acme/new",
+	}}})
+
+	jobIDs, err := exec.ExecuteJobAtGeneration("github.com/acme/old", checked.Generation())
+	require.ErrorIs(t, err, ErrConfigGenerationChanged)
+	require.Empty(t, jobIDs)
+	require.Empty(t, executionStatusCounts(t, testDB))
+
+	current := exec.RuntimeConfigSnapshot()
+	require.Greater(t, current.Generation(), checked.Generation())
+	jobIDs, err = exec.ExecuteJobAtGeneration("github.com/acme/new", current.Generation())
 	require.NoError(t, err)
 	require.Len(t, jobIDs, 1)
 	waitForJob(t, exec, jobIDs[0])

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1716,6 +1716,77 @@ func TestRefreshConfigDownsizeWaitsUntilRunningFallsBelowNewLimit(t *testing.T) 
 	}
 }
 
+func TestUnifiedPublicationDoesNotDeadlockQueueResizeAdmissionReservationAndAcquire(t *testing.T) {
+	previous := config.GetIns()
+	oldConfig := &config.Config{
+		GitHubAPIConcurrency: 2,
+		ConcurrencyNum:       1,
+		Repository: []typedef.Repository{{
+			Name: "old", URL: "github.com/acme/repo",
+		}},
+	}
+	config.SetIns(oldConfig)
+	t.Cleanup(func() { config.SetIns(previous) })
+	exec, _ := newTestExecutorForConfig(t, oldConfig, Runners{})
+	newConfig := config.Clone(oldConfig)
+	newConfig.GitHubAPIConcurrency = 1
+	newConfig.ConcurrencyNum = 2
+	newConfig.Repository[0].Name = "new"
+
+	publicationEntered := make(chan struct{})
+	exec.queueMu.Lock()
+	publishDone := make(chan struct{})
+	go func() {
+		config.PublishSnapshot(newConfig, func(published *config.Config) {
+			close(publicationEntered)
+			exec.RefreshConfig(published)
+		})
+		close(publishDone)
+	}()
+	<-publicationEntered
+
+	runtimeDone := make(chan *RuntimeConfigSnapshot, 1)
+	go func() { runtimeDone <- exec.RuntimeConfigSnapshot() }()
+	executeDone := make(chan error, 1)
+	go func() {
+		_, executeErr := exec.ExecuteJob("github.com/acme/repo")
+		executeDone <- executeErr
+	}()
+	acquireDone := make(chan error, 1)
+	go func() {
+		permit, acquireErr := githubapi.Acquire(context.Background(), "core")
+		if permit != nil {
+			permit.Done(githubapi.Observation{})
+		}
+		acquireDone <- acquireErr
+	}()
+
+	exec.queueMu.Unlock()
+	select {
+	case <-publishDone:
+	case <-time.After(time.Second):
+		t.Fatal("publication deadlocked waiting for queue resize")
+	}
+	select {
+	case runtime := <-runtimeDone:
+		require.Equal(t, "new", runtime.Repositories()[0].Name)
+	case <-time.After(time.Second):
+		t.Fatal("runtime read deadlocked with publication and queue resize")
+	}
+	select {
+	case err := <-executeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("reservation deadlocked with publication and queue resize")
+	}
+	select {
+	case err := <-acquireDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("GitHub Acquire deadlocked with publication")
+	}
+}
+
 func TestConcurrentCloseCallersWaitForSameCompletion(t *testing.T) {
 	runnerEntered := make(chan struct{})
 	runnerCancelled := make(chan struct{})

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,13 +25,19 @@ func newTestExecutor(t *testing.T) (*Executor, *db.DB) {
 
 func newTestExecutorForRepo(t *testing.T, repo typedef.Repository, runners Runners) (*Executor, *db.DB) {
 	t.Helper()
+	return newTestExecutorForConfig(t, &config.Config{Repository: []typedef.Repository{repo}}, runners)
+}
+
+func newTestExecutorForConfig(t *testing.T, cfg *config.Config, runners Runners) (*Executor, *db.DB) {
+	t.Helper()
 	testDB, err := db.Initialize(":memory:")
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, testDB.Close()) })
 
 	log := logger.NewLogger(testDB)
-	cfg := &config.Config{Repository: []typedef.Repository{repo}}
-	return NewExecutorWithRunners(log, testDB, cfg, runners), testDB
+	exec := NewExecutorWithRunners(log, testDB, cfg, runners)
+	t.Cleanup(func() { require.NoError(t, exec.Close()) })
+	return exec, testDB
 }
 
 func noOpRunners() Runners {
@@ -69,14 +76,94 @@ func (r *runnerRecorder) recordedCalls() []string {
 	return append([]string(nil), r.calls...)
 }
 
+type blockingRunner struct {
+	entered    chan string
+	release    chan struct{}
+	running    atomic.Int32
+	maxRunning atomic.Int32
+}
+
+func newBlockingRunner(capacity int) *blockingRunner {
+	return &blockingRunner{
+		entered: make(chan string, capacity),
+		release: make(chan struct{}),
+	}
+}
+
+func (r *blockingRunner) run(ctx context.Context, repo typedef.Repository, _ []typedef.MultiStorage) error {
+	running := r.running.Add(1)
+	defer r.running.Add(-1)
+	for {
+		maxRunning := r.maxRunning.Load()
+		if running <= maxRunning || r.maxRunning.CompareAndSwap(maxRunning, running) {
+			break
+		}
+	}
+	r.entered <- repo.Key()
+	select {
+	case <-r.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *blockingRunner) runners() Runners {
+	runners := noOpRunners()
+	runners.Code = r.run
+	return runners
+}
+
+func requireRunnerEntry(t *testing.T, entered <-chan string) string {
+	t.Helper()
+	select {
+	case repoKey := <-entered:
+		return repoKey
+	case <-time.After(3 * time.Second):
+		t.Fatal("runner did not start")
+		return ""
+	}
+}
+
+func repositoryConfig(limit uint, count int) *config.Config {
+	repos := make([]typedef.Repository, count)
+	for i := range repos {
+		repos[i] = typedef.Repository{
+			Name: fmt.Sprintf("repo-%d", i),
+			URL:  fmt.Sprintf("github.com/test/repo-%d", i),
+		}
+	}
+	return &config.Config{ConcurrencyNum: limit, Repository: repos}
+}
+
+func executionStatusCounts(t *testing.T, testDB *db.DB) map[string]int {
+	t.Helper()
+	rows, err := testDB.Query(`SELECT status, COUNT(*) FROM executions GROUP BY status`)
+	require.NoError(t, err)
+	defer rows.Close()
+	counts := make(map[string]int)
+	for rows.Next() {
+		var status string
+		var count int
+		require.NoError(t, rows.Scan(&status, &count))
+		counts[status] = count
+	}
+	require.NoError(t, rows.Err())
+	return counts
+}
+
 func waitForJob(t *testing.T, exec *Executor, jobID string) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for exec.IsJobRunning(jobID) {
-		if time.Now().After(deadline) {
-			t.Fatalf("job %s did not finish", jobID)
-		}
-		time.Sleep(10 * time.Millisecond)
+	exec.queueMu.Lock()
+	jobCtx := exec.jobs[jobID]
+	exec.queueMu.Unlock()
+	if jobCtx == nil {
+		return
+	}
+	select {
+	case <-jobCtx.done:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("job %s did not finish", jobID)
 	}
 }
 
@@ -655,4 +742,229 @@ func TestRefreshConfigRepointsExecutor(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, jobIDs, 1)
 	waitForJob(t, exec, jobIDs[0])
+}
+
+func TestExecuteJobLimitsActualRunnerConcurrencyAndKeepsOverflowPending(t *testing.T) {
+	blocker := newBlockingRunner(6)
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(2, 6), blocker.runners())
+
+	jobIDs := make([]string, 0, 6)
+	for i := 0; i < 6; i++ {
+		ids, err := exec.ExecuteJob(fmt.Sprintf("github.com/test/repo-%d", i))
+		require.NoError(t, err)
+		require.Len(t, ids, 1)
+		jobIDs = append(jobIDs, ids[0])
+	}
+
+	requireRunnerEntry(t, blocker.entered)
+	requireRunnerEntry(t, blocker.entered)
+	require.Equal(t, map[string]int{"pending": 4, "running": 2}, executionStatusCounts(t, testDB))
+	require.Equal(t, int32(2), blocker.running.Load())
+	require.Equal(t, int32(2), blocker.maxRunning.Load())
+
+	close(blocker.release)
+	for _, jobID := range jobIDs {
+		waitForJob(t, exec, jobID)
+	}
+	require.Equal(t, int32(2), blocker.maxRunning.Load())
+}
+
+func TestExecuteJobDefaultsZeroConcurrencyToThree(t *testing.T) {
+	blocker := newBlockingRunner(4)
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(0, 4), blocker.runners())
+	for i := 0; i < 4; i++ {
+		_, err := exec.ExecuteJob(fmt.Sprintf("github.com/test/repo-%d", i))
+		require.NoError(t, err)
+	}
+
+	requireRunnerEntry(t, blocker.entered)
+	requireRunnerEntry(t, blocker.entered)
+	requireRunnerEntry(t, blocker.entered)
+	require.Equal(t, map[string]int{"pending": 1, "running": 3}, executionStatusCounts(t, testDB))
+	require.Equal(t, int32(3), blocker.maxRunning.Load())
+}
+
+func TestExecuteJobRejectsDuplicateRepositoryReservedInThisProcess(t *testing.T) {
+	blocker := newBlockingRunner(1)
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 1), blocker.runners())
+
+	_, err := exec.ExecuteJob("https://github.com/test/repo-0")
+	require.NoError(t, err)
+	requireRunnerEntry(t, blocker.entered)
+
+	_, err = exec.ExecuteJob("github.com/test/repo-0")
+	require.ErrorIs(t, err, ErrRepositoryActive)
+	var count int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&count))
+	require.Equal(t, 1, count)
+}
+
+func TestExecuteJobAtomicallyReservesRepositoryAcrossConcurrentRequests(t *testing.T) {
+	blocker := newBlockingRunner(1)
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 1), blocker.runners())
+	start := make(chan struct{})
+	results := make(chan error, 8)
+	var callers sync.WaitGroup
+	for i := 0; i < cap(results); i++ {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			<-start
+			_, err := exec.ExecuteJob("https://github.com/test/repo-0")
+			results <- err
+		}()
+	}
+	close(start)
+	callers.Wait()
+	close(results)
+
+	succeeded := 0
+	active := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, ErrRepositoryActive):
+			active++
+		default:
+			t.Fatalf("unexpected enqueue error: %v", err)
+		}
+	}
+	require.Equal(t, 1, succeeded)
+	require.Equal(t, 7, active)
+	var count int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&count))
+	require.Equal(t, 1, count)
+}
+
+func TestExecuteJobRejectsDuplicateRepositoryAlreadyActiveInSQLite(t *testing.T) {
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 1), noOpRunners())
+	_, err := testDB.Exec(`
+		INSERT INTO executions (id, job_name, repo_key, start_time, status)
+		VALUES (?, ?, ?, ?, ?)`, "existing", "repo-0", "github.com/test/repo-0", time.Now(), StatusPending)
+	require.NoError(t, err)
+
+	_, err = exec.ExecuteJob("github.com/test/repo-0")
+	require.ErrorIs(t, err, ErrRepositoryActive)
+	var count int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&count))
+	require.Equal(t, 1, count)
+}
+
+func TestExecuteJobReleasesRepositoryReservationAfterExecutionInsertFails(t *testing.T) {
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 1), noOpRunners())
+	_, err := testDB.Exec(`
+		CREATE TRIGGER reject_execution_insert
+		BEFORE INSERT ON executions
+		BEGIN
+			SELECT RAISE(FAIL, 'forced execution insert failure');
+		END;`)
+	require.NoError(t, err)
+
+	_, err = exec.ExecuteJob("github.com/test/repo-0")
+	require.ErrorContains(t, err, "forced execution insert failure")
+	_, err = testDB.Exec(`DROP TRIGGER reject_execution_insert`)
+	require.NoError(t, err)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo-0")
+	require.NoError(t, err)
+	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
+}
+
+func TestExecuteJobReleasesRepositoryReservationAfterComponentInsertFails(t *testing.T) {
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 1), noOpRunners())
+	_, err := testDB.Exec(`
+		CREATE TRIGGER reject_component_insert
+		BEFORE INSERT ON execution_components
+		BEGIN
+			SELECT RAISE(FAIL, 'forced component insert failure');
+		END;`)
+	require.NoError(t, err)
+
+	_, err = exec.ExecuteJob("github.com/test/repo-0")
+	require.ErrorContains(t, err, "forced component insert failure")
+	_, err = testDB.Exec(`DROP TRIGGER reject_component_insert`)
+	require.NoError(t, err)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo-0")
+	require.NoError(t, err)
+	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
+}
+
+func TestCancelJobRemovesQueuedWorkWithoutCallingRunner(t *testing.T) {
+	blocker := newBlockingRunner(2)
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 2), blocker.runners())
+
+	firstIDs, err := exec.ExecuteJob("github.com/test/repo-0")
+	require.NoError(t, err)
+	requireRunnerEntry(t, blocker.entered)
+	queuedIDs, err := exec.ExecuteJob("github.com/test/repo-1")
+	require.NoError(t, err)
+
+	require.NoError(t, exec.CancelJob(queuedIDs[0]))
+	requireExecution(t, testDB, queuedIDs[0], StatusCancelled, "")
+	requireComponents(t, testDB, queuedIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCancelled, "context canceled"},
+	)
+	require.Equal(t, int32(1), blocker.running.Load())
+	select {
+	case repoKey := <-blocker.entered:
+		t.Fatalf("queued repository entered runner: %s", repoKey)
+	default:
+	}
+
+	close(blocker.release)
+	waitForJob(t, exec, firstIDs[0])
+}
+
+func TestRefreshConfigRaisesLiveAdmissionLimit(t *testing.T) {
+	blocker := newBlockingRunner(3)
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 3), blocker.runners())
+	for i := 0; i < 3; i++ {
+		_, err := exec.ExecuteJob(fmt.Sprintf("github.com/test/repo-%d", i))
+		require.NoError(t, err)
+	}
+	requireRunnerEntry(t, blocker.entered)
+	require.Equal(t, map[string]int{"pending": 2, "running": 1}, executionStatusCounts(t, testDB))
+
+	exec.RefreshConfig(repositoryConfig(2, 3))
+	requireRunnerEntry(t, blocker.entered)
+	require.Equal(t, map[string]int{"pending": 1, "running": 2}, executionStatusCounts(t, testDB))
+	require.Equal(t, int32(2), blocker.maxRunning.Load())
+}
+
+func TestCloseCancelsQueuedAndRunningWorkAndIsIdempotent(t *testing.T) {
+	blocker := newBlockingRunner(3)
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 3), blocker.runners())
+	jobIDs := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		ids, err := exec.ExecuteJob(fmt.Sprintf("github.com/test/repo-%d", i))
+		require.NoError(t, err)
+		jobIDs = append(jobIDs, ids[0])
+	}
+	requireRunnerEntry(t, blocker.entered)
+
+	require.NoError(t, exec.Close())
+	require.NoError(t, exec.Close())
+	require.Equal(t, map[string]int{"cancelled": 3}, executionStatusCounts(t, testDB))
+	require.Equal(t, int32(0), blocker.running.Load())
+	select {
+	case repoKey := <-blocker.entered:
+		t.Fatalf("queued repository entered runner during close: %s", repoKey)
+	default:
+	}
+	for _, jobID := range jobIDs {
+		require.False(t, exec.IsJobRunning(jobID))
+	}
+
+	_, err := exec.ExecuteJob("github.com/test/repo-0")
+	require.ErrorIs(t, err, ErrExecutorClosed)
+}
+
+func TestCloseBeforeFirstEnqueueIsIdempotent(t *testing.T) {
+	exec, _ := newTestExecutorForConfig(t, nil, noOpRunners())
+	require.NoError(t, exec.Close())
+	require.NoError(t, exec.Close())
 }

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
@@ -83,6 +84,56 @@ type blockingRunner struct {
 	maxRunning atomic.Int32
 }
 
+type blockingExecutionStore struct {
+	delegate *db.DB
+
+	activeKey     string
+	activeEntered chan struct{}
+	activeRelease chan struct{}
+	activeOnce    sync.Once
+
+	execEntered chan struct{}
+	execRelease chan struct{}
+	execOnce    sync.Once
+
+	componentsEntered chan struct{}
+	componentsRelease chan struct{}
+	componentsOnce    sync.Once
+}
+
+func (s *blockingExecutionStore) Exec(query string, args ...interface{}) (sql.Result, error) {
+	if s.execEntered != nil {
+		s.execOnce.Do(func() { close(s.execEntered) })
+		<-s.execRelease
+	}
+	return s.delegate.Exec(query, args...)
+}
+
+func (s *blockingExecutionStore) ActiveExecutionExists(ctx context.Context, repoKey string) (bool, error) {
+	if repoKey == s.activeKey {
+		s.activeOnce.Do(func() { close(s.activeEntered) })
+		<-s.activeRelease
+	}
+	return s.delegate.ActiveExecutionExists(ctx, repoKey)
+}
+
+func (s *blockingExecutionStore) CreateComponents(ctx context.Context, executionID string, components []db.ComponentName) error {
+	err := s.delegate.CreateComponents(ctx, executionID, components)
+	if err == nil && s.componentsEntered != nil {
+		s.componentsOnce.Do(func() { close(s.componentsEntered) })
+		<-s.componentsRelease
+	}
+	return err
+}
+
+func (s *blockingExecutionStore) StartComponent(ctx context.Context, executionID string, component db.ComponentName, startedAt time.Time) error {
+	return s.delegate.StartComponent(ctx, executionID, component, startedAt)
+}
+
+func (s *blockingExecutionStore) FinishComponent(ctx context.Context, executionID string, component db.ComponentName, status db.ComponentStatus, finishedAt time.Time, errorMessage string) error {
+	return s.delegate.FinishComponent(ctx, executionID, component, status, finishedAt, errorMessage)
+}
+
 func newBlockingRunner(capacity int) *blockingRunner {
 	return &blockingRunner{
 		entered: make(chan string, capacity),
@@ -123,6 +174,19 @@ func requireRunnerEntry(t *testing.T, entered <-chan string) string {
 		t.Fatal("runner did not start")
 		return ""
 	}
+}
+
+func executorClosedSignal(exec *Executor) <-chan struct{} {
+	closed := make(chan struct{})
+	go func() {
+		exec.queueMu.Lock()
+		for !exec.closed {
+			exec.queueCond.Wait()
+		}
+		exec.queueMu.Unlock()
+		close(closed)
+	}()
+	return closed
 }
 
 func repositoryConfig(limit uint, count int) *config.Config {
@@ -967,4 +1031,331 @@ func TestCloseBeforeFirstEnqueueIsIdempotent(t *testing.T) {
 	exec, _ := newTestExecutorForConfig(t, nil, noOpRunners())
 	require.NoError(t, exec.Close())
 	require.NoError(t, exec.Close())
+}
+
+func TestBlockedSubmissionDoesNotPreventCloseFromCancellingRunningWork(t *testing.T) {
+	runnerEntered := make(chan struct{})
+	runnerCancelled := make(chan struct{})
+	runners := noOpRunners()
+	runners.Code = func(ctx context.Context, _ typedef.Repository, _ []typedef.MultiStorage) error {
+		close(runnerEntered)
+		<-ctx.Done()
+		close(runnerCancelled)
+		return ctx.Err()
+	}
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 2), runners)
+	_, err := exec.ExecuteJob("github.com/test/repo-0")
+	require.NoError(t, err)
+	<-runnerEntered
+
+	activeRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(activeRelease) }) })
+	store := &blockingExecutionStore{
+		delegate:      testDB,
+		activeKey:     "github.com/test/repo-1",
+		activeEntered: make(chan struct{}),
+		activeRelease: activeRelease,
+	}
+	exec.db = store
+	submitResult := make(chan error, 1)
+	go func() {
+		_, submitErr := exec.ExecuteJob("github.com/test/repo-1")
+		submitResult <- submitErr
+	}()
+	<-store.activeEntered
+
+	closed := executorClosedSignal(exec)
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- exec.Close() }()
+	<-closed
+	<-runnerCancelled
+	select {
+	case err := <-closeResult:
+		t.Fatalf("Close returned before the in-flight submission completed: %v", err)
+	default:
+	}
+
+	releaseOnce.Do(func() { close(activeRelease) })
+	require.ErrorIs(t, <-submitResult, ErrExecutorClosed)
+	require.NoError(t, <-closeResult)
+}
+
+func TestUnknownJobCancellationPersistenceDoesNotHoldQueueLock(t *testing.T) {
+	exec, testDB := newTestExecutorForConfig(t, nil, noOpRunners())
+	execRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(execRelease) }) })
+	store := &blockingExecutionStore{
+		delegate:    testDB,
+		execEntered: make(chan struct{}),
+		execRelease: execRelease,
+	}
+	exec.db = store
+	cancelResult := make(chan error, 1)
+	go func() { cancelResult <- exec.CancelJob("unknown") }()
+	<-store.execEntered
+
+	closed := executorClosedSignal(exec)
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- exec.Close() }()
+	<-closed
+	select {
+	case err := <-closeResult:
+		t.Fatalf("Close returned before unknown-job persistence completed: %v", err)
+	default:
+	}
+
+	releaseOnce.Do(func() { close(execRelease) })
+	require.Error(t, <-cancelResult)
+	require.NoError(t, <-closeResult)
+}
+
+func TestExecuteJobExpandedBatchIsAtomicWhenSecondRepositoryIsActive(t *testing.T) {
+	runnerEntered := make(chan string, 2)
+	runners := noOpRunners()
+	runners.Code = func(ctx context.Context, repo typedef.Repository, _ []typedef.MultiStorage) error {
+		runnerEntered <- repo.Key()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	exec, testDB := newTestExecutorForConfig(t, &config.Config{Repository: []typedef.Repository{{
+		Name: "acme", URL: "github.com/acme", Type: typedef.TypeOrg, OrgName: "acme",
+	}}}, runners)
+	_, err := testDB.Exec(`
+		INSERT INTO executions (id, job_name, repo_key, start_time, status)
+		VALUES (?, ?, ?, ?, ?)`, "active-beta", "beta", "github.com/acme/beta", time.Now(), StatusRunning)
+	require.NoError(t, err)
+
+	old := expandRepos
+	t.Cleanup(func() { expandRepos = old })
+	expandRepos = func(typedef.Repository) []typedef.Repository {
+		return []typedef.Repository{
+			{Name: "alpha", URL: "github.com/acme/alpha"},
+			{Name: "beta", URL: "github.com/acme/beta"},
+		}
+	}
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme")
+	require.ErrorIs(t, err, ErrRepositoryActive)
+	require.Empty(t, jobIDs)
+	var count int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&count))
+	require.Equal(t, 1, count)
+	select {
+	case repoKey := <-runnerEntered:
+		t.Fatalf("expanded batch started hidden work for %s", repoKey)
+	default:
+	}
+}
+
+func TestExecuteJobExpandedBatchTerminalizesEarlierRowsWhenLaterPersistenceFails(t *testing.T) {
+	runnerEntered := make(chan string, 2)
+	runners := noOpRunners()
+	runners.Code = func(ctx context.Context, repo typedef.Repository, _ []typedef.MultiStorage) error {
+		runnerEntered <- repo.Key()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	exec, testDB := newTestExecutorForConfig(t, &config.Config{Repository: []typedef.Repository{{
+		Name: "acme", URL: "github.com/acme", Type: typedef.TypeOrg, OrgName: "acme",
+	}}}, runners)
+	_, err := testDB.Exec(`
+		CREATE TRIGGER reject_beta_component
+		BEFORE INSERT ON execution_components
+		WHEN (SELECT repo_key FROM executions WHERE id = NEW.execution_id) = 'github.com/acme/beta'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced beta component failure');
+		END;`)
+	require.NoError(t, err)
+
+	old := expandRepos
+	t.Cleanup(func() { expandRepos = old })
+	expandRepos = func(typedef.Repository) []typedef.Repository {
+		return []typedef.Repository{
+			{Name: "alpha", URL: "github.com/acme/alpha"},
+			{Name: "beta", URL: "github.com/acme/beta"},
+		}
+	}
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme")
+	require.ErrorContains(t, err, "forced beta component failure")
+	require.Empty(t, jobIDs)
+	require.Equal(t, map[string]int{"failed": 2}, executionStatusCounts(t, testDB))
+	var activeComponents int
+	require.NoError(t, testDB.QueryRow(`
+		SELECT COUNT(*) FROM execution_components WHERE status IN ('pending', 'running')`).Scan(&activeComponents))
+	require.Zero(t, activeComponents)
+	select {
+	case repoKey := <-runnerEntered:
+		t.Fatalf("failed expanded batch started hidden work for %s", repoKey)
+	default:
+	}
+}
+
+func TestExecuteJobRejectsDuplicateKeysWithinExpandedBatchBeforePersistence(t *testing.T) {
+	exec, testDB := newTestExecutorForConfig(t, &config.Config{Repository: []typedef.Repository{{
+		Name: "acme", URL: "github.com/acme", Type: typedef.TypeOrg, OrgName: "acme",
+	}}}, noOpRunners())
+	old := expandRepos
+	t.Cleanup(func() { expandRepos = old })
+	expandRepos = func(typedef.Repository) []typedef.Repository {
+		return []typedef.Repository{
+			{Name: "alpha", URL: "https://github.com/acme/alpha"},
+			{Name: "alpha-copy", URL: "github.com/acme/alpha/"},
+		}
+	}
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme")
+	require.ErrorIs(t, err, ErrRepositoryActive)
+	require.Empty(t, jobIDs)
+	var count int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&count))
+	require.Zero(t, count)
+}
+
+func TestRefreshConfigDownsizeWaitsUntilRunningFallsBelowNewLimit(t *testing.T) {
+	cfg := repositoryConfig(3, 4)
+	entered := make(chan string, 4)
+	gates := make(map[string]chan struct{}, 4)
+	for _, repo := range cfg.Repository {
+		gates[repo.Key()] = make(chan struct{})
+	}
+	runners := noOpRunners()
+	runners.Code = func(ctx context.Context, repo typedef.Repository, _ []typedef.MultiStorage) error {
+		entered <- repo.Key()
+		select {
+		case <-gates[repo.Key()]:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	exec, _ := newTestExecutorForConfig(t, cfg, runners)
+	jobByRepo := make(map[string]string, 4)
+	for _, repo := range cfg.Repository {
+		ids, err := exec.ExecuteJob(repo.Key())
+		require.NoError(t, err)
+		jobByRepo[repo.Key()] = ids[0]
+	}
+	first := requireRunnerEntry(t, entered)
+	second := requireRunnerEntry(t, entered)
+	third := requireRunnerEntry(t, entered)
+
+	exec.RefreshConfig(repositoryConfig(2, 4))
+	close(gates[first])
+	waitForJob(t, exec, jobByRepo[first])
+	exec.queueMu.Lock()
+	require.Equal(t, 2, exec.running)
+	require.Len(t, exec.pending, 1)
+	exec.queueMu.Unlock()
+	select {
+	case repoKey := <-entered:
+		t.Fatalf("replacement %s started while running equalled downsized limit", repoKey)
+	default:
+	}
+
+	close(gates[second])
+	fourth := requireRunnerEntry(t, entered)
+	close(gates[third])
+	close(gates[fourth])
+	for _, jobID := range jobByRepo {
+		waitForJob(t, exec, jobID)
+	}
+}
+
+func TestConcurrentCloseCallersWaitForSameCompletion(t *testing.T) {
+	runnerEntered := make(chan struct{})
+	runnerCancelled := make(chan struct{})
+	releaseRunner := make(chan struct{})
+	runners := noOpRunners()
+	runners.Code = func(ctx context.Context, _ typedef.Repository, _ []typedef.MultiStorage) error {
+		close(runnerEntered)
+		<-ctx.Done()
+		close(runnerCancelled)
+		<-releaseRunner
+		return ctx.Err()
+	}
+	exec, _ := newTestExecutorForConfig(t, repositoryConfig(1, 1), runners)
+	_, err := exec.ExecuteJob("github.com/test/repo-0")
+	require.NoError(t, err)
+	<-runnerEntered
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			<-start
+			results <- exec.Close()
+		}()
+	}
+	close(start)
+	<-runnerCancelled
+	select {
+	case err := <-results:
+		t.Fatalf("Close returned before worker completion: %v", err)
+	default:
+	}
+	close(releaseRunner)
+	require.NoError(t, <-results)
+	require.NoError(t, <-results)
+}
+
+func TestCloseWinningAfterPersistencePreventsPostCloseRunner(t *testing.T) {
+	runnerEntered := make(chan struct{}, 1)
+	runners := noOpRunners()
+	runners.Code = func(context.Context, typedef.Repository, []typedef.MultiStorage) error {
+		runnerEntered <- struct{}{}
+		return nil
+	}
+	exec, testDB := newTestExecutorForConfig(t, repositoryConfig(1, 1), runners)
+	componentsRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(componentsRelease) }) })
+	store := &blockingExecutionStore{
+		delegate:          testDB,
+		componentsEntered: make(chan struct{}),
+		componentsRelease: componentsRelease,
+	}
+	exec.db = store
+	type executeResult struct {
+		ids []string
+		err error
+	}
+	submitResult := make(chan executeResult, 1)
+	go func() {
+		ids, submitErr := exec.ExecuteJob("github.com/test/repo-0")
+		submitResult <- executeResult{ids: ids, err: submitErr}
+	}()
+	<-store.componentsEntered
+
+	closed := executorClosedSignal(exec)
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- exec.Close() }()
+	<-closed
+	select {
+	case <-runnerEntered:
+		t.Fatal("runner started before persisted submission was published")
+	default:
+	}
+	releaseOnce.Do(func() { close(componentsRelease) })
+
+	result := <-submitResult
+	require.ErrorIs(t, result.err, ErrExecutorClosed)
+	require.Empty(t, result.ids)
+	require.NoError(t, <-closeResult)
+	var active int
+	require.NoError(t, testDB.QueryRow(`
+		SELECT COUNT(*) FROM executions WHERE status IN ('pending', 'running')`).Scan(&active))
+	require.Zero(t, active)
+	select {
+	case <-runnerEntered:
+		t.Fatal("runner started after Close won the publish race")
+	default:
+	}
+}
+
+func TestConcurrencyLimitClampsMaxUintToMaxInt(t *testing.T) {
+	want := int(^uint(0) >> 1)
+	require.Equal(t, want, concurrencyLimit(&config.Config{ConcurrencyNum: ^uint(0)}))
 }

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -217,6 +217,38 @@ func TestExecuteJobOverallFailureContinuesAfterCodeFailure(t *testing.T) {
 	)
 }
 
+func TestExecuteJobComponentContextErrorWithoutJobCancellationIsFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "runner cancelled", err: context.Canceled},
+		{name: "runner deadline exceeded", err: context.DeadlineExceeded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &runnerRecorder{errors: map[string]error{"code": tt.err}}
+			exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+				Name:           "test-repo",
+				URL:            "github.com/test/repo",
+				DownloadIssues: true,
+			}, recorder.runners())
+
+			jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+			require.NoError(t, err)
+			waitForJob(t, exec, jobIDs[0])
+
+			require.Equal(t, []string{"code", "issues"}, recorder.recordedCalls())
+			requireExecution(t, testDB, jobIDs[0], StatusFailed, "code: "+tt.err.Error())
+			requireComponents(t, testDB, jobIDs[0],
+				expectedComponent{db.ComponentCode, db.ComponentFailed, tt.err.Error()},
+				expectedComponent{db.ComponentIssue, db.ComponentCompleted, ""},
+			)
+		})
+	}
+}
+
 func TestExecuteJobComponentFailuresUseSemicolonSeparatedSummary(t *testing.T) {
 	recorder := &runnerRecorder{errors: map[string]error{
 		"issues": errors.New("rate limit"),
@@ -243,7 +275,7 @@ func TestExecuteJobComponentFailuresUseSemicolonSeparatedSummary(t *testing.T) {
 
 func TestExecuteJobSkipCompletesOverall(t *testing.T) {
 	recorder := &runnerRecorder{errors: map[string]error{
-		"wiki": syncresult.Skip("repository has no wiki"),
+		"wiki": fmt.Errorf("wiki preflight: %w", syncresult.Skip("repository has no wiki")),
 	}}
 	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
 		Name:         "test-repo",
@@ -291,6 +323,48 @@ func TestExecuteJobCancelTerminalizesCurrentAndRemainingComponents(t *testing.T)
 	)
 }
 
+func TestExecuteJobCancelStoreFailureFallsBackToFailedComponentAndOverall(t *testing.T) {
+	issueStarted := make(chan struct{})
+	runners := noOpRunners()
+	runners.Issue = func(ctx context.Context, _ typedef.Repository, _ []typedef.MultiStorage) error {
+		close(issueStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:           "test-repo",
+		URL:            "github.com/test/repo",
+		DownloadIssues: true,
+		DownloadWiki:   true,
+	}, runners)
+	_, err := testDB.Exec(`
+		CREATE TRIGGER fail_issue_cancellation
+		BEFORE UPDATE OF status ON execution_components
+		WHEN OLD.component = 'issues' AND NEW.status = 'cancelled'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced cancellation terminal update failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	<-issueStarted
+	require.NoError(t, exec.CancelJob(jobIDs[0]))
+	waitForJob(t, exec, jobIDs[0])
+
+	persistenceMessage := fmt.Sprintf(
+		`persist cancelled state: finish component "issues" for execution %q: constraint failed: forced cancellation terminal update failure (1811)`,
+		jobIDs[0],
+	)
+	requireExecution(t, testDB, jobIDs[0], StatusFailed, "issue: "+persistenceMessage)
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+		expectedComponent{db.ComponentIssue, db.ComponentFailed, persistenceMessage},
+		expectedComponent{db.ComponentWiki, db.ComponentCancelled, "context canceled"},
+	)
+}
+
 func TestExecuteJobComponentStoreFailurePreventsCompletedOverall(t *testing.T) {
 	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
 		Name:         "test-repo",
@@ -319,6 +393,32 @@ func TestExecuteJobComponentStoreFailurePreventsCompletedOverall(t *testing.T) {
 	requireComponents(t, testDB, jobIDs[0],
 		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
 		expectedComponent{db.ComponentWiki, db.ComponentFailed, storeMessage},
+	)
+}
+
+func TestExecuteJobOverallTerminalStoreFailureFallsBackToFailed(t *testing.T) {
+	exec, testDB := newTestExecutor(t)
+	_, err := testDB.Exec(`
+		CREATE TRIGGER fail_execution_completion
+		BEFORE UPDATE OF status ON executions
+		WHEN NEW.status = 'completed'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced overall completion failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	waitForJob(t, exec, jobIDs[0])
+
+	persistenceMessage := fmt.Sprintf(
+		`persist completed execution state: update execution %q to "completed": constraint failed: forced overall completion failure (1811)`,
+		jobIDs[0],
+	)
+	requireExecution(t, testDB, jobIDs[0], StatusFailed, persistenceMessage)
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
 	)
 }
 
@@ -359,7 +459,7 @@ func TestCancelNonRunningJob(t *testing.T) {
 	exec, _ := newTestExecutor(t)
 
 	err := exec.CancelJob("never-started")
-	assert.NoError(t, err)
+	require.EqualError(t, err, `update execution "never-started" to "cancelled": expected one row, updated 0`)
 }
 
 func TestExecuteJobWritesRepoKey(t *testing.T) {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -808,11 +808,11 @@ func TestExecuteJobExpandsOrgIntoMultipleJobs(t *testing.T) {
 
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
-	expandRepos = func(_ context.Context, repo typedef.Repository) []typedef.Repository {
+	expandRepos = func(_ context.Context, repo typedef.Repository) ([]typedef.Repository, error) {
 		return []typedef.Repository{
 			{Name: "alpha", URL: "github.com/acme/alpha"},
 			{Name: "beta", URL: "github.com/acme/beta"},
-		}
+		}, nil
 	}
 
 	jobIDs, err := exec.ExecuteJob("github.com/acme")
@@ -828,6 +828,43 @@ func TestExecuteJobExpandsOrgIntoMultipleJobs(t *testing.T) {
 	}
 	assert.True(t, keys["github.com/acme/alpha"])
 	assert.True(t, keys["github.com/acme/beta"])
+}
+
+func TestExecuteJobPropagatesProductionExpansionFailure(t *testing.T) {
+	expansionErr := errors.New("GitHub repository listing failed")
+	old := expandRepos
+	t.Cleanup(func() { expandRepos = old })
+	expandRepos = func(context.Context, typedef.Repository) ([]typedef.Repository, error) {
+		return nil, expansionErr
+	}
+	exec, testDB := newTestExecutorForConfig(t, &config.Config{Repository: []typedef.Repository{{
+		Name: "acme", URL: "github.com/acme", Type: typedef.TypeOrg, OrgName: "acme",
+	}}}, noOpRunners())
+
+	jobIDs, err := exec.ExecuteJob("github.com/acme")
+	require.ErrorIs(t, err, expansionErr)
+	require.Empty(t, jobIDs)
+	require.Empty(t, executionStatusCounts(t, testDB))
+}
+
+func TestExecuteJobRejectsEmptyExpansionAsTypedEnqueueFailure(t *testing.T) {
+	cfg := &config.Config{Repository: []typedef.Repository{{
+		Name: "empty", URL: "github.com/empty", Type: typedef.TypeUser, OrgName: "empty",
+	}}}
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testDB.Close()) })
+	exec := NewExecutorWithRunners(logger.NewLogger(testDB), testDB, cfg, noOpRunners(),
+		func(typedef.Repository) []typedef.Repository { return nil },
+	)
+	t.Cleanup(func() { require.NoError(t, exec.Close()) })
+
+	jobIDs, err := exec.ExecuteJob("github.com/empty")
+	var empty *RepositoryExpansionEmptyError
+	require.ErrorAs(t, err, &empty)
+	require.Equal(t, "github.com/empty", empty.RepositoryKey)
+	require.Empty(t, jobIDs)
+	require.Empty(t, executionStatusCounts(t, testDB))
 }
 
 func TestRefreshConfigRepointsExecutor(t *testing.T) {
@@ -1533,11 +1570,11 @@ func TestExecuteJobExpandedBatchIsAtomicWhenSecondRepositoryIsActive(t *testing.
 
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
-	expandRepos = func(context.Context, typedef.Repository) []typedef.Repository {
+	expandRepos = func(context.Context, typedef.Repository) ([]typedef.Repository, error) {
 		return []typedef.Repository{
 			{Name: "alpha", URL: "github.com/acme/alpha"},
 			{Name: "beta", URL: "github.com/acme/beta"},
-		}
+		}, nil
 	}
 
 	jobIDs, err := exec.ExecuteJob("github.com/acme")
@@ -1575,11 +1612,11 @@ func TestExecuteJobExpandedBatchRollsBackAllRowsWhenLaterPersistenceFails(t *tes
 
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
-	expandRepos = func(context.Context, typedef.Repository) []typedef.Repository {
+	expandRepos = func(context.Context, typedef.Repository) ([]typedef.Repository, error) {
 		return []typedef.Repository{
 			{Name: "alpha", URL: "github.com/acme/alpha"},
 			{Name: "beta", URL: "github.com/acme/beta"},
-		}
+		}, nil
 	}
 
 	jobIDs, err := exec.ExecuteJob("github.com/acme")
@@ -1614,11 +1651,11 @@ func TestExecuteJobRejectsDuplicateKeysWithinExpandedBatchBeforePersistence(t *t
 	}}}, noOpRunners())
 	old := expandRepos
 	t.Cleanup(func() { expandRepos = old })
-	expandRepos = func(context.Context, typedef.Repository) []typedef.Repository {
+	expandRepos = func(context.Context, typedef.Repository) ([]typedef.Repository, error) {
 		return []typedef.Repository{
 			{Name: "alpha", URL: "https://github.com/acme/alpha"},
 			{Name: "alpha-copy", URL: "github.com/acme/alpha/"},
-		}
+		}, nil
 	}
 
 	jobIDs, err := exec.ExecuteJob("github.com/acme")

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,7 +1,10 @@
 package executor
 
 import (
-	"os"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,22 +13,99 @@ import (
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/db"
 	"github.com/wnarutou/gitrieve/internal/logger"
+	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 )
 
 func newTestExecutor(t *testing.T) (*Executor, *db.DB) {
 	t.Helper()
+	return newTestExecutorForRepo(t, typedef.Repository{Name: "test-repo", URL: "github.com/test/repo"}, noOpRunners())
+}
+
+func newTestExecutorForRepo(t *testing.T, repo typedef.Repository, runners Runners) (*Executor, *db.DB) {
+	t.Helper()
 	testDB, err := db.Initialize(":memory:")
-	assert.NoError(t, err)
-	t.Cleanup(func() { testDB.Close() })
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testDB.Close()) })
 
 	log := logger.NewLogger(testDB)
-	cfg := &config.Config{
-		Repository: []typedef.Repository{
-			{Name: "test-repo", URL: "github.com/test/repo"},
-		},
+	cfg := &config.Config{Repository: []typedef.Repository{repo}}
+	return NewExecutorWithRunners(log, testDB, cfg, runners), testDB
+}
+
+func noOpRunners() Runners {
+	run := func(context.Context, typedef.Repository, []typedef.MultiStorage) error { return nil }
+	return Runners{Code: run, Release: run, Issue: run, Wiki: run, Discussion: run}
+}
+
+type runnerRecorder struct {
+	mu     sync.Mutex
+	calls  []string
+	errors map[string]error
+}
+
+func (r *runnerRecorder) runner(name string) SyncFunc {
+	return func(context.Context, typedef.Repository, []typedef.MultiStorage) error {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.calls = append(r.calls, name)
+		return r.errors[name]
 	}
-	return NewExecutor(log, testDB, cfg), testDB
+}
+
+func (r *runnerRecorder) runners() Runners {
+	return Runners{
+		Code:       r.runner("code"),
+		Release:    r.runner("release"),
+		Issue:      r.runner("issues"),
+		Wiki:       r.runner("wiki"),
+		Discussion: r.runner("discussion"),
+	}
+}
+
+func (r *runnerRecorder) recordedCalls() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+func waitForJob(t *testing.T, exec *Executor, jobID string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for exec.IsJobRunning(jobID) {
+		if time.Now().After(deadline) {
+			t.Fatalf("job %s did not finish", jobID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func requireExecution(t *testing.T, testDB *db.DB, jobID string, wantStatus ExecutionStatus, wantError string) {
+	t.Helper()
+	var status, errorMessage string
+	require.NoError(t, testDB.QueryRow(
+		"SELECT status, COALESCE(error_message, '') FROM executions WHERE id = ?", jobID,
+	).Scan(&status, &errorMessage))
+	require.Equal(t, string(wantStatus), status)
+	require.Equal(t, wantError, errorMessage)
+}
+
+type expectedComponent struct {
+	name         db.ComponentName
+	status       db.ComponentStatus
+	errorMessage string
+}
+
+func requireComponents(t *testing.T, testDB *db.DB, jobID string, want ...expectedComponent) {
+	t.Helper()
+	components, err := testDB.ListComponents(context.Background(), jobID)
+	require.NoError(t, err)
+	require.Len(t, components, len(want))
+	for i := range want {
+		require.Equal(t, want[i].name, components[i].Component)
+		require.Equal(t, want[i].status, components[i].Status)
+		require.Equal(t, want[i].errorMessage, components[i].ErrorMessage)
+	}
 }
 
 func TestExecuteJobWritesBoundLogs(t *testing.T) {
@@ -34,97 +114,238 @@ func TestExecuteJobWritesBoundLogs(t *testing.T) {
 	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
 	require.NoError(t, err)
 	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
 
-	// executeAsync binds the goroutine and ui.Printf("Starting job execution")
-	// is forwarded to the DB logs for this execution. Poll for that specific
-	// row rather than asserting a single snapshot's ordering: under parallel
-	// full-suite load a concurrent reader can transiently hold SQLite's write
-	// lock and an insert can be BUSY-dropped (sink errors are deliberately
-	// discarded), so the row is only guaranteed to appear eventually.
-	deadline := time.Now().Add(3 * time.Second)
-	for {
-		var count int
-		err := testDB.QueryRow(
-			"SELECT COUNT(*) FROM logs WHERE execution_id = ? AND message = 'Starting job execution'", jobIDs[0],
-		).Scan(&count)
-		require.NoError(t, err)
-		if count >= 1 {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("expected a 'Starting job execution' log row for execution %s", jobIDs[0])
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	var count int
+	err = testDB.QueryRow(
+		"SELECT COUNT(*) FROM logs WHERE execution_id = ? AND message = 'Starting job execution'", jobIDs[0],
+	).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
 }
 
 func TestExecuteJobRunsConfiguredComponents(t *testing.T) {
-	// The component syncs (issue/release/wiki/discussion) read the package-global
-	// config via config.GetIns() and dereference cfg.GitHubToken, so mirror the
-	// server process (where cobra.OnInitialize runs config.Init) to avoid a nil
-	// pointer panic.
-	tmp, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
-	require.NoError(t, err)
-	_, err = tmp.WriteString("githubtoken: test-token\n")
-	require.NoError(t, err)
-	require.NoError(t, tmp.Close())
-	config.Path = tmp.Name()
-	config.Init()
-	t.Cleanup(func() { config.Path = "" })
-
-	testDB, err := db.Initialize(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() { testDB.Close() })
-
-	log := logger.NewLogger(testDB)
-	cfg := &config.Config{
-		Repository: []typedef.Repository{
-			{Name: "test-repo", URL: "github.com/test/repo", DownloadIssues: true},
-		},
-	}
-	exec := NewExecutor(log, testDB, cfg)
+	recorder := &runnerRecorder{errors: map[string]error{}}
+	exec, _ := newTestExecutorForRepo(t, typedef.Repository{
+		Name:               "test-repo",
+		URL:                "github.com/test/repo",
+		DownloadReleases:   true,
+		DownloadIssues:     true,
+		DownloadWiki:       true,
+		DownloadDiscussion: true,
+	}, recorder.runners())
 
 	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
 	require.NoError(t, err)
 	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
+	require.Equal(t, []string{"code", "release", "issues", "wiki", "discussion"}, recorder.recordedCalls())
+}
 
-	// The executor must run the configured component syncs. "Downloading issues"
-	// is written only after repository.Sync returns, and that sync does a real
-	// clone of the (nonexistent) test repo that can take a while on a slow
-	// network — use a generous deadline.
-	deadline := time.Now().Add(20 * time.Second)
-	for {
-		var count int
-		err := testDB.QueryRow(
-			"SELECT COUNT(*) FROM logs WHERE execution_id = ? AND message = 'Downloading issues'", jobIDs[0],
-		).Scan(&count)
-		require.NoError(t, err)
-		if count >= 1 {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("expected 'Downloading issues' log row for execution %s", jobIDs[0])
-		}
-		time.Sleep(50 * time.Millisecond)
+func TestExecuteJobComponentsArePlannedBeforeTheFirstRunner(t *testing.T) {
+	codeStarted := make(chan struct{})
+	releaseCode := make(chan struct{})
+	runners := noOpRunners()
+	runners.Code = func(context.Context, typedef.Repository, []typedef.MultiStorage) error {
+		close(codeStarted)
+		<-releaseCode
+		return nil
 	}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:               "test-repo",
+		URL:                "github.com/test/repo",
+		DownloadReleases:   true,
+		DownloadIssues:     true,
+		DownloadWiki:       true,
+		DownloadDiscussion: true,
+	}, runners)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	<-codeStarted
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentRunning, ""},
+		expectedComponent{db.ComponentRelease, db.ComponentPending, ""},
+		expectedComponent{db.ComponentIssue, db.ComponentPending, ""},
+		expectedComponent{db.ComponentWiki, db.ComponentPending, ""},
+		expectedComponent{db.ComponentDiscussion, db.ComponentPending, ""},
+	)
+
+	close(releaseCode)
+	waitForJob(t, exec, jobIDs[0])
+}
+
+func TestExecuteJobComponentFailureRunsLaterComponentsAndFailsOverall(t *testing.T) {
+	recorder := &runnerRecorder{errors: map[string]error{"issues": errors.New("rate limit")}}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:           "test-repo",
+		URL:            "github.com/test/repo",
+		DownloadIssues: true,
+		DownloadWiki:   true,
+	}, recorder.runners())
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	waitForJob(t, exec, jobIDs[0])
+
+	require.Equal(t, []string{"code", "issues", "wiki"}, recorder.recordedCalls())
+	requireExecution(t, testDB, jobIDs[0], StatusFailed, "issue: rate limit")
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+		expectedComponent{db.ComponentIssue, db.ComponentFailed, "rate limit"},
+		expectedComponent{db.ComponentWiki, db.ComponentCompleted, ""},
+	)
+}
+
+func TestExecuteJobOverallFailureContinuesAfterCodeFailure(t *testing.T) {
+	recorder := &runnerRecorder{errors: map[string]error{"code": errors.New("clone failed")}}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:           "test-repo",
+		URL:            "github.com/test/repo",
+		DownloadIssues: true,
+	}, recorder.runners())
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	waitForJob(t, exec, jobIDs[0])
+
+	require.Equal(t, []string{"code", "issues"}, recorder.recordedCalls())
+	requireExecution(t, testDB, jobIDs[0], StatusFailed, "code: clone failed")
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentFailed, "clone failed"},
+		expectedComponent{db.ComponentIssue, db.ComponentCompleted, ""},
+	)
+}
+
+func TestExecuteJobComponentFailuresUseSemicolonSeparatedSummary(t *testing.T) {
+	recorder := &runnerRecorder{errors: map[string]error{
+		"issues": errors.New("rate limit"),
+		"wiki":   errors.New("permission denied"),
+	}}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:           "test-repo",
+		URL:            "github.com/test/repo",
+		DownloadIssues: true,
+		DownloadWiki:   true,
+	}, recorder.runners())
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	waitForJob(t, exec, jobIDs[0])
+
+	requireExecution(t, testDB, jobIDs[0], StatusFailed, "issue: rate limit; wiki: permission denied")
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+		expectedComponent{db.ComponentIssue, db.ComponentFailed, "rate limit"},
+		expectedComponent{db.ComponentWiki, db.ComponentFailed, "permission denied"},
+	)
+}
+
+func TestExecuteJobSkipCompletesOverall(t *testing.T) {
+	recorder := &runnerRecorder{errors: map[string]error{
+		"wiki": syncresult.Skip("repository has no wiki"),
+	}}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:         "test-repo",
+		URL:          "github.com/test/repo",
+		DownloadWiki: true,
+	}, recorder.runners())
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	waitForJob(t, exec, jobIDs[0])
+
+	requireExecution(t, testDB, jobIDs[0], StatusCompleted, "")
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+		expectedComponent{db.ComponentWiki, db.ComponentSkipped, "repository has no wiki"},
+	)
+}
+
+func TestExecuteJobCancelTerminalizesCurrentAndRemainingComponents(t *testing.T) {
+	issueStarted := make(chan struct{})
+	runners := noOpRunners()
+	runners.Issue = func(ctx context.Context, _ typedef.Repository, _ []typedef.MultiStorage) error {
+		close(issueStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:           "test-repo",
+		URL:            "github.com/test/repo",
+		DownloadIssues: true,
+		DownloadWiki:   true,
+	}, runners)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	<-issueStarted
+	require.NoError(t, exec.CancelJob(jobIDs[0]))
+	waitForJob(t, exec, jobIDs[0])
+
+	requireExecution(t, testDB, jobIDs[0], StatusCancelled, "")
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+		expectedComponent{db.ComponentIssue, db.ComponentCancelled, "context canceled"},
+		expectedComponent{db.ComponentWiki, db.ComponentCancelled, "context canceled"},
+	)
+}
+
+func TestExecuteJobComponentStoreFailurePreventsCompletedOverall(t *testing.T) {
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{
+		Name:         "test-repo",
+		URL:          "github.com/test/repo",
+		DownloadWiki: true,
+	}, noOpRunners())
+	_, err := testDB.Exec(`
+		CREATE TRIGGER fail_wiki_completion
+		BEFORE UPDATE OF status ON execution_components
+		WHEN OLD.component = 'wiki' AND NEW.status = 'completed'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced component terminal update failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
+	require.NoError(t, err)
+	waitForJob(t, exec, jobIDs[0])
+
+	storeMessage := fmt.Sprintf(
+		`persist completed state: finish component "wiki" for execution %q: constraint failed: forced component terminal update failure (1811)`,
+		jobIDs[0],
+	)
+	requireExecution(t, testDB, jobIDs[0], StatusFailed, "wiki: "+storeMessage)
+	requireComponents(t, testDB, jobIDs[0],
+		expectedComponent{db.ComponentCode, db.ComponentCompleted, ""},
+		expectedComponent{db.ComponentWiki, db.ComponentFailed, storeMessage},
+	)
 }
 
 func TestExecuteJobCreatesRecord(t *testing.T) {
-	exec, testDB := newTestExecutor(t)
+	codeStarted := make(chan struct{})
+	runners := noOpRunners()
+	runners.Code = func(ctx context.Context, _ typedef.Repository, _ []typedef.MultiStorage) error {
+		close(codeStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	exec, testDB := newTestExecutorForRepo(t, typedef.Repository{Name: "test-repo", URL: "github.com/test/repo"}, runners)
 
 	jobIDs, err := exec.ExecuteJob("github.com/test/repo")
 	assert.NoError(t, err)
 	require.Len(t, jobIDs, 1)
 	assert.NotEmpty(t, jobIDs[0])
+	<-codeStarted
 
-	// A pending/running execution record should exist in the database
 	var status string
 	err = testDB.QueryRow("SELECT status FROM executions WHERE id = ?", jobIDs[0]).Scan(&status)
 	assert.NoError(t, err)
-	assert.Contains(t, []string{"pending", "running"}, status)
-
-	// The job should be marked as running in memory
+	assert.Equal(t, "running", status)
 	assert.True(t, exec.IsJobRunning(jobIDs[0]))
+
+	require.NoError(t, exec.CancelJob(jobIDs[0]))
+	waitForJob(t, exec, jobIDs[0])
 }
 
 func TestExecuteJobUnknownRepository(t *testing.T) {
@@ -137,7 +358,6 @@ func TestExecuteJobUnknownRepository(t *testing.T) {
 func TestCancelNonRunningJob(t *testing.T) {
 	exec, _ := newTestExecutor(t)
 
-	// Cancelling a job that was never started should still update its status
 	err := exec.CancelJob("never-started")
 	assert.NoError(t, err)
 }
@@ -153,6 +373,7 @@ func TestExecuteJobWritesRepoKey(t *testing.T) {
 	err = testDB.QueryRow("SELECT repo_key FROM executions WHERE id = ?", jobIDs[0]).Scan(&repoKey)
 	assert.NoError(t, err)
 	assert.Equal(t, "github.com/test/repo", repoKey)
+	waitForJob(t, exec, jobIDs[0])
 }
 
 func TestExecuteJobExpandsOrgIntoMultipleJobs(t *testing.T) {
@@ -179,6 +400,7 @@ func TestExecuteJobExpandsOrgIntoMultipleJobs(t *testing.T) {
 		var repoKey string
 		require.NoError(t, testDB.QueryRow("SELECT repo_key FROM executions WHERE id = ?", id).Scan(&repoKey))
 		keys[repoKey] = true
+		waitForJob(t, exec, id)
 	}
 	assert.True(t, keys["github.com/acme/alpha"])
 	assert.True(t, keys["github.com/acme/beta"])
@@ -191,12 +413,11 @@ func TestRefreshConfigRepointsExecutor(t *testing.T) {
 		{Name: "other", URL: "github.com/other/repo"},
 	}})
 
-	// The old key no longer resolves against the executor's config.
 	_, err := exec.ExecuteJob("github.com/test/repo")
 	require.Error(t, err)
 
-	// The new key resolves.
 	jobIDs, err := exec.ExecuteJob("github.com/other/repo")
 	require.NoError(t, err)
 	require.Len(t, jobIDs, 1)
+	waitForJob(t, exec, jobIDs[0])
 }

--- a/internal/githubapi/coordinator.go
+++ b/internal/githubapi/coordinator.go
@@ -43,6 +43,7 @@ type permit struct {
 }
 
 var current atomic.Pointer[coordinator]
+var publicationMu sync.RWMutex
 
 func newCoordinator(cfg Config) *coordinator {
 	if cfg.Concurrency == 0 {
@@ -51,16 +52,49 @@ func newCoordinator(cfg Config) *coordinator {
 	return &coordinator{cfg: cfg, sem: make(chan struct{}, cfg.Concurrency), resourcePause: make(map[string]time.Time)}
 }
 
-func Configure(cfg Config) { current.Store(newCoordinator(cfg)) }
+// Publish installs an application configuration snapshot and its matching
+// GitHub coordinator under one reader-visible publication boundary. install
+// must only publish immutable state; it runs while publicationMu is held.
+func Publish(cfg Config, install func()) {
+	next := newCoordinator(cfg)
+	publicationMu.Lock()
+	defer publicationMu.Unlock()
+	if install != nil {
+		install()
+	}
+	current.Store(next)
+}
+
+// ReadPublication runs read while no paired configuration/coordinator
+// publication is in progress.
+func ReadPublication(read func()) {
+	publicationMu.RLock()
+	defer publicationMu.RUnlock()
+	read()
+}
+
+func Configure(cfg Config) { Publish(cfg, nil) }
 
 func Acquire(ctx context.Context, resource string) (Permit, error) {
-	c := current.Load()
-	if c == nil {
-		c = newCoordinator(Config{Concurrency: 1})
-		current.CompareAndSwap(nil, c)
-		c = current.Load()
-	}
+	c := loadCoordinator()
 	return c.acquire(ctx, resource)
+}
+
+func loadCoordinator() *coordinator {
+	publicationMu.RLock()
+	c := current.Load()
+	publicationMu.RUnlock()
+	if c != nil {
+		return c
+	}
+
+	publicationMu.Lock()
+	defer publicationMu.Unlock()
+	if c = current.Load(); c == nil {
+		c = newCoordinator(Config{Concurrency: 1})
+		current.Store(c)
+	}
+	return c
 }
 
 func (c *coordinator) acquire(ctx context.Context, resource string) (Permit, error) {

--- a/internal/githubapi/coordinator.go
+++ b/internal/githubapi/coordinator.go
@@ -45,6 +45,16 @@ type permit struct {
 var current atomic.Pointer[coordinator]
 var publicationMu sync.RWMutex
 
+// publicationReadBoundaryTestHook is a package-private synchronization seam
+// for tests that need to observe the exact publication read-lock boundary.
+type publicationReadBoundaryTestHook struct {
+	beforeLock  func()
+	afterLock   func()
+	afterUnlock func()
+}
+
+var publicationReadBoundaryHookForTest atomic.Pointer[publicationReadBoundaryTestHook]
+
 func newCoordinator(cfg Config) *coordinator {
 	if cfg.Concurrency == 0 {
 		cfg.Concurrency = 1
@@ -68,8 +78,24 @@ func Publish(cfg Config, install func()) {
 // ReadPublication runs read while no paired configuration/coordinator
 // publication is in progress.
 func ReadPublication(read func()) {
+	readPublication(read)
+}
+
+func readPublication(read func()) {
+	hook := publicationReadBoundaryHookForTest.Load()
+	if hook != nil && hook.beforeLock != nil {
+		hook.beforeLock()
+	}
 	publicationMu.RLock()
-	defer publicationMu.RUnlock()
+	defer func() {
+		publicationMu.RUnlock()
+		if hook != nil && hook.afterUnlock != nil {
+			hook.afterUnlock()
+		}
+	}()
+	if hook != nil && hook.afterLock != nil {
+		hook.afterLock()
+	}
 	read()
 }
 
@@ -81,9 +107,10 @@ func Acquire(ctx context.Context, resource string) (Permit, error) {
 }
 
 func loadCoordinator() *coordinator {
-	publicationMu.RLock()
-	c := current.Load()
-	publicationMu.RUnlock()
+	var c *coordinator
+	readPublication(func() {
+		c = current.Load()
+	})
 	if c != nil {
 		return c
 	}

--- a/internal/githubapi/coordinator.go
+++ b/internal/githubapi/coordinator.go
@@ -30,8 +30,9 @@ type Permit interface{ Done(Observation) }
 
 type coordinator struct {
 	cfg            Config
-	sem            chan struct{}
 	mu             sync.Mutex
+	active         uint
+	changed        chan struct{}
 	nextStart      time.Time
 	resourcePause  map[string]time.Time
 	secondaryPause time.Time
@@ -44,16 +45,15 @@ type permit struct {
 
 type scopeContextKey struct{}
 
-// Scope owns the API coordinator for one immutable runtime configuration
-// generation. Jobs from the same generation share pacing and quota state,
-// while an already-admitted old job never switches to a newly published one.
+// Scope records the immutable API configuration accepted with one runtime
+// generation. Acquisition always delegates to the stable process arbiter so
+// old and new generations share concurrency, pacing, and quota state.
 type Scope struct {
-	cfg         Config
-	coordinator *coordinator
+	cfg Config
 }
 
 func NewScope(cfg Config) *Scope {
-	return &Scope{cfg: cfg, coordinator: newCoordinator(cfg)}
+	return &Scope{cfg: cfg}
 }
 
 func WithScope(ctx context.Context, scope *Scope) context.Context {
@@ -88,23 +88,47 @@ type publicationReadBoundaryTestHook struct {
 var publicationReadBoundaryHookForTest atomic.Pointer[publicationReadBoundaryTestHook]
 
 func newCoordinator(cfg Config) *coordinator {
+	return &coordinator{
+		cfg:           normalizedConfig(cfg),
+		changed:       make(chan struct{}),
+		resourcePause: make(map[string]time.Time),
+	}
+}
+
+func normalizedConfig(cfg Config) Config {
 	if cfg.Concurrency == 0 {
 		cfg.Concurrency = 1
 	}
-	return &coordinator{cfg: cfg, sem: make(chan struct{}, cfg.Concurrency), resourcePause: make(map[string]time.Time)}
+	return cfg
+}
+
+func (c *coordinator) configure(cfg Config) {
+	c.mu.Lock()
+	c.cfg = normalizedConfig(cfg)
+	c.signalLocked()
+	c.mu.Unlock()
+}
+
+func (c *coordinator) signalLocked() {
+	close(c.changed)
+	c.changed = make(chan struct{})
 }
 
 // Publish installs an application configuration snapshot and its matching
 // GitHub coordinator under one reader-visible publication boundary. install
 // must only publish immutable state; it runs while publicationMu is held.
 func Publish(cfg Config, install func()) {
-	next := newCoordinator(cfg)
 	publicationMu.Lock()
 	defer publicationMu.Unlock()
 	if install != nil {
 		install()
 	}
-	current.Store(next)
+	c := current.Load()
+	if c == nil {
+		current.Store(newCoordinator(cfg))
+		return
+	}
+	c.configure(cfg)
 }
 
 // ReadPublication runs read while no paired configuration/coordinator
@@ -134,11 +158,6 @@ func readPublication(read func()) {
 func Configure(cfg Config) { Publish(cfg, nil) }
 
 func Acquire(ctx context.Context, resource string) (Permit, error) {
-	if ctx != nil {
-		if scope, ok := ctx.Value(scopeContextKey{}).(*Scope); ok && scope != nil {
-			return scope.coordinator.acquire(ctx, resource)
-		}
-	}
 	c := loadCoordinator()
 	return c.acquire(ctx, resource)
 }
@@ -162,10 +181,8 @@ func loadCoordinator() *coordinator {
 }
 
 func (c *coordinator) acquire(ctx context.Context, resource string) (Permit, error) {
-	select {
-	case c.sem <- struct{}{}:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	for {
 		c.mu.Lock()
@@ -186,7 +203,8 @@ func (c *coordinator) acquire(ctx context.Context, resource string) (Permit, err
 		if c.nextStart.After(until) {
 			until = c.nextStart
 		}
-		if !until.After(now) {
+		if c.active < c.cfg.Concurrency && !until.After(now) {
+			c.active++
 			c.nextStart = now.Add(c.cfg.MinRequestInterval)
 			c.mu.Unlock()
 			if resumed {
@@ -194,14 +212,39 @@ func (c *coordinator) acquire(ctx context.Context, resource string) (Permit, err
 			}
 			return &permit{c: c}, nil
 		}
+		changed := c.changed
+		hasDeadline := c.active < c.cfg.Concurrency && until.After(now)
+		wait := time.Duration(0)
+		if hasDeadline {
+			wait = until.Sub(now)
+		}
 		c.mu.Unlock()
-		t := time.NewTimer(time.Until(until))
+		if !hasDeadline {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-changed:
+			}
+			continue
+		}
+		timer := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
-			t.Stop()
-			<-c.sem
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
 			return nil, ctx.Err()
-		case <-t.C:
+		case <-changed:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		case <-timer.C:
 		}
 	}
 }
@@ -209,7 +252,12 @@ func (c *coordinator) acquire(ctx context.Context, resource string) (Permit, err
 func (p *permit) Done(obs Observation) {
 	p.once.Do(func() {
 		p.c.observe(obs)
-		<-p.c.sem
+		p.c.mu.Lock()
+		if p.c.active > 0 {
+			p.c.active--
+		}
+		p.c.signalLocked()
+		p.c.mu.Unlock()
 	})
 }
 
@@ -233,6 +281,9 @@ func (c *coordinator) observe(obs Observation) {
 	if obs.Resource != "" && !obs.Reset.IsZero() && obs.Remaining <= c.cfg.LowRemainingThreshold && obs.Reset.After(c.resourcePause[obs.Resource]) {
 		c.resourcePause[obs.Resource] = obs.Reset
 		resourceExtended = true
+	}
+	if secondaryExtended || resourceExtended {
+		c.signalLocked()
 	}
 	c.mu.Unlock()
 	if secondaryExtended {

--- a/internal/githubapi/coordinator.go
+++ b/internal/githubapi/coordinator.go
@@ -42,6 +42,38 @@ type permit struct {
 	once sync.Once
 }
 
+type scopeContextKey struct{}
+
+// Scope owns the API coordinator for one immutable runtime configuration
+// generation. Jobs from the same generation share pacing and quota state,
+// while an already-admitted old job never switches to a newly published one.
+type Scope struct {
+	cfg         Config
+	coordinator *coordinator
+}
+
+func NewScope(cfg Config) *Scope {
+	return &Scope{cfg: cfg, coordinator: newCoordinator(cfg)}
+}
+
+func WithScope(ctx context.Context, scope *Scope) context.Context {
+	if scope == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, scopeContextKey{}, scope)
+}
+
+func ConfigFromContext(ctx context.Context) (Config, bool) {
+	if ctx == nil {
+		return Config{}, false
+	}
+	scope, ok := ctx.Value(scopeContextKey{}).(*Scope)
+	if !ok || scope == nil {
+		return Config{}, false
+	}
+	return scope.cfg, true
+}
+
 var current atomic.Pointer[coordinator]
 var publicationMu sync.RWMutex
 
@@ -102,6 +134,11 @@ func readPublication(read func()) {
 func Configure(cfg Config) { Publish(cfg, nil) }
 
 func Acquire(ctx context.Context, resource string) (Permit, error) {
+	if ctx != nil {
+		if scope, ok := ctx.Value(scopeContextKey{}).(*Scope); ok && scope != nil {
+			return scope.coordinator.acquire(ctx, resource)
+		}
+	}
 	c := loadCoordinator()
 	return c.acquire(ctx, resource)
 }

--- a/internal/githubapi/coordinator_test.go
+++ b/internal/githubapi/coordinator_test.go
@@ -3,6 +3,7 @@ package githubapi
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,6 +25,275 @@ func TestCoordinatorLimitsConcurrentRequests(t *testing.T) {
 	p2, err := c.acquire(context.Background(), "core")
 	require.NoError(t, err)
 	p2.Done(Observation{})
+}
+
+func TestReadPublicationUsesReadBoundary(t *testing.T) {
+	gateHeld := make(chan bool, 1)
+	gateReleased := make(chan bool, 1)
+	hook := &publicationReadBoundaryTestHook{
+		afterLock: func() {
+			unexpectedlyUnlocked := publicationMu.TryLock()
+			if unexpectedlyUnlocked {
+				publicationMu.Unlock()
+			}
+			gateHeld <- !unexpectedlyUnlocked
+		},
+		afterUnlock: func() {
+			unlocked := publicationMu.TryLock()
+			if unlocked {
+				publicationMu.Unlock()
+			}
+			gateReleased <- unlocked
+		},
+	}
+	publicationReadBoundaryHookForTest.Store(hook)
+	t.Cleanup(func() { publicationReadBoundaryHookForTest.CompareAndSwap(hook, nil) })
+
+	callbackCalled := false
+	ReadPublication(func() { callbackCalled = true })
+	require.True(t, callbackCalled)
+	select {
+	case held := <-gateHeld:
+		require.True(t, held, "ReadPublication callback ran without the publication read lock")
+	default:
+		t.Fatal("ReadPublication bypassed the publication read boundary")
+	}
+	select {
+	case released := <-gateReleased:
+		require.True(t, released, "ReadPublication retained the publication read lock")
+	default:
+		t.Fatal("ReadPublication bypassed the publication unlock boundary")
+	}
+}
+
+func TestAcquireWaitsForPublicationBeforeSelectingCoordinator(t *testing.T) {
+	previous := current.Load()
+	old := newCoordinator(Config{Concurrency: 1})
+	publicationMu.Lock()
+	current.Store(old)
+	publicationMu.Unlock()
+	t.Cleanup(func() {
+		publicationMu.Lock()
+		current.Store(previous)
+		publicationMu.Unlock()
+	})
+
+	oldPermit, err := old.acquire(context.Background(), "core")
+	require.NoError(t, err)
+	t.Cleanup(func() { oldPermit.Done(Observation{}) })
+
+	publishEntered := make(chan struct{})
+	publishRelease := make(chan struct{})
+	publishDone := make(chan struct{})
+	var publishReleaseOnce sync.Once
+	selectionEntered := make(chan struct{})
+	selectionProceed := make(chan struct{})
+	selectionGateHeld := make(chan bool, 1)
+	var selectionProceedOnce sync.Once
+	type acquireResult struct {
+		permit Permit
+		err    error
+	}
+	acquireDone := make(chan acquireResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	var workers sync.WaitGroup
+	hook := &publicationReadBoundaryTestHook{
+		beforeLock: func() {
+			close(selectionEntered)
+			<-selectionProceed
+		},
+		afterLock: func() {
+			unexpectedlyUnlocked := publicationMu.TryLock()
+			if unexpectedlyUnlocked {
+				publicationMu.Unlock()
+			}
+			selectionGateHeld <- !unexpectedlyUnlocked
+		},
+	}
+	t.Cleanup(func() {
+		cancel()
+		publishReleaseOnce.Do(func() { close(publishRelease) })
+		selectionProceedOnce.Do(func() { close(selectionProceed) })
+		workers.Wait()
+		publicationReadBoundaryHookForTest.CompareAndSwap(hook, nil)
+		select {
+		case result := <-acquireDone:
+			if result.permit != nil {
+				result.permit.Done(Observation{})
+			}
+		default:
+		}
+	})
+
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		Publish(Config{Concurrency: 2}, func() {
+			close(publishEntered)
+			<-publishRelease
+		})
+		close(publishDone)
+	}()
+	select {
+	case <-publishEntered:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for publication writer")
+	}
+
+	publicationReadBoundaryHookForTest.Store(hook)
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		permit, acquireErr := Acquire(ctx, "core")
+		acquireDone <- acquireResult{permit: permit, err: acquireErr}
+	}()
+
+	select {
+	case <-selectionEntered:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for Acquire to reach the pre-selection barrier")
+	}
+	select {
+	case result := <-acquireDone:
+		if result.permit != nil {
+			result.permit.Done(Observation{})
+		}
+		t.Fatal("Acquire returned while blocked inside coordinator selection")
+	default:
+	}
+	if publicationMu.TryRLock() {
+		publicationMu.RUnlock()
+		t.Fatal("publication writer did not hold the selection gate")
+	}
+
+	publishReleaseOnce.Do(func() { close(publishRelease) })
+	select {
+	case <-publishDone:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for publication writer completion")
+	}
+	selectionProceedOnce.Do(func() { close(selectionProceed) })
+
+	select {
+	case gateHeld := <-selectionGateHeld:
+		require.True(t, gateHeld, "coordinator selection did not hold the publication read gate")
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for coordinator selection gate acquisition")
+	}
+
+	select {
+	case result := <-acquireDone:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.permit)
+		selectedPermit, ok := result.permit.(*permit)
+		require.True(t, ok)
+		require.NotSame(t, old, selectedPermit.c)
+		require.Same(t, current.Load(), selectedPermit.c)
+		result.permit.Done(Observation{})
+	case <-ctx.Done():
+		t.Fatal("Acquire remained blocked on the saturated old coordinator")
+	}
+}
+
+func TestAcquireReleasesPublicationLockBeforeWaitingForPermit(t *testing.T) {
+	previous := current.Load()
+	old := newCoordinator(Config{Concurrency: 1})
+	publicationMu.Lock()
+	current.Store(old)
+	publicationMu.Unlock()
+	t.Cleanup(func() {
+		publicationMu.Lock()
+		current.Store(previous)
+		publicationMu.Unlock()
+	})
+
+	oldPermit, err := old.acquire(context.Background(), "core")
+	require.NoError(t, err)
+	t.Cleanup(func() { oldPermit.Done(Observation{}) })
+
+	selectionGateHeld := make(chan bool, 1)
+	selectionGateReleased := make(chan bool, 1)
+	hook := &publicationReadBoundaryTestHook{
+		afterLock: func() {
+			unexpectedlyUnlocked := publicationMu.TryLock()
+			if unexpectedlyUnlocked {
+				publicationMu.Unlock()
+			}
+			selectionGateHeld <- !unexpectedlyUnlocked
+		},
+		afterUnlock: func() {
+			unlocked := publicationMu.TryLock()
+			if unlocked {
+				publicationMu.Unlock()
+			}
+			selectionGateReleased <- unlocked
+		},
+	}
+	publicationReadBoundaryHookForTest.Store(hook)
+
+	type acquireResult struct {
+		permit Permit
+		err    error
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	acquireDone := make(chan acquireResult, 1)
+	var workers sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		workers.Wait()
+		publicationReadBoundaryHookForTest.CompareAndSwap(hook, nil)
+		select {
+		case result := <-acquireDone:
+			if result.permit != nil {
+				result.permit.Done(Observation{})
+			}
+		default:
+		}
+	})
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		permit, acquireErr := Acquire(ctx, "core")
+		acquireDone <- acquireResult{permit: permit, err: acquireErr}
+	}()
+
+	select {
+	case gateHeld := <-selectionGateHeld:
+		require.True(t, gateHeld, "coordinator selection did not hold the publication read gate")
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("timed out waiting for coordinator selection gate acquisition")
+	}
+	select {
+	case gateReleased := <-selectionGateReleased:
+		require.True(t, gateReleased, "coordinator selection retained the publication read gate")
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("timed out waiting for coordinator selection gate release")
+	}
+
+	publishDone := make(chan struct{})
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		Publish(Config{Concurrency: 2}, nil)
+		close(publishDone)
+	}()
+	select {
+	case <-publishDone:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("publication was blocked while Acquire waited for a permit")
+	}
+
+	cancel()
+	select {
+	case result := <-acquireDone:
+		require.Nil(t, result.permit)
+		require.ErrorIs(t, result.err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for canceled Acquire")
+	}
 }
 
 func TestCoordinatorPausesOnlyObservedResource(t *testing.T) {

--- a/internal/githubapi/coordinator_test.go
+++ b/internal/githubapi/coordinator_test.go
@@ -27,6 +27,157 @@ func TestCoordinatorLimitsConcurrentRequests(t *testing.T) {
 	p2.Done(Observation{})
 }
 
+func installCoordinatorForTest(t *testing.T, cfg Config) {
+	t.Helper()
+	previous := current.Load()
+	publicationMu.Lock()
+	current.Store(newCoordinator(cfg))
+	publicationMu.Unlock()
+	t.Cleanup(func() {
+		publicationMu.Lock()
+		current.Store(previous)
+		publicationMu.Unlock()
+	})
+}
+
+func TestScopesShareOneProcessArbiterAcrossGenerations(t *testing.T) {
+	installCoordinatorForTest(t, Config{Concurrency: 1})
+	oldScope := NewScope(Config{Concurrency: 1})
+	oldPermit, err := Acquire(WithScope(context.Background(), oldScope), "core")
+	require.NoError(t, err)
+	var releaseOld sync.Once
+	t.Cleanup(func() { releaseOld.Do(func() { oldPermit.Done(Observation{}) }) })
+
+	Configure(Config{Concurrency: 1})
+	newScope := NewScope(Config{Concurrency: 1})
+	waitCtx, cancel := context.WithTimeout(WithScope(context.Background(), newScope), 40*time.Millisecond)
+	defer cancel()
+	newPermit, err := Acquire(waitCtx, "core")
+	if newPermit != nil {
+		newPermit.Done(Observation{})
+	}
+	require.ErrorIs(t, err, context.DeadlineExceeded, "new-generation traffic bypassed the held old-generation permit")
+
+	releaseOld.Do(func() { oldPermit.Done(Observation{}) })
+	acquireCtx, acquireCancel := context.WithTimeout(WithScope(context.Background(), newScope), time.Second)
+	defer acquireCancel()
+	newPermit, err = Acquire(acquireCtx, "core")
+	require.NoError(t, err)
+	newPermit.Done(Observation{})
+}
+
+func TestScopePublicationPreservesObservedSecondaryPause(t *testing.T) {
+	installCoordinatorForTest(t, Config{Concurrency: 1})
+	oldScope := NewScope(Config{Concurrency: 1})
+	permit, err := Acquire(WithScope(context.Background(), oldScope), "core")
+	require.NoError(t, err)
+	permit.Done(Observation{Secondary: true, RetryAfter: time.Second})
+
+	Configure(Config{Concurrency: 1})
+	newScope := NewScope(Config{Concurrency: 1})
+	waitCtx, cancel := context.WithTimeout(WithScope(context.Background(), newScope), 40*time.Millisecond)
+	defer cancel()
+	permit, err = Acquire(waitCtx, "graphql")
+	if permit != nil {
+		permit.Done(Observation{})
+	}
+	require.ErrorIs(t, err, context.DeadlineExceeded, "new-generation traffic bypassed an old-generation secondary pause")
+}
+
+func TestProcessArbiterCancellationAndResizeWakeSafely(t *testing.T) {
+	installCoordinatorForTest(t, Config{Concurrency: 1})
+	oldScope := NewScope(Config{Concurrency: 1})
+	first, err := Acquire(WithScope(context.Background(), oldScope), "core")
+	require.NoError(t, err)
+	var releaseFirst sync.Once
+	t.Cleanup(func() { releaseFirst.Do(func() { first.Done(Observation{}) }) })
+
+	newScope := NewScope(Config{Concurrency: 1})
+	type acquireResult struct {
+		permit Permit
+		err    error
+	}
+	cancelCtx, cancelWaiter := context.WithCancel(WithScope(context.Background(), newScope))
+	cancelStarted := make(chan struct{})
+	cancelled := make(chan acquireResult, 1)
+	go func() {
+		close(cancelStarted)
+		permit, acquireErr := Acquire(cancelCtx, "core")
+		cancelled <- acquireResult{permit: permit, err: acquireErr}
+	}()
+	<-cancelStarted
+	select {
+	case result := <-cancelled:
+		if result.permit != nil {
+			result.permit.Done(Observation{})
+		}
+		t.Fatal("waiter bypassed the process-wide concurrency limit")
+	case <-time.After(30 * time.Millisecond):
+	}
+	cancelWaiter()
+	result := <-cancelled
+	require.Nil(t, result.permit)
+	require.ErrorIs(t, result.err, context.Canceled)
+
+	secondDone := make(chan acquireResult, 1)
+	go func() {
+		permit, acquireErr := Acquire(WithScope(context.Background(), newScope), "core")
+		secondDone <- acquireResult{permit: permit, err: acquireErr}
+	}()
+	select {
+	case result = <-secondDone:
+		if result.permit != nil {
+			result.permit.Done(Observation{})
+		}
+		t.Fatal("waiter returned before the concurrency limit was raised")
+	case <-time.After(30 * time.Millisecond):
+	}
+	Configure(Config{Concurrency: 2})
+	select {
+	case result = <-secondDone:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.permit)
+	case <-time.After(time.Second):
+		t.Fatal("raising concurrency did not wake a waiter")
+	}
+	second := result.permit
+	var releaseSecond sync.Once
+	t.Cleanup(func() { releaseSecond.Do(func() { second.Done(Observation{}) }) })
+
+	Configure(Config{Concurrency: 1})
+	thirdDone := make(chan acquireResult, 1)
+	go func() {
+		permit, acquireErr := Acquire(WithScope(context.Background(), NewScope(Config{Concurrency: 1})), "core")
+		thirdDone <- acquireResult{permit: permit, err: acquireErr}
+	}()
+	select {
+	case result = <-thirdDone:
+		if result.permit != nil {
+			result.permit.Done(Observation{})
+		}
+		t.Fatal("lowered concurrency admitted work before active calls drained")
+	case <-time.After(30 * time.Millisecond):
+	}
+	releaseFirst.Do(func() { first.Done(Observation{}) })
+	select {
+	case result = <-thirdDone:
+		if result.permit != nil {
+			result.permit.Done(Observation{})
+		}
+		t.Fatal("lowered concurrency admitted work while active calls still equaled the limit")
+	case <-time.After(30 * time.Millisecond):
+	}
+	releaseSecond.Do(func() { second.Done(Observation{}) })
+	select {
+	case result = <-thirdDone:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.permit)
+		result.permit.Done(Observation{})
+	case <-time.After(time.Second):
+		t.Fatal("waiter did not resume after active calls drained below the lowered limit")
+	}
+}
+
 func TestReadPublicationUsesReadBoundary(t *testing.T) {
 	gateHeld := make(chan bool, 1)
 	gateReleased := make(chan bool, 1)
@@ -187,7 +338,7 @@ func TestAcquireWaitsForPublicationBeforeSelectingCoordinator(t *testing.T) {
 		require.NotNil(t, result.permit)
 		selectedPermit, ok := result.permit.(*permit)
 		require.True(t, ok)
-		require.NotSame(t, old, selectedPermit.c)
+		require.Same(t, old, selectedPermit.c, "publication must reconfigure the stable arbiter in place")
 		require.Same(t, current.Load(), selectedPermit.c)
 		result.permit.Done(Observation{})
 	case <-ctx.Done():
@@ -276,7 +427,7 @@ func TestAcquireReleasesPublicationLockBeforeWaitingForPermit(t *testing.T) {
 	workers.Add(1)
 	go func() {
 		defer workers.Done()
-		Publish(Config{Concurrency: 2}, nil)
+		Publish(Config{Concurrency: 1}, nil)
 		close(publishDone)
 	}()
 	select {

--- a/internal/issue/issue.go
+++ b/internal/issue/issue.go
@@ -145,14 +145,14 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 	// syncs use the same instant in UTC without reinterpreting wall-clock time.
 	opt := newIssueListOptions(lastUpdate)
 
-	cfg := config.GetIns()
+	cfg := config.GetExecutionConfig(ctx)
 	client := gh.NewClient(nil).WithAuthToken(cfg.GitHubToken)
 	for {
 		var (
 			issues []*gh.Issue
 			resp   *gh.Response
 		)
-		err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+		err := retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
 			permit, acquireErr := githubapi.Acquire(ctx, "core")
 			if acquireErr != nil {
 				return acquireErr
@@ -184,7 +184,7 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 					comments []*gh.IssueComment
 					resp     *gh.Response
 				)
-				err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+				err := retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
 					permit, acquireErr := githubapi.Acquire(ctx, "core")
 					if acquireErr != nil {
 						return acquireErr

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -35,8 +35,8 @@ func DownloadAllAssets(ctx context.Context, repo typedef.Repository, storages []
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	releaseNumLimit := config.GetReleaseNumLimit()
-	releaseSizeLimit := config.GetReleaseSizeLimit()
+	releaseNumLimit := config.GetReleaseNumLimitContext(ctx)
+	releaseSizeLimit := config.GetReleaseSizeLimitContext(ctx)
 	r, err := scm.NewRepository(repo.URL)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func DownloadAllAssets(ctx context.Context, repo typedef.Repository, storages []
 		return err
 	}
 	defer unlock()
-	c, err := github.New()
+	c, err := github.NewWithContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/expand_test.go
+++ b/internal/repository/expand_test.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +16,13 @@ type fakeRepoLister struct {
 }
 
 func (f *fakeRepoLister) GetRepos(name, accountType string) ([]string, error) {
+	return f.repos, f.err
+}
+
+func (f *fakeRepoLister) GetReposContext(ctx context.Context, name, accountType string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return f.repos, f.err
 }
 
@@ -51,4 +60,61 @@ func TestExpand(t *testing.T) {
 		bad := typedef.Repository{Name: "x", URL: "github.com/a/x", Type: "whatever"}
 		assert.Empty(t, Expand(bad))
 	})
+}
+
+func TestExpandContextPropagatesClientAndListFailures(t *testing.T) {
+	old := newGithubClientWithContext
+	t.Cleanup(func() { newGithubClientWithContext = old })
+	org := typedef.Repository{Name: "acme", Type: typedef.TypeOrg, OrgName: "acme"}
+
+	clientErr := errors.New("create client")
+	newGithubClientWithContext = func(context.Context) (contextualRepoLister, error) {
+		return nil, clientErr
+	}
+	got, err := ExpandContext(context.Background(), org)
+	require.ErrorIs(t, err, clientErr)
+	require.Empty(t, got)
+
+	listErr := errors.New("list repositories")
+	newGithubClientWithContext = func(context.Context) (contextualRepoLister, error) {
+		return &fakeRepoLister{err: listErr}, nil
+	}
+	got, err = ExpandContext(context.Background(), org)
+	require.ErrorIs(t, err, listErr)
+	require.Empty(t, got)
+}
+
+func TestExpandContextPassesCancellationToListing(t *testing.T) {
+	old := newGithubClientWithContext
+	t.Cleanup(func() { newGithubClientWithContext = old })
+	newGithubClientWithContext = func(context.Context) (contextualRepoLister, error) {
+		return &fakeRepoLister{repos: []string{"github.com/acme/unreachable"}}, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := ExpandContext(ctx, typedef.Repository{Name: "acme", Type: typedef.TypeOrg, OrgName: "acme"})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, got)
+}
+
+func TestExpandContextReturnsConcreteRepositories(t *testing.T) {
+	old := newGithubClientWithContext
+	t.Cleanup(func() { newGithubClientWithContext = old })
+	newGithubClientWithContext = func(context.Context) (contextualRepoLister, error) {
+		return &fakeRepoLister{repos: []string{"github.com/acme/alpha", "github.com/acme/beta"}}, nil
+	}
+	org := typedef.Repository{
+		Name: "acme", Type: typedef.TypeOrg, OrgName: "acme",
+		Cron: "0 2 * * *", AllBranches: true,
+	}
+
+	got, err := ExpandContext(context.Background(), org)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.Equal(t, "alpha", got[0].Name)
+	require.Equal(t, "github.com/acme/alpha", got[0].URL)
+	require.Equal(t, typedef.TypeRepo, got[0].GetType())
+	require.Equal(t, org.Cron, got[0].Cron)
+	require.True(t, got[0].AllBranches)
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"time"
@@ -25,9 +26,13 @@ type repoLister interface {
 	GetRepos(name, accountType string) ([]string, error)
 }
 
+type contextualRepoLister interface {
+	GetReposContext(context.Context, string, string) ([]string, error)
+}
+
 // newGithubClient 是可替换的包级 seam：生产用真客户端，测试注入 fake。
 var newGithubClient = func() (repoLister, error) { return github.New() }
-var newGithubClientWithContext = func(ctx context.Context) (repoLister, error) { return github.NewWithContext(ctx) }
+var newGithubClientWithContext = func(ctx context.Context) (contextualRepoLister, error) { return github.NewWithContext(ctx) }
 
 func GetRepositories(name string) []typedef.Repository {
 	repositories := make([]typedef.Repository, 0)
@@ -50,12 +55,6 @@ func addRepo(repo typedef.Repository, ret []typedef.Repository) []typedef.Reposi
 	return addRepoWithClient(repo, ret, newGithubClient)
 }
 
-func addRepoWithContext(ctx context.Context, repo typedef.Repository, ret []typedef.Repository) []typedef.Repository {
-	return addRepoWithClient(repo, ret, func() (repoLister, error) {
-		return newGithubClientWithContext(ctx)
-	})
-}
-
 func addRepoWithClient(repo typedef.Repository, ret []typedef.Repository, newClient func() (repoLister, error)) []typedef.Repository {
 	switch repo.GetType() {
 	case typedef.TypeRepo:
@@ -72,24 +71,29 @@ func addRepoWithClient(repo typedef.Repository, ret []typedef.Repository, newCli
 			ui.Errorf("Error getting user repos, %s", err)
 			return ret
 		}
-		for _, r := range repos {
-			ret = append(ret, typedef.Repository{
-				Name:               path.Base(r),
-				URL:                r,
-				Cron:               repo.Cron,
-				Storage:            repo.Storage,
-				UseCache:           repo.UseCache,
-				Type:               typedef.TypeRepo,
-				AllBranches:        repo.AllBranches,
-				Depth:              repo.Depth,
-				DownloadReleases:   repo.DownloadReleases,
-				DownloadIssues:     repo.DownloadIssues,
-				DownloadWiki:       repo.DownloadWiki,
-				DownloadDiscussion: repo.DownloadDiscussion,
-			})
-		}
+		ret = appendConcreteRepositories(ret, repo, repos)
 	default:
 		ui.Errorf("Invalid repository type %s", repo.Type)
+	}
+	return ret
+}
+
+func appendConcreteRepositories(ret []typedef.Repository, configured typedef.Repository, repositories []string) []typedef.Repository {
+	for _, repository := range repositories {
+		ret = append(ret, typedef.Repository{
+			Name:               path.Base(repository),
+			URL:                repository,
+			Cron:               configured.Cron,
+			Storage:            configured.Storage,
+			UseCache:           configured.UseCache,
+			Type:               typedef.TypeRepo,
+			AllBranches:        configured.AllBranches,
+			Depth:              configured.Depth,
+			DownloadReleases:   configured.DownloadReleases,
+			DownloadIssues:     configured.DownloadIssues,
+			DownloadWiki:       configured.DownloadWiki,
+			DownloadDiscussion: configured.DownloadDiscussion,
+		})
 	}
 	return ret
 }
@@ -439,6 +443,21 @@ func Expand(repo typedef.Repository) []typedef.Repository {
 
 // ExpandContext expands a user/org entry using the caller's frozen execution
 // configuration (token, retry, and API coordination scope when present).
-func ExpandContext(ctx context.Context, repo typedef.Repository) []typedef.Repository {
-	return addRepoWithContext(ctx, repo, nil)
+func ExpandContext(ctx context.Context, repo typedef.Repository) ([]typedef.Repository, error) {
+	switch repo.GetType() {
+	case typedef.TypeRepo:
+		return []typedef.Repository{repo}, nil
+	case typedef.TypeUser, typedef.TypeOrg:
+		client, err := newGithubClientWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		repositories, err := client.GetReposContext(ctx, repo.OrgName, repo.Type)
+		if err != nil {
+			return nil, err
+		}
+		return appendConcreteRepositories(nil, repo, repositories), nil
+	default:
+		return nil, fmt.Errorf("invalid repository type %q", repo.Type)
+	}
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -27,6 +27,7 @@ type repoLister interface {
 
 // newGithubClient 是可替换的包级 seam：生产用真客户端，测试注入 fake。
 var newGithubClient = func() (repoLister, error) { return github.New() }
+var newGithubClientWithContext = func(ctx context.Context) (repoLister, error) { return github.NewWithContext(ctx) }
 
 func GetRepositories(name string) []typedef.Repository {
 	repositories := make([]typedef.Repository, 0)
@@ -46,12 +47,22 @@ func GetRepositories(name string) []typedef.Repository {
 }
 
 func addRepo(repo typedef.Repository, ret []typedef.Repository) []typedef.Repository {
+	return addRepoWithClient(repo, ret, newGithubClient)
+}
+
+func addRepoWithContext(ctx context.Context, repo typedef.Repository, ret []typedef.Repository) []typedef.Repository {
+	return addRepoWithClient(repo, ret, func() (repoLister, error) {
+		return newGithubClientWithContext(ctx)
+	})
+}
+
+func addRepoWithClient(repo typedef.Repository, ret []typedef.Repository, newClient func() (repoLister, error)) []typedef.Repository {
 	switch repo.GetType() {
 	case typedef.TypeRepo:
 		ret = append(ret, repo)
 	case typedef.TypeUser, typedef.TypeOrg:
 		// get repos
-		client, err := newGithubClient()
+		client, err := newClient()
 		if err != nil {
 			ui.Errorf("Error creating github client, %s", err)
 			return ret
@@ -424,4 +435,10 @@ func Sync(ctx context.Context, repo typedef.Repository, iswiki bool, storages []
 // 非法类型返回空切片。CLI 与 executor 共用。
 func Expand(repo typedef.Repository) []typedef.Repository {
 	return addRepo(repo, nil)
+}
+
+// ExpandContext expands a user/org entry using the caller's frozen execution
+// configuration (token, retry, and API coordination scope when present).
+func ExpandContext(ctx context.Context, repo typedef.Repository) []typedef.Repository {
+	return addRepoWithContext(ctx, repo, nil)
 }

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -18,8 +18,12 @@ type Client struct {
 }
 
 func New() (*Client, error) {
+	return NewWithContext(context.Background())
+}
+
+func NewWithContext(ctx context.Context) (*Client, error) {
 	c := github.NewClient(nil)
-	if token := config.GetIns().GitHubToken; token != "" {
+	if token := config.GetExecutionConfig(ctx).GitHubToken; token != "" {
 		c = c.WithAuthToken(token)
 	}
 	return &Client{c: c}, nil
@@ -55,7 +59,7 @@ func (c *Client) GetReleases(ctx context.Context, owner, repo string) ([]*github
 		list []*github.RepositoryRelease
 		err  error
 	)
-	err = retry.Do(ctx, config.GetRetryConfig(), func() error {
+	err = retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
 		permit, acquireErr := githubapi.Acquire(ctx, "core")
 		if acquireErr != nil {
 			return acquireErr
@@ -77,7 +81,7 @@ func (c *Client) GetReleaseAssets(ctx context.Context, owner, repo string, id in
 		list []*github.ReleaseAsset
 		err  error
 	)
-	err = retry.Do(ctx, config.GetRetryConfig(), func() error {
+	err = retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
 		permit, acquireErr := githubapi.Acquire(ctx, "core")
 		if acquireErr != nil {
 			return acquireErr
@@ -96,7 +100,7 @@ func (c *Client) GetReleaseAssets(ctx context.Context, owner, repo string, id in
 
 func (c *Client) DownloadAsset(ctx context.Context, owner, repo string, id int64) (io.ReadCloser, error) {
 	var rc io.ReadCloser
-	err := retry.Do(ctx, config.GetRetryConfig(), func() error {
+	err := retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
 		permit, acquireErr := githubapi.Acquire(ctx, "core")
 		if acquireErr != nil {
 			return acquireErr

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -30,15 +30,29 @@ func NewWithContext(ctx context.Context) (*Client, error) {
 }
 
 func (c *Client) GetRepos(name string, accountType string) ([]string, error) {
+	return c.GetReposContext(context.Background(), name, accountType)
+}
+
+func (c *Client) GetReposContext(ctx context.Context, name string, accountType string) ([]string, error) {
 	var (
 		list []*github.Repository
 		err  error
 	)
-	if accountType == typedef.TypeOrg {
-		list, _, err = c.c.Repositories.ListByOrg(context.Background(), name, nil)
-	} else {
-		list, _, err = c.c.Repositories.List(context.Background(), name, nil)
-	}
+	err = retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
+		permit, acquireErr := githubapi.Acquire(ctx, "core")
+		if acquireErr != nil {
+			return acquireErr
+		}
+		var response *github.Response
+		var apiErr error
+		if accountType == typedef.TypeOrg {
+			list, response, apiErr = c.c.Repositories.ListByOrg(ctx, name, nil)
+		} else {
+			list, response, apiErr = c.c.Repositories.List(ctx, name, nil)
+		}
+		permit.Done(githubapi.ObserveREST(response, apiErr))
+		return apiErr
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -2,13 +2,18 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
+	"github.com/wnarutou/gitrieve/internal/typedef"
 )
 
 func TestNewObservesReloadedToken(t *testing.T) {
@@ -31,4 +36,107 @@ func TestNewObservesReloadedToken(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.Equal(t, []string{"Bearer first", "Bearer second"}, auth)
+}
+
+func githubExecutionContext(parent context.Context, cfg *config.Config) context.Context {
+	ctx := config.WithExecutionSnapshot(parent, config.NewExecutionSnapshot(cfg))
+	return githubapi.WithScope(ctx, githubapi.NewScope(config.GitHubAPIConfigFrom(cfg)))
+}
+
+func TestGetReposContextCancellationInterruptsScopedPermitWait(t *testing.T) {
+	githubapi.Configure(githubapi.Config{Concurrency: 1})
+	held, err := githubapi.Acquire(context.Background(), "core")
+	require.NoError(t, err)
+	var releaseHeld sync.Once
+	t.Cleanup(func() { releaseHeld.Do(func() { held.Done(githubapi.Observation{}) }) })
+
+	requestSeen := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestSeen <- struct{}{}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+	base, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	cfg := &config.Config{RetryMaxCount: 0}
+	ctx, cancel := context.WithCancel(githubExecutionContext(context.Background(), cfg))
+	client, err := NewWithContext(ctx)
+	require.NoError(t, err)
+	client.c.BaseURL = base
+
+	done := make(chan error, 1)
+	go func() {
+		_, listErr := client.GetReposContext(ctx, "acme", typedef.TypeOrg)
+		done <- listErr
+	}()
+	select {
+	case <-requestSeen:
+		t.Fatal("repository listing reached HTTP while the scoped permit was held")
+	case err := <-done:
+		t.Fatalf("repository listing returned before cancellation: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not interrupt repository listing permit wait")
+	}
+	select {
+	case <-requestSeen:
+		t.Fatal("cancelled repository listing reached HTTP")
+	default:
+	}
+}
+
+func TestGetReposContextRetriesFromSnapshotAndObservesREST(t *testing.T) {
+	githubapi.Configure(githubapi.Config{Concurrency: 1, LowRemainingThreshold: 1})
+	previousConfig := config.GetIns()
+	config.SetIns(&config.Config{RetryMaxCount: 0})
+	t.Cleanup(func() { config.SetIns(previousConfig) })
+
+	var calls int
+	reset := time.Now().Add(time.Second).Unix()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"temporary"}`))
+			return
+		}
+		w.Header().Set("X-RateLimit-Resource", "core")
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", fmt.Sprintf("%d", reset))
+		_, _ = w.Write([]byte(`[{"html_url":"https://github.com/acme/one"}]`))
+	}))
+	defer server.Close()
+	base, err := url.Parse(server.URL + "/")
+	require.NoError(t, err)
+	cfg := &config.Config{RetryMaxCount: 1, RetryBaseDelay: time.Millisecond}
+	ctx := githubExecutionContext(context.Background(), cfg)
+	client, err := NewWithContext(ctx)
+	require.NoError(t, err)
+	client.c.BaseURL = base
+
+	repositories, err := client.GetReposContext(ctx, "acme", typedef.TypeOrg)
+	require.NoError(t, err)
+	require.Equal(t, []string{"github.com/acme/one"}, repositories)
+	require.Equal(t, 2, calls, "repository listing must use the job snapshot retry count")
+
+	otherCtx, otherCancel := context.WithTimeout(context.Background(), time.Second)
+	defer otherCancel()
+	permit, err := githubapi.Acquire(otherCtx, "graphql")
+	require.NoError(t, err, "REST observation did not release the process permit")
+	permit.Done(githubapi.Observation{})
+	coreCtx, coreCancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer coreCancel()
+	permit, err = githubapi.Acquire(coreCtx, "core")
+	if permit != nil {
+		permit.Done(githubapi.Observation{})
+	}
+	require.ErrorIs(t, err, context.DeadlineExceeded, "repository listing response was not observed by the quota arbiter")
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -20,10 +21,12 @@ import (
 )
 
 type API struct {
+	configMu            sync.RWMutex
 	config              *config.Config
 	db                  *db.DB
 	executor            *executor.Executor
 	bulkRepositoryStats func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error)
+	bulkExecute         func(context.Context, string, uint64) ([]string, error)
 	scheduleRefresher   ScheduleRefresher
 }
 
@@ -34,20 +37,53 @@ type ScheduleRefresher interface {
 }
 
 func NewAPI(cfg *config.Config, db *db.DB, exec *executor.Executor) *API {
-	api := &API{config: cfg, db: db, executor: exec}
+	initial := config.Clone(cfg)
+	if exec != nil {
+		initial = exec.RuntimeConfigSnapshot().Config()
+	}
+	api := &API{config: initial, db: db, executor: exec}
 	api.bulkRepositoryStats = api.repositoryRunStatsForCandidate
+	if exec != nil {
+		api.bulkExecute = exec.ExecuteJobAtGenerationContext
+	}
 	return api
+}
+
+func (a *API) configSnapshot() *config.Config {
+	a.configMu.RLock()
+	defer a.configMu.RUnlock()
+	if a.executor != nil {
+		return a.executor.RuntimeConfigSnapshot().Config()
+	}
+	return config.Clone(a.config)
+}
+
+func (a *API) publishConfigLocked(next *config.Config) *config.Config {
+	published := config.Clone(next)
+	if a.executor != nil {
+		a.executor.RefreshConfig(published)
+	}
+	a.config = published
+	config.SetIns(published)
+	return config.Clone(published)
+}
+
+func (a *API) publishConfig(next *config.Config) *config.Config {
+	a.configMu.Lock()
+	published := a.publishConfigLocked(next)
+	a.configMu.Unlock()
+	return published
 }
 
 func (a *API) SetScheduleRefresher(refresher ScheduleRefresher) {
 	a.scheduleRefresher = refresher
 }
 
-func (a *API) refreshSchedules() string {
+func (a *API) refreshSchedules(cfg *config.Config) string {
 	if a.scheduleRefresher == nil {
 		return ""
 	}
-	if err := a.scheduleRefresher.RefreshSchedules(a.config); err != nil {
+	if err := a.scheduleRefresher.RefreshSchedules(config.Clone(cfg)); err != nil {
 		return "Cron schedules refreshed with errors: " + err.Error()
 	}
 	return ""
@@ -136,6 +172,7 @@ func (a *API) BulkCreateJobs(c *gin.Context) {
 
 	result := BulkCreateJobsResponse{Requested: len(confirmed)}
 	ctx := c.Request.Context()
+bulkLoop:
 	for index, candidate := range confirmed {
 		remaining := len(confirmed) - index
 		if ctx.Err() != nil {
@@ -161,10 +198,13 @@ func (a *API) BulkCreateJobs(c *gin.Context) {
 			break
 		}
 
-		_, executeErr := a.executor.ExecuteJobAtGeneration(candidate.Key(), runtime.Generation())
+		_, executeErr := a.bulkExecute(ctx, candidate.Key(), runtime.Generation())
 		switch {
 		case executeErr == nil:
 			result.Queued++
+		case ctx.Err() != nil || errors.Is(executeErr, context.Canceled) || errors.Is(executeErr, context.DeadlineExceeded):
+			result.FailedToEnqueue += remaining
+			break bulkLoop
 		case errors.Is(executeErr, executor.ErrRepositoryActive):
 			result.SkippedActive++
 		case errors.Is(executeErr, executor.ErrRepositoryNotFound):
@@ -272,10 +312,10 @@ func (a *API) currentRepositorySnapshot(ctx context.Context, now time.Time) ([]R
 	}
 	var repos []typedef.Repository
 	var overdueGrace, stuckThreshold time.Duration
-	if a.config != nil {
-		repos = a.config.Repository
-		overdueGrace = a.config.SyncOverdueGrace
-		stuckThreshold = a.config.SyncStuckThreshold
+	if cfg := a.configSnapshot(); cfg != nil {
+		repos = cfg.Repository
+		overdueGrace = cfg.SyncOverdueGrace
+		stuckThreshold = cfg.SyncStuckThreshold
 	}
 	return buildRepositorySnapshot(repos, stats, now, overdueGrace, stuckThreshold), nil
 }
@@ -460,6 +500,7 @@ func (a *API) GetJobs(c *gin.Context) {
 	defer rows.Close()
 
 	jobs := make([]Job, 0)
+	cfg := a.configSnapshot()
 	for rows.Next() {
 		var job Job
 		var startTime time.Time
@@ -484,7 +525,7 @@ func (a *API) GetJobs(c *gin.Context) {
 
 		// Resolve URL from config by identity key; unmatched (renamed/deleted/old
 		// empty-key rows) keeps the job_name snapshot and empty URL.
-		for _, repo := range a.config.Repository {
+		for _, repo := range cfg.Repository {
 			if repo.Matches(repoKey) {
 				job.URL = repo.URL
 				break
@@ -792,9 +833,12 @@ func (a *API) CreateRepository(c *gin.Context) {
 		})
 		return
 	}
+	a.configMu.Lock()
+	defer a.configMu.Unlock()
+	next := config.Clone(a.config)
 
 	// 判重按身份键（URL），name 允许重复。
-	for _, existing := range a.config.Repository {
+	for _, existing := range next.Repository {
 		if existing.Key() == repo.Key() {
 			c.JSON(http.StatusConflict, Response{
 				Code:    409,
@@ -804,18 +848,16 @@ func (a *API) CreateRepository(c *gin.Context) {
 		}
 	}
 
-	// Append to in-memory config
-	a.config.Repository = append(a.config.Repository, repo)
-	if a.executor != nil {
-		a.executor.RefreshConfig(a.config)
-	}
+	// Publish a copy-on-write replacement to the API and Executor together.
+	next.Repository = append(next.Repository, repo)
+	published := a.publishConfigLocked(next)
 
 	// Persist config; tolerate save failures with a warning
 	msg := ""
 	if err := config.Save(); err != nil {
 		msg = "Repository added in memory but failed to persist config: " + err.Error()
 	}
-	msg = joinMessages(msg, a.refreshSchedules())
+	msg = joinMessages(msg, a.refreshSchedules(published))
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,
@@ -830,10 +872,13 @@ func (a *API) UpdateRepository(c *gin.Context) {
 	// handler; gin prefixes the captured value with "/", which we strip before
 	// matching against repo keys.
 	id := strings.TrimPrefix(c.Param("id"), "/")
+	a.configMu.Lock()
+	defer a.configMu.Unlock()
+	next := config.Clone(a.config)
 
 	// Locate the existing repository by identity key (URL).
 	idx := -1
-	for i, existing := range a.config.Repository {
+	for i, existing := range next.Repository {
 		if existing.Matches(id) {
 			idx = i
 			break
@@ -860,7 +905,7 @@ func (a *API) UpdateRepository(c *gin.Context) {
 	// Marshal the existing repository into a map, overlay the patch fields,
 	// then unmarshal back into a typed struct. This preserves unspecified
 	// fields while applying only the supplied changes.
-	existingRaw, err := json.Marshal(a.config.Repository[idx])
+	existingRaw, err := json.Marshal(next.Repository[idx])
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{
 			Code:    500,
@@ -905,7 +950,7 @@ func (a *API) UpdateRepository(c *gin.Context) {
 		})
 		return
 	}
-	for i, other := range a.config.Repository {
+	for i, other := range next.Repository {
 		if i != idx && other.Key() == updated.Key() {
 			c.JSON(http.StatusConflict, Response{
 				Code:    409,
@@ -915,16 +960,14 @@ func (a *API) UpdateRepository(c *gin.Context) {
 		}
 	}
 
-	a.config.Repository[idx] = updated
-	if a.executor != nil {
-		a.executor.RefreshConfig(a.config)
-	}
+	next.Repository[idx] = updated
+	published := a.publishConfigLocked(next)
 
 	msg := ""
 	if err := config.Save(); err != nil {
 		msg = "Repository updated in memory but failed to persist config: " + err.Error()
 	}
-	msg = joinMessages(msg, a.refreshSchedules())
+	msg = joinMessages(msg, a.refreshSchedules(published))
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,
@@ -937,9 +980,12 @@ func (a *API) UpdateRepository(c *gin.Context) {
 func (a *API) DeleteRepository(c *gin.Context) {
 	// See UpdateRepository: strip the leading "/" gin adds to *id catch-all values.
 	id := strings.TrimPrefix(c.Param("id"), "/")
+	a.configMu.Lock()
+	defer a.configMu.Unlock()
+	next := config.Clone(a.config)
 
 	idx := -1
-	for i, existing := range a.config.Repository {
+	for i, existing := range next.Repository {
 		if existing.Matches(id) {
 			idx = i
 			break
@@ -954,16 +1000,14 @@ func (a *API) DeleteRepository(c *gin.Context) {
 	}
 
 	// Remove element at idx
-	a.config.Repository = append(a.config.Repository[:idx], a.config.Repository[idx+1:]...)
-	if a.executor != nil {
-		a.executor.RefreshConfig(a.config)
-	}
+	next.Repository = append(next.Repository[:idx], next.Repository[idx+1:]...)
+	published := a.publishConfigLocked(next)
 
 	msg := ""
 	if err := config.Save(); err != nil {
 		msg = "Repository deleted in memory but failed to persist config: " + err.Error()
 	}
-	msg = joinMessages(msg, a.refreshSchedules())
+	msg = joinMessages(msg, a.refreshSchedules(published))
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,
@@ -974,9 +1018,10 @@ func (a *API) DeleteRepository(c *gin.Context) {
 
 // GetStorages returns all storage backends from the configuration.
 func (a *API) GetStorages(c *gin.Context) {
+	cfg := a.configSnapshot()
 	c.JSON(http.StatusOK, Response{
 		Code: 200,
-		Data: a.config.Storage,
+		Data: cfg.Storage,
 	})
 }
 
@@ -1007,9 +1052,12 @@ func (a *API) CreateStorage(c *gin.Context) {
 		})
 		return
 	}
+	a.configMu.Lock()
+	defer a.configMu.Unlock()
+	next := config.Clone(a.config)
 
 	// Check for duplicates
-	for _, existing := range a.config.Storage {
+	for _, existing := range next.Storage {
 		if existing.Name == storage.Name {
 			c.JSON(http.StatusConflict, Response{
 				Code:    409,
@@ -1019,11 +1067,9 @@ func (a *API) CreateStorage(c *gin.Context) {
 		}
 	}
 
-	// Append to in-memory config
-	a.config.Storage = append(a.config.Storage, storage)
-	if a.executor != nil {
-		a.executor.RefreshConfig(a.config)
-	}
+	// Publish a copy-on-write replacement to the API and Executor together.
+	next.Storage = append(next.Storage, storage)
+	a.publishConfigLocked(next)
 
 	// Persist config; tolerate save failures with a warning
 	msg := ""
@@ -1041,10 +1087,13 @@ func (a *API) CreateStorage(c *gin.Context) {
 // UpdateStorage modifies an existing storage backend by name (partial update via JSON merge).
 func (a *API) UpdateStorage(c *gin.Context) {
 	id := c.Param("id")
+	a.configMu.Lock()
+	defer a.configMu.Unlock()
+	next := config.Clone(a.config)
 
 	// Locate the existing storage
 	idx := -1
-	for i, existing := range a.config.Storage {
+	for i, existing := range next.Storage {
 		if existing.Name == id {
 			idx = i
 			break
@@ -1071,7 +1120,7 @@ func (a *API) UpdateStorage(c *gin.Context) {
 	// Marshal the existing storage into a map, overlay the patch fields,
 	// then unmarshal back into a typed struct. This preserves unspecified
 	// fields while applying only the supplied changes.
-	existingRaw, err := json.Marshal(a.config.Storage[idx])
+	existingRaw, err := json.Marshal(next.Storage[idx])
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{
 			Code:    500,
@@ -1107,10 +1156,8 @@ func (a *API) UpdateStorage(c *gin.Context) {
 		return
 	}
 
-	a.config.Storage[idx] = updated
-	if a.executor != nil {
-		a.executor.RefreshConfig(a.config)
-	}
+	next.Storage[idx] = updated
+	a.publishConfigLocked(next)
 
 	msg := ""
 	if err := config.Save(); err != nil {
@@ -1127,9 +1174,12 @@ func (a *API) UpdateStorage(c *gin.Context) {
 // DeleteStorage removes a storage backend from the configuration by name.
 func (a *API) DeleteStorage(c *gin.Context) {
 	id := c.Param("id")
+	a.configMu.Lock()
+	defer a.configMu.Unlock()
+	next := config.Clone(a.config)
 
 	idx := -1
-	for i, existing := range a.config.Storage {
+	for i, existing := range next.Storage {
 		if existing.Name == id {
 			idx = i
 			break
@@ -1144,10 +1194,8 @@ func (a *API) DeleteStorage(c *gin.Context) {
 	}
 
 	// Remove element at idx
-	a.config.Storage = append(a.config.Storage[:idx], a.config.Storage[idx+1:]...)
-	if a.executor != nil {
-		a.executor.RefreshConfig(a.config)
-	}
+	next.Storage = append(next.Storage[:idx], next.Storage[idx+1:]...)
+	a.publishConfigLocked(next)
 
 	msg := ""
 	if err := config.Save(); err != nil {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -381,109 +380,170 @@ func lookupStats(stats map[string]runStats, repo typedef.Repository) runStats {
 // GetRepositories returns repositories with per-repo execution stats, last/next
 // run times, search (fuzzy name or URL match) and pagination.
 func (a *API) GetRepositories(c *gin.Context) {
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	search := c.Query("search")
-
-	if page < 1 {
-		page = 1
-	}
-	if limit < 1 || limit > 100 {
-		limit = 20
+	now := time.Now()
+	filter, page, limit, err := parseRepositoryHealthQuery(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, Response{Code: 400, Message: "Invalid repository query: " + err.Error()})
+		return
 	}
 
-	// Aggregate per-repository execution stats from the DB.
-	stats := map[string]runStats{}
-
-	// Note: we select the bare start_time column (constrained to the max by
-	// HAVING) rather than MAX(start_time). The modernc.org/sqlite driver only
-	// converts TEXT to time.Time for columns with a declared DATETIME type;
-	// aggregate expressions like MAX(start_time) have no declared type and come
-	// back as a raw string that database/sql cannot scan into *time.Time.
-	rows, err := a.db.Query(`
-		SELECT repo_key,
-		       start_time AS last_run,
-		       COUNT(*)        AS total,
-		       COALESCE(SUM(status = 'completed'), 0) AS success,
-		       COALESCE(SUM(status = 'failed'), 0)    AS failed
-		FROM executions
-		GROUP BY repo_key
-		HAVING start_time = MAX(start_time)`)
+	stats, err := a.db.RepositoryRunStats(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to query repository stats: " + err.Error()})
 		return
 	}
-	defer rows.Close()
 
-	for rows.Next() {
-		var key string
-		var lastRun sql.NullTime
-		var a runStats
-		if err := rows.Scan(&key, &lastRun, &a.Total, &a.Success, &a.Failed); err != nil {
-			c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to scan repository stats: " + err.Error()})
-			return
-		}
-		if lastRun.Valid {
-			a.LastRun = &lastRun.Time
-		}
-		stats[key] = a
+	var repos []typedef.Repository
+	var overdueGrace, stuckThreshold time.Duration
+	if a.config != nil {
+		repos = a.config.Repository
+		overdueGrace = a.config.SyncOverdueGrace
+		stuckThreshold = a.config.SyncStuckThreshold
 	}
-	if err := rows.Err(); err != nil {
-		c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to iterate repository stats: " + err.Error()})
-		return
-	}
-
-	// Fuzzy name or URL filter (in-memory equivalent of LIKE '%search%'). SQL
-	// LIKE is case-insensitive for ASCII, so match that by folding both sides to
-	// lower case before the Contains check.
-	filtered := make([]typedef.Repository, 0, len(a.config.Repository))
-	for _, repo := range a.config.Repository {
-		if search != "" {
-			inName := strings.Contains(strings.ToLower(repo.Name), strings.ToLower(search))
-			inURL := strings.Contains(strings.ToLower(repo.EffectiveURL()), strings.ToLower(search))
-			if !inName && !inURL {
-				continue
-			}
-		}
-		filtered = append(filtered, repo)
-	}
+	matched := searchRepositorySnapshot(buildRepositorySnapshot(repos, stats, now, overdueGrace, stuckThreshold), filter.Search)
+	summary := summarizeRepositorySnapshot(matched)
+	filtered := filterRepositorySnapshot(matched, filter)
+	sortRepositorySnapshot(filtered, filter.Sort, filter.Direction)
 
 	total := len(filtered)
-	start := (page - 1) * limit
-	if start > total {
-		start = total
+	start := total
+	if page <= 1+total/limit {
+		start = (page - 1) * limit
 	}
 	end := start + limit
 	if end > total {
 		end = total
 	}
 
-	now := time.Now()
-	overviews := make([]RepositoryOverview, 0, end-start)
-	for _, repo := range filtered[start:end] {
-		// Serve the effective URL (type=user/org with empty URL and an orgName
-		// synthesizes https://github.com/<orgName>). The frontend keys rows off
-		// r.URL, so a raw config entry without `url` would otherwise come back
-		// with URL=="" and its row buttons would no-op / 404. repo is a loop copy,
-		// so this neither mutates nor persists the config.
-		repo.URL = repo.EffectiveURL()
-		s := lookupStats(stats, repo)
-		overviews = append(overviews, RepositoryOverview{
-			Repository:  repo,
-			LastRunTime: s.LastRun,
-			NextRunTime: nextRunTime(repo.Cron, now),
-			TotalRuns:   s.Total,
-			SuccessRuns: s.Success,
-			FailedRuns:  s.Failed,
-		})
-	}
-
 	c.JSON(http.StatusOK, Response{Code: 200, Data: ListRepositoriesResponse{
-		Repositories: overviews,
+		Repositories: filtered[start:end],
+		Summary:      summary,
 		Total:        total,
 		Page:         page,
 		Limit:        limit,
 	}})
+}
+
+func parseRepositoryHealthQuery(c *gin.Context) (RepositoryHealthFilter, int, int, error) {
+	health, healthSet := c.GetQuery("health")
+	sortKey, sortSet := c.GetQuery("sort")
+	direction, directionSet := c.GetQuery("direction")
+	if !sortSet {
+		sortKey = "attention"
+	}
+	if !directionSet {
+		direction = "asc"
+	}
+	filter := RepositoryHealthFilter{
+		Search:    c.Query("search"),
+		Health:    health,
+		Sort:      sortKey,
+		Direction: direction,
+	}
+	if healthSet && !validRepositoryHealth(filter.Health) {
+		return RepositoryHealthFilter{}, 0, 0, fmt.Errorf("health %q is not supported", filter.Health)
+	}
+	if !validRepositorySort(filter.Sort) {
+		return RepositoryHealthFilter{}, 0, 0, fmt.Errorf("sort %q is not supported", filter.Sort)
+	}
+	if filter.Direction != "asc" && filter.Direction != "desc" {
+		return RepositoryHealthFilter{}, 0, 0, fmt.Errorf("direction %q is not supported", filter.Direction)
+	}
+
+	var err error
+	if raw, ok := c.GetQuery("overdue"); ok {
+		filter.Overdue, err = strictQueryBool(raw)
+		if err != nil {
+			return RepositoryHealthFilter{}, 0, 0, fmt.Errorf("overdue: %w", err)
+		}
+	}
+	if raw, ok := c.GetQuery("stuck"); ok {
+		filter.Stuck, err = strictQueryBool(raw)
+		if err != nil {
+			return RepositoryHealthFilter{}, 0, 0, fmt.Errorf("stuck: %w", err)
+		}
+	}
+	page, err := strictQueryInt(c, "page", 1, 1, int(^uint(0)>>1))
+	if err != nil {
+		return RepositoryHealthFilter{}, 0, 0, err
+	}
+	limit, err := strictQueryInt(c, "limit", 20, 1, 100)
+	if err != nil {
+		return RepositoryHealthFilter{}, 0, 0, err
+	}
+	return filter, page, limit, nil
+}
+
+func validRepositoryHealth(health string) bool {
+	switch health {
+	case "healthy", "failed", "overdue", "stuck", "never_synced", "cancelled", "pending", "running", "syncing":
+		return true
+	default:
+		return false
+	}
+}
+
+func validRepositorySort(sortKey string) bool {
+	switch sortKey {
+	case "attention", "name", "last_attempt", "last_success":
+		return true
+	default:
+		return false
+	}
+}
+
+func strictQueryBool(raw string) (*bool, error) {
+	switch raw {
+	case "true":
+		value := true
+		return &value, nil
+	case "false":
+		value := false
+		return &value, nil
+	default:
+		return nil, fmt.Errorf("must be true or false")
+	}
+}
+
+func strictQueryInt(c *gin.Context, name string, defaultValue, minimum, maximum int) (int, error) {
+	raw, ok := c.GetQuery(name)
+	if !ok {
+		return defaultValue, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < minimum || value > maximum {
+		return 0, fmt.Errorf("%s must be between %d and %d", name, minimum, maximum)
+	}
+	return value, nil
+}
+
+// GetJobComponents returns the persisted component rows for one execution.
+func (a *API) GetJobComponents(c *gin.Context) {
+	jobID := c.Param("id")
+	if jobID == "" {
+		c.JSON(http.StatusBadRequest, Response{Code: 400, Message: "Job ID is required"})
+		return
+	}
+
+	exists, err := a.db.ExecutionExists(c.Request.Context(), jobID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to check job: " + err.Error()})
+		return
+	}
+	if !exists {
+		c.JSON(http.StatusNotFound, Response{Code: 404, Message: "Job not found"})
+		return
+	}
+
+	components, err := a.db.ListComponents(c.Request.Context(), jobID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to query job components: " + err.Error()})
+		return
+	}
+	if components == nil {
+		components = []db.ComponentExecution{}
+	}
+	c.JSON(http.StatusOK, Response{Code: 200, Data: ListComponentsResponse{Components: components}})
 }
 
 // CreateRepository adds a new repository to the configuration.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -339,44 +339,6 @@ func (a *API) GetJobLogs(c *gin.Context) {
 	})
 }
 
-// runStats 是单仓库/单组织的聚合运行统计。
-type runStats struct {
-	LastRun *time.Time
-	Total   int64
-	Success int64
-	Failed  int64
-}
-
-// lookupStats 返回配置条目的运行统计。type=repo 直接取自身键；type=org/user
-// 对「路径边界前缀」（entry.Key()+"/"）命中的成员求和，last_run 取成员最大值。
-// 前缀以 "/" 结尾，避免 github.com/acme 误吞 github.com/acme2/x。
-func lookupStats(stats map[string]runStats, repo typedef.Repository) runStats {
-	key := repo.Key()
-	if key == "" {
-		return runStats{}
-	}
-	switch repo.GetType() {
-	case typedef.TypeOrg, typedef.TypeUser:
-		prefix := key + "/"
-		var sum runStats
-		for k, s := range stats {
-			if !strings.HasPrefix(k, prefix) {
-				continue
-			}
-			sum.Total += s.Total
-			sum.Success += s.Success
-			sum.Failed += s.Failed
-			if s.LastRun != nil && (sum.LastRun == nil || s.LastRun.After(*sum.LastRun)) {
-				t := *s.LastRun
-				sum.LastRun = &t
-			}
-		}
-		return sum
-	default:
-		return stats[key]
-	}
-}
-
 // GetRepositories returns repositories with per-repo execution stats, last/next
 // run times, search (fuzzy name or URL match) and pagination.
 func (a *API) GetRepositories(c *gin.Context) {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -71,6 +71,13 @@ func (a *API) CreateJob(c *gin.Context) {
 
 	jobIDs, err := a.executor.ExecuteJob(req.RepositoryKey)
 	if err != nil {
+		if errors.Is(err, executor.ErrRepositoryActive) {
+			c.JSON(http.StatusConflict, Response{
+				Code:    http.StatusConflict,
+				Message: "Repository is already active",
+			})
+			return
+		}
 		if errors.Is(err, executor.ErrRepositoryNotFound) {
 			c.JSON(http.StatusNotFound, Response{
 				Code:    404,
@@ -89,7 +96,7 @@ func (a *API) CreateJob(c *gin.Context) {
 		Code: 200,
 		Data: CreateJobResponse{
 			JobIDs: jobIDs,
-			Status: string(executor.StatusRunning),
+			Status: string(executor.StatusPending),
 		},
 	})
 }
@@ -108,6 +115,14 @@ func (a *API) CancelJob(c *gin.Context) {
 	// Cancel the job
 	err := a.executor.CancelJob(jobID)
 	if err != nil {
+		exists, lookupErr := a.db.ExecutionExists(c.Request.Context(), jobID)
+		if lookupErr == nil && !exists {
+			c.JSON(http.StatusOK, Response{
+				Code: 200,
+				Data: CancelJobResponse{Status: string(executor.StatusCancelled)},
+			})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, Response{
 			Code:    500,
 			Message: "Failed to cancel job: " + err.Error(),

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -20,10 +20,11 @@ import (
 )
 
 type API struct {
-	config            *config.Config
-	db                *db.DB
-	executor          *executor.Executor
-	scheduleRefresher ScheduleRefresher
+	config              *config.Config
+	db                  *db.DB
+	executor            *executor.Executor
+	bulkRepositoryStats func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error)
+	scheduleRefresher   ScheduleRefresher
 }
 
 // ScheduleRefresher updates the live server scheduler after repository or
@@ -33,7 +34,9 @@ type ScheduleRefresher interface {
 }
 
 func NewAPI(cfg *config.Config, db *db.DB, exec *executor.Executor) *API {
-	return &API{config: cfg, db: db, executor: exec}
+	api := &API{config: cfg, db: db, executor: exec}
+	api.bulkRepositoryStats = api.repositoryRunStatsForCandidate
+	return api
 }
 
 func (a *API) SetScheduleRefresher(refresher ScheduleRefresher) {
@@ -112,7 +115,12 @@ func (a *API) BulkCreateJobs(c *gin.Context) {
 		return
 	}
 
-	confirmed, err := a.bulkEligibleSnapshot(c.Request.Context(), req.Selector, time.Now())
+	if a.executor == nil {
+		c.JSON(http.StatusInternalServerError, Response{Code: http.StatusInternalServerError, Message: "Executor is unavailable"})
+		return
+	}
+	runtime := a.executor.RuntimeConfigSnapshot()
+	confirmed, err := a.bulkEligibleSnapshot(c.Request.Context(), runtime, req.Selector, time.Now())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{Code: http.StatusInternalServerError, Message: "Failed to query repository stats: " + err.Error()})
 		return
@@ -127,9 +135,20 @@ func (a *API) BulkCreateJobs(c *gin.Context) {
 	}
 
 	result := BulkCreateJobsResponse{Requested: len(confirmed)}
-	for _, candidate := range confirmed {
-		eligible, recheckErr := a.bulkRepositoryEligible(c.Request.Context(), candidate.Key(), req.Selector, time.Now())
+	ctx := c.Request.Context()
+	for index, candidate := range confirmed {
+		remaining := len(confirmed) - index
+		if ctx.Err() != nil {
+			result.FailedToEnqueue += remaining
+			break
+		}
+		runtime = a.executor.RuntimeConfigSnapshot()
+		eligible, recheckErr := a.bulkRepositoryEligible(ctx, runtime, candidate.Key(), req.Selector, time.Now())
 		if recheckErr != nil {
+			if ctx.Err() != nil || errors.Is(recheckErr, context.Canceled) || errors.Is(recheckErr, context.DeadlineExceeded) {
+				result.FailedToEnqueue += remaining
+				break
+			}
 			result.FailedToEnqueue++
 			continue
 		}
@@ -137,18 +156,20 @@ func (a *API) BulkCreateJobs(c *gin.Context) {
 			result.NoLongerEligible++
 			continue
 		}
-
-		if a.executor == nil {
-			result.FailedToEnqueue++
-			continue
+		if ctx.Err() != nil {
+			result.FailedToEnqueue += remaining
+			break
 		}
-		_, executeErr := a.executor.ExecuteJob(candidate.Key())
+
+		_, executeErr := a.executor.ExecuteJobAtGeneration(candidate.Key(), runtime.Generation())
 		switch {
 		case executeErr == nil:
 			result.Queued++
 		case errors.Is(executeErr, executor.ErrRepositoryActive):
 			result.SkippedActive++
 		case errors.Is(executeErr, executor.ErrRepositoryNotFound):
+			result.NoLongerEligible++
+		case errors.Is(executeErr, executor.ErrConfigGenerationChanged):
 			result.NoLongerEligible++
 		default:
 			result.FailedToEnqueue++
@@ -214,11 +235,13 @@ func decodeStrictJSON(reader io.Reader, target interface{}) error {
 	return nil
 }
 
-func (a *API) bulkEligibleSnapshot(ctx context.Context, selector BulkJobSelector, now time.Time) ([]RepositoryOverview, error) {
-	snapshot, err := a.currentRepositorySnapshot(ctx, now)
+func (a *API) bulkEligibleSnapshot(ctx context.Context, runtime *executor.RuntimeConfigSnapshot, selector BulkJobSelector, now time.Time) ([]RepositoryOverview, error) {
+	stats, err := a.db.RepositoryRunStats(ctx)
 	if err != nil {
 		return nil, err
 	}
+	overdueGrace, stuckThreshold := runtime.SyncHealthThresholds()
+	snapshot := buildRepositorySnapshot(runtime.Repositories(), stats, now, overdueGrace, stuckThreshold)
 	return selectBulkEligible(snapshot, selector), nil
 }
 
@@ -257,29 +280,20 @@ func (a *API) currentRepositorySnapshot(ctx context.Context, now time.Time) ([]R
 	return buildRepositorySnapshot(repos, stats, now, overdueGrace, stuckThreshold), nil
 }
 
-func (a *API) bulkRepositoryEligible(ctx context.Context, repositoryKey string, selector BulkJobSelector, now time.Time) (bool, error) {
-	var repository typedef.Repository
-	found := false
-	if a.config != nil {
-		for _, configured := range a.config.Repository {
-			if configured.Matches(repositoryKey) {
-				repository = configured
-				found = true
-				break
-			}
-		}
-	}
+func (a *API) bulkRepositoryEligible(ctx context.Context, runtime *executor.RuntimeConfigSnapshot, repositoryKey string, selector BulkJobSelector, now time.Time) (bool, error) {
+	repository, found := runtime.Repository(repositoryKey)
 	if !found {
 		return false, nil
 	}
 
-	stats, err := a.repositoryRunStatsForCandidate(ctx, repository)
+	stats, err := a.bulkRepositoryStats(ctx, repository)
 	if err != nil {
 		return false, err
 	}
+	overdueGrace, stuckThreshold := runtime.SyncHealthThresholds()
 	snapshot := buildRepositorySnapshot(
 		[]typedef.Repository{repository}, stats, now,
-		a.config.SyncOverdueGrace, a.config.SyncStuckThreshold,
+		overdueGrace, stuckThreshold,
 	)
 	return len(selectBulkEligible(snapshot, selector)) == 1, nil
 }
@@ -288,20 +302,7 @@ func (a *API) bulkRepositoryEligible(ctx context.Context, repositoryKey string, 
 // history. This keeps enqueue-time rechecks O(candidates) instead of rebuilding
 // the full ~6,000-repository fleet snapshot for every item.
 func (a *API) repositoryRunStatsForCandidate(ctx context.Context, repository typedef.Repository) (map[string]db.RepositoryRunStats, error) {
-	key := repository.Key()
-	query := `
-		SELECT id, repo_key, start_time, end_time, status, error_message
-		FROM executions WHERE repo_key = ?
-		ORDER BY repo_key, start_time DESC, id DESC LIMIT 1`
-	args := []interface{}{key}
-	if repository.GetType() == typedef.TypeOrg || repository.GetType() == typedef.TypeUser {
-		prefix := key + "/"
-		query = `
-			SELECT id, repo_key, start_time, end_time, status, error_message
-			FROM executions WHERE substr(repo_key, 1, ?) = ?
-			ORDER BY repo_key, start_time DESC, id DESC`
-		args = []interface{}{len(prefix), prefix}
-	}
+	query, args := repositoryRunStatsQuery(repository)
 
 	rows, err := a.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -343,6 +344,24 @@ func (a *API) repositoryRunStatsForCandidate(ctx context.Context, repository typ
 		return nil, err
 	}
 	return stats, nil
+}
+
+func repositoryRunStatsQuery(repository typedef.Repository) (string, []interface{}) {
+	key := repository.Key()
+	query := `
+		SELECT id, repo_key, start_time, end_time, status, error_message
+		FROM executions WHERE repo_key = ?
+		ORDER BY repo_key, start_time DESC, id DESC LIMIT 1`
+	args := []interface{}{key}
+	if repository.GetType() == typedef.TypeOrg || repository.GetType() == typedef.TypeUser {
+		prefix := key + "/"
+		query = `
+			SELECT id, repo_key, start_time, end_time, status, error_message
+			FROM executions WHERE repo_key >= ? AND repo_key < ?
+			ORDER BY repo_key, start_time DESC, id DESC`
+		args = []interface{}{prefix, key + "0"}
+	}
+	return query, args
 }
 
 func (a *API) CancelJob(c *gin.Context) {
@@ -787,6 +806,9 @@ func (a *API) CreateRepository(c *gin.Context) {
 
 	// Append to in-memory config
 	a.config.Repository = append(a.config.Repository, repo)
+	if a.executor != nil {
+		a.executor.RefreshConfig(a.config)
+	}
 
 	// Persist config; tolerate save failures with a warning
 	msg := ""
@@ -894,6 +916,9 @@ func (a *API) UpdateRepository(c *gin.Context) {
 	}
 
 	a.config.Repository[idx] = updated
+	if a.executor != nil {
+		a.executor.RefreshConfig(a.config)
+	}
 
 	msg := ""
 	if err := config.Save(); err != nil {
@@ -930,6 +955,9 @@ func (a *API) DeleteRepository(c *gin.Context) {
 
 	// Remove element at idx
 	a.config.Repository = append(a.config.Repository[:idx], a.config.Repository[idx+1:]...)
+	if a.executor != nil {
+		a.executor.RefreshConfig(a.config)
+	}
 
 	msg := ""
 	if err := config.Save(); err != nil {
@@ -993,6 +1021,9 @@ func (a *API) CreateStorage(c *gin.Context) {
 
 	// Append to in-memory config
 	a.config.Storage = append(a.config.Storage, storage)
+	if a.executor != nil {
+		a.executor.RefreshConfig(a.config)
+	}
 
 	// Persist config; tolerate save failures with a warning
 	msg := ""
@@ -1077,6 +1108,9 @@ func (a *API) UpdateStorage(c *gin.Context) {
 	}
 
 	a.config.Storage[idx] = updated
+	if a.executor != nil {
+		a.executor.RefreshConfig(a.config)
+	}
 
 	msg := ""
 	if err := config.Save(); err != nil {
@@ -1111,6 +1145,9 @@ func (a *API) DeleteStorage(c *gin.Context) {
 
 	// Remove element at idx
 	a.config.Storage = append(a.config.Storage[:idx], a.config.Storage[idx+1:]...)
+	if a.executor != nil {
+		a.executor.RefreshConfig(a.config)
+	}
 
 	msg := ""
 	if err := config.Save(); err != nil {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -98,6 +100,249 @@ func (a *API) CreateJob(c *gin.Context) {
 			Status: string(executor.StatusPending),
 		},
 	})
+}
+
+// BulkCreateJobs retries the current server-side eligible set selected by the
+// request. It never accepts repository IDs, and each confirmed candidate is
+// independently rechecked and submitted through the shared Executor.
+func (a *API) BulkCreateJobs(c *gin.Context) {
+	req, err := decodeBulkCreateJobsRequest(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, Response{Code: http.StatusBadRequest, Message: "Invalid request: " + err.Error()})
+		return
+	}
+
+	confirmed, err := a.bulkEligibleSnapshot(c.Request.Context(), req.Selector, time.Now())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, Response{Code: http.StatusInternalServerError, Message: "Failed to query repository stats: " + err.Error()})
+		return
+	}
+	if len(confirmed) != req.ExpectedCount {
+		c.JSON(http.StatusConflict, Response{
+			Code:    http.StatusConflict,
+			Data:    gin.H{"actual_count": len(confirmed)},
+			Message: "Eligible repository count changed",
+		})
+		return
+	}
+
+	result := BulkCreateJobsResponse{Requested: len(confirmed)}
+	for _, candidate := range confirmed {
+		eligible, recheckErr := a.bulkRepositoryEligible(c.Request.Context(), candidate.Key(), req.Selector, time.Now())
+		if recheckErr != nil {
+			result.FailedToEnqueue++
+			continue
+		}
+		if !eligible {
+			result.NoLongerEligible++
+			continue
+		}
+
+		if a.executor == nil {
+			result.FailedToEnqueue++
+			continue
+		}
+		_, executeErr := a.executor.ExecuteJob(candidate.Key())
+		switch {
+		case executeErr == nil:
+			result.Queued++
+		case errors.Is(executeErr, executor.ErrRepositoryActive):
+			result.SkippedActive++
+		case errors.Is(executeErr, executor.ErrRepositoryNotFound):
+			result.NoLongerEligible++
+		default:
+			result.FailedToEnqueue++
+		}
+	}
+
+	c.JSON(http.StatusOK, Response{Code: http.StatusOK, Data: result})
+}
+
+func decodeBulkCreateJobsRequest(body io.Reader) (BulkCreateJobsRequest, error) {
+	var envelope struct {
+		Selector      json.RawMessage `json:"selector"`
+		ExpectedCount json.RawMessage `json:"expected_count"`
+	}
+	if err := decodeStrictJSON(body, &envelope); err != nil {
+		return BulkCreateJobsRequest{}, err
+	}
+	if len(envelope.Selector) == 0 || string(envelope.Selector) == "null" {
+		return BulkCreateJobsRequest{}, fmt.Errorf("selector is required")
+	}
+	if len(envelope.ExpectedCount) == 0 || string(envelope.ExpectedCount) == "null" {
+		return BulkCreateJobsRequest{}, fmt.Errorf("expected_count is required")
+	}
+
+	var req BulkCreateJobsRequest
+	if err := decodeStrictJSON(strings.NewReader(string(envelope.Selector)), &req.Selector); err != nil {
+		return BulkCreateJobsRequest{}, fmt.Errorf("selector: %w", err)
+	}
+	var selectorFields map[string]json.RawMessage
+	if err := json.Unmarshal(envelope.Selector, &selectorFields); err != nil {
+		return BulkCreateJobsRequest{}, fmt.Errorf("selector: %w", err)
+	}
+	for _, field := range []string{"search", "health", "overdue"} {
+		if raw, present := selectorFields[field]; present && string(raw) == "null" {
+			return BulkCreateJobsRequest{}, fmt.Errorf("selector.%s must not be null", field)
+		}
+	}
+	if req.Selector.Health != "" && !validRepositoryHealth(req.Selector.Health) {
+		return BulkCreateJobsRequest{}, fmt.Errorf("health %q is not supported", req.Selector.Health)
+	}
+	if err := json.Unmarshal(envelope.ExpectedCount, &req.ExpectedCount); err != nil {
+		return BulkCreateJobsRequest{}, fmt.Errorf("expected_count must be an integer")
+	}
+	if req.ExpectedCount < 0 {
+		return BulkCreateJobsRequest{}, fmt.Errorf("expected_count must not be negative")
+	}
+	return req, nil
+}
+
+func decodeStrictJSON(reader io.Reader, target interface{}) error {
+	decoder := json.NewDecoder(reader)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("request must contain one JSON object")
+		}
+		return err
+	}
+	return nil
+}
+
+func (a *API) bulkEligibleSnapshot(ctx context.Context, selector BulkJobSelector, now time.Time) ([]RepositoryOverview, error) {
+	snapshot, err := a.currentRepositorySnapshot(ctx, now)
+	if err != nil {
+		return nil, err
+	}
+	return selectBulkEligible(snapshot, selector), nil
+}
+
+func selectBulkEligible(snapshot []RepositoryOverview, selector BulkJobSelector) []RepositoryOverview {
+	matched := searchRepositorySnapshot(snapshot, selector.Search)
+	matched = filterRepositorySnapshot(matched, RepositoryHealthFilter{
+		Health:  selector.Health,
+		Overdue: selector.Overdue,
+	})
+	eligible := make([]RepositoryOverview, 0, len(matched))
+	for _, repository := range matched {
+		if repository.Stuck {
+			continue
+		}
+		if repository.LastStatus == string(StatusFailed) ||
+			repository.LastStatus == string(StatusCancelled) || repository.Overdue {
+			eligible = append(eligible, repository)
+		}
+	}
+	sortRepositorySnapshot(eligible, "name", "asc")
+	return eligible
+}
+
+func (a *API) currentRepositorySnapshot(ctx context.Context, now time.Time) ([]RepositoryOverview, error) {
+	stats, err := a.db.RepositoryRunStats(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var repos []typedef.Repository
+	var overdueGrace, stuckThreshold time.Duration
+	if a.config != nil {
+		repos = a.config.Repository
+		overdueGrace = a.config.SyncOverdueGrace
+		stuckThreshold = a.config.SyncStuckThreshold
+	}
+	return buildRepositorySnapshot(repos, stats, now, overdueGrace, stuckThreshold), nil
+}
+
+func (a *API) bulkRepositoryEligible(ctx context.Context, repositoryKey string, selector BulkJobSelector, now time.Time) (bool, error) {
+	var repository typedef.Repository
+	found := false
+	if a.config != nil {
+		for _, configured := range a.config.Repository {
+			if configured.Matches(repositoryKey) {
+				repository = configured
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		return false, nil
+	}
+
+	stats, err := a.repositoryRunStatsForCandidate(ctx, repository)
+	if err != nil {
+		return false, err
+	}
+	snapshot := buildRepositorySnapshot(
+		[]typedef.Repository{repository}, stats, now,
+		a.config.SyncOverdueGrace, a.config.SyncStuckThreshold,
+	)
+	return len(selectBulkEligible(snapshot, selector)) == 1, nil
+}
+
+// repositoryRunStatsForCandidate reads only the candidate's indexed execution
+// history. This keeps enqueue-time rechecks O(candidates) instead of rebuilding
+// the full ~6,000-repository fleet snapshot for every item.
+func (a *API) repositoryRunStatsForCandidate(ctx context.Context, repository typedef.Repository) (map[string]db.RepositoryRunStats, error) {
+	key := repository.Key()
+	query := `
+		SELECT id, repo_key, start_time, end_time, status, error_message
+		FROM executions WHERE repo_key = ?
+		ORDER BY repo_key, start_time DESC, id DESC LIMIT 1`
+	args := []interface{}{key}
+	if repository.GetType() == typedef.TypeOrg || repository.GetType() == typedef.TypeUser {
+		prefix := key + "/"
+		query = `
+			SELECT id, repo_key, start_time, end_time, status, error_message
+			FROM executions WHERE substr(repo_key, 1, ?) = ?
+			ORDER BY repo_key, start_time DESC, id DESC`
+		args = []interface{}{len(prefix), prefix}
+	}
+
+	rows, err := a.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	stats := make(map[string]db.RepositoryRunStats)
+	for rows.Next() {
+		var (
+			id           string
+			repoKey      string
+			start        time.Time
+			end          sql.NullTime
+			status       string
+			errorMessage sql.NullString
+		)
+		if err := rows.Scan(&id, &repoKey, &start, &end, &status, &errorMessage); err != nil {
+			return nil, err
+		}
+		if _, exists := stats[repoKey]; exists {
+			continue
+		}
+		entry := db.RepositoryRunStats{
+			LatestExecutionID: id,
+			LatestStatus:      status,
+			LatestStart:       start,
+			TotalRuns:         1,
+		}
+		if end.Valid {
+			latestEnd := end.Time
+			entry.LatestEnd = &latestEnd
+		}
+		if errorMessage.Valid {
+			entry.LatestError = errorMessage.String
+		}
+		stats[repoKey] = entry
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return stats, nil
 }
 
 func (a *API) CancelJob(c *gin.Context) {
@@ -349,20 +594,12 @@ func (a *API) GetRepositories(c *gin.Context) {
 		return
 	}
 
-	stats, err := a.db.RepositoryRunStats(c.Request.Context())
+	snapshot, err := a.currentRepositorySnapshot(c.Request.Context(), now)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "Failed to query repository stats: " + err.Error()})
 		return
 	}
-
-	var repos []typedef.Repository
-	var overdueGrace, stuckThreshold time.Duration
-	if a.config != nil {
-		repos = a.config.Repository
-		overdueGrace = a.config.SyncOverdueGrace
-		stuckThreshold = a.config.SyncStuckThreshold
-	}
-	matched := searchRepositorySnapshot(buildRepositorySnapshot(repos, stats, now, overdueGrace, stuckThreshold), filter.Search)
+	matched := searchRepositorySnapshot(snapshot, filter.Search)
 	summary := summarizeRepositorySnapshot(matched)
 	filtered := filterRepositorySnapshot(matched, filter)
 	sortRepositorySnapshot(filtered, filter.Sort, filter.Direction)

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -68,15 +68,19 @@ func (a *API) publishConfigLocked(next *config.Config) *config.Config {
 	return config.Clone(published)
 }
 
-func (a *API) publishConfig(next *config.Config) *config.Config {
-	a.configMu.Lock()
-	published := a.publishConfigLocked(next)
-	a.configMu.Unlock()
-	return published
-}
-
 func (a *API) SetScheduleRefresher(refresher ScheduleRefresher) {
 	a.scheduleRefresher = refresher
+}
+
+// publishPersistAndRefreshConfigLocked completes one configuration generation
+// while its caller retains configMu for the entire operation.
+func (a *API) publishPersistAndRefreshConfigLocked(next *config.Config, saveFailurePrefix string) (*config.Config, string) {
+	published := a.publishConfigLocked(next)
+	message := ""
+	if err := config.SaveSnapshot(published); err != nil {
+		message = saveFailurePrefix + err.Error()
+	}
+	return published, joinMessages(message, a.refreshSchedules(published))
 }
 
 func (a *API) refreshSchedules(cfg *config.Config) string {
@@ -850,14 +854,7 @@ func (a *API) CreateRepository(c *gin.Context) {
 
 	// Publish a copy-on-write replacement to the API and Executor together.
 	next.Repository = append(next.Repository, repo)
-	published := a.publishConfigLocked(next)
-
-	// Persist config; tolerate save failures with a warning
-	msg := ""
-	if err := config.Save(); err != nil {
-		msg = "Repository added in memory but failed to persist config: " + err.Error()
-	}
-	msg = joinMessages(msg, a.refreshSchedules(published))
+	_, msg := a.publishPersistAndRefreshConfigLocked(next, "Repository added in memory but failed to persist config: ")
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,
@@ -872,6 +869,15 @@ func (a *API) UpdateRepository(c *gin.Context) {
 	// handler; gin prefixes the captured value with "/", which we strip before
 	// matching against repo keys.
 	id := strings.TrimPrefix(c.Param("id"), "/")
+	// Decode request input before entering the configuration generation lock.
+	var patch map[string]interface{}
+	if err := c.ShouldBindJSON(&patch); err != nil {
+		c.JSON(http.StatusBadRequest, Response{
+			Code:    400,
+			Message: "Invalid request: " + err.Error(),
+		})
+		return
+	}
 	a.configMu.Lock()
 	defer a.configMu.Unlock()
 	next := config.Clone(a.config)
@@ -888,16 +894,6 @@ func (a *API) UpdateRepository(c *gin.Context) {
 		c.JSON(http.StatusNotFound, Response{
 			Code:    404,
 			Message: "Repository not found",
-		})
-		return
-	}
-
-	// Decode the patch as a generic map for a partial merge.
-	var patch map[string]interface{}
-	if err := c.ShouldBindJSON(&patch); err != nil {
-		c.JSON(http.StatusBadRequest, Response{
-			Code:    400,
-			Message: "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -961,13 +957,7 @@ func (a *API) UpdateRepository(c *gin.Context) {
 	}
 
 	next.Repository[idx] = updated
-	published := a.publishConfigLocked(next)
-
-	msg := ""
-	if err := config.Save(); err != nil {
-		msg = "Repository updated in memory but failed to persist config: " + err.Error()
-	}
-	msg = joinMessages(msg, a.refreshSchedules(published))
+	_, msg := a.publishPersistAndRefreshConfigLocked(next, "Repository updated in memory but failed to persist config: ")
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,
@@ -1001,13 +991,7 @@ func (a *API) DeleteRepository(c *gin.Context) {
 
 	// Remove element at idx
 	next.Repository = append(next.Repository[:idx], next.Repository[idx+1:]...)
-	published := a.publishConfigLocked(next)
-
-	msg := ""
-	if err := config.Save(); err != nil {
-		msg = "Repository deleted in memory but failed to persist config: " + err.Error()
-	}
-	msg = joinMessages(msg, a.refreshSchedules(published))
+	_, msg := a.publishPersistAndRefreshConfigLocked(next, "Repository deleted in memory but failed to persist config: ")
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,
@@ -1069,13 +1053,7 @@ func (a *API) CreateStorage(c *gin.Context) {
 
 	// Publish a copy-on-write replacement to the API and Executor together.
 	next.Storage = append(next.Storage, storage)
-	a.publishConfigLocked(next)
-
-	// Persist config; tolerate save failures with a warning
-	msg := ""
-	if err := config.Save(); err != nil {
-		msg = "Storage added in memory but failed to persist config: " + err.Error()
-	}
+	_, msg := a.publishPersistAndRefreshConfigLocked(next, "Storage added in memory but failed to persist config: ")
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,
@@ -1087,6 +1065,15 @@ func (a *API) CreateStorage(c *gin.Context) {
 // UpdateStorage modifies an existing storage backend by name (partial update via JSON merge).
 func (a *API) UpdateStorage(c *gin.Context) {
 	id := c.Param("id")
+	// Decode request input before entering the configuration generation lock.
+	var patch map[string]interface{}
+	if err := c.ShouldBindJSON(&patch); err != nil {
+		c.JSON(http.StatusBadRequest, Response{
+			Code:    400,
+			Message: "Invalid request: " + err.Error(),
+		})
+		return
+	}
 	a.configMu.Lock()
 	defer a.configMu.Unlock()
 	next := config.Clone(a.config)
@@ -1103,16 +1090,6 @@ func (a *API) UpdateStorage(c *gin.Context) {
 		c.JSON(http.StatusNotFound, Response{
 			Code:    404,
 			Message: "Storage not found",
-		})
-		return
-	}
-
-	// Decode the patch as a generic map for a partial merge.
-	var patch map[string]interface{}
-	if err := c.ShouldBindJSON(&patch); err != nil {
-		c.JSON(http.StatusBadRequest, Response{
-			Code:    400,
-			Message: "Invalid request: " + err.Error(),
 		})
 		return
 	}
@@ -1157,12 +1134,7 @@ func (a *API) UpdateStorage(c *gin.Context) {
 	}
 
 	next.Storage[idx] = updated
-	a.publishConfigLocked(next)
-
-	msg := ""
-	if err := config.Save(); err != nil {
-		msg = "Storage updated in memory but failed to persist config: " + err.Error()
-	}
+	_, msg := a.publishPersistAndRefreshConfigLocked(next, "Storage updated in memory but failed to persist config: ")
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,
@@ -1195,12 +1167,7 @@ func (a *API) DeleteStorage(c *gin.Context) {
 
 	// Remove element at idx
 	next.Storage = append(next.Storage[:idx], next.Storage[idx+1:]...)
-	a.publishConfigLocked(next)
-
-	msg := ""
-	if err := config.Save(); err != nil {
-		msg = "Storage deleted in memory but failed to persist config: " + err.Error()
-	}
+	_, msg := a.publishPersistAndRefreshConfigLocked(next, "Storage deleted in memory but failed to persist config: ")
 
 	c.JSON(http.StatusOK, Response{
 		Code:    200,

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -25,10 +25,14 @@ type API struct {
 	config              *config.Config
 	db                  *db.DB
 	executor            *executor.Executor
-	reloadConfig        func() error
+	readReloadSnapshot  func() (*config.ReloadSnapshot, error)
 	bulkRepositoryStats func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error)
 	bulkExecute         func(context.Context, string, uint64, executor.EligibilityCheck) ([]string, error)
 	scheduleRefresher   ScheduleRefresher
+
+	// Test-only synchronization seam used to pause inside the unified
+	// publication callback after the Executor runtime store.
+	afterRuntimePublishForTest func()
 }
 
 // ScheduleRefresher updates the live server scheduler after repository or
@@ -42,7 +46,7 @@ func NewAPI(cfg *config.Config, db *db.DB, exec *executor.Executor) *API {
 	if exec != nil {
 		initial = exec.RuntimeConfigSnapshot().Config()
 	}
-	api := &API{config: initial, db: db, executor: exec, reloadConfig: config.Reload}
+	api := &API{config: initial, db: db, executor: exec, readReloadSnapshot: config.ReadReloadSnapshot}
 	api.bulkRepositoryStats = api.repositoryRunStatsForCandidate
 	if exec != nil {
 		api.bulkExecute = exec.ExecuteJobAtGenerationIfEligibleContext
@@ -60,13 +64,21 @@ func (a *API) configSnapshot() *config.Config {
 }
 
 func (a *API) publishConfigLocked(next *config.Config) *config.Config {
-	published := config.Clone(next)
+	return config.PublishSnapshot(next, a.installPublishedConfig)
+}
+
+func (a *API) publishReloadConfigLocked(snapshot *config.ReloadSnapshot) *config.Config {
+	return config.PublishReloadSnapshot(snapshot, a.installPublishedConfig)
+}
+
+func (a *API) installPublishedConfig(published *config.Config) {
 	if a.executor != nil {
 		a.executor.RefreshConfig(published)
 	}
-	a.config = published
-	config.SetIns(published)
-	return config.Clone(published)
+	a.config = config.Clone(published)
+	if a.afterRuntimePublishForTest != nil {
+		a.afterRuntimePublishForTest()
+	}
 }
 
 func (a *API) SetScheduleRefresher(refresher ScheduleRefresher) {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -25,8 +25,9 @@ type API struct {
 	config              *config.Config
 	db                  *db.DB
 	executor            *executor.Executor
+	reloadConfig        func() error
 	bulkRepositoryStats func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error)
-	bulkExecute         func(context.Context, string, uint64) ([]string, error)
+	bulkExecute         func(context.Context, string, uint64, executor.EligibilityCheck) ([]string, error)
 	scheduleRefresher   ScheduleRefresher
 }
 
@@ -41,10 +42,10 @@ func NewAPI(cfg *config.Config, db *db.DB, exec *executor.Executor) *API {
 	if exec != nil {
 		initial = exec.RuntimeConfigSnapshot().Config()
 	}
-	api := &API{config: initial, db: db, executor: exec}
+	api := &API{config: initial, db: db, executor: exec, reloadConfig: config.Reload}
 	api.bulkRepositoryStats = api.repositoryRunStatsForCandidate
 	if exec != nil {
-		api.bulkExecute = exec.ExecuteJobAtGenerationContext
+		api.bulkExecute = exec.ExecuteJobAtGenerationIfEligibleContext
 	}
 	return api
 }
@@ -80,6 +81,15 @@ func (a *API) publishPersistAndRefreshConfigLocked(next *config.Config, saveFail
 	if err := config.SaveSnapshot(published); err != nil {
 		message = saveFailurePrefix + err.Error()
 	}
+	return published, joinMessages(message, a.refreshSchedules(published))
+}
+
+// publishAndRefreshConfigLocked installs one in-memory generation and updates
+// schedules without writing config.yaml. Reload uses this path because the
+// operator's on-disk bytes are the source of truth for that operation.
+func (a *API) publishAndRefreshConfigLocked(next *config.Config) (*config.Config, string) {
+	published := a.publishConfigLocked(next)
+	message := ""
 	return published, joinMessages(message, a.refreshSchedules(published))
 }
 
@@ -202,7 +212,11 @@ bulkLoop:
 			break
 		}
 
-		_, executeErr := a.bulkExecute(ctx, candidate.Key(), runtime.Generation())
+		_, executeErr := a.bulkExecute(ctx, candidate.Key(), runtime.Generation(),
+			func(checkCtx context.Context, admitted *executor.RuntimeConfigSnapshot, repository typedef.Repository) (bool, error) {
+				return a.bulkRepositoryEligible(checkCtx, admitted, repository.Key(), req.Selector, time.Now())
+			})
+		var noLongerEligible *executor.RepositoryNoLongerEligibleError
 		switch {
 		case executeErr == nil:
 			result.Queued++
@@ -214,6 +228,8 @@ bulkLoop:
 		case errors.Is(executeErr, executor.ErrRepositoryNotFound):
 			result.NoLongerEligible++
 		case errors.Is(executeErr, executor.ErrConfigGenerationChanged):
+			result.NoLongerEligible++
+		case errors.As(executeErr, &noLongerEligible):
 			result.NoLongerEligible++
 		default:
 			result.FailedToEnqueue++

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -20,6 +20,72 @@ import (
 	"github.com/wnarutou/gitrieve/internal/typedef"
 )
 
+func TestGetJobComponents(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testDB.Close()) })
+
+	exec := executor.NewExecutor(logger.NewLogger(testDB), testDB, nil)
+	t.Cleanup(func() { require.NoError(t, exec.Close()) })
+	s := server.NewTestServerWithExecutor(testDB, exec)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, status) VALUES (?, ?, ?, ?, ?)`,
+		"components", "components", "github.com/test/components", now, "completed")
+	require.NoError(t, err)
+	require.NoError(t, testDB.CreateComponents(context.Background(), "components", []db.ComponentName{db.ComponentRelease, db.ComponentCode}))
+	_, err = testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, status) VALUES (?, ?, ?, ?, ?)`,
+		"historical", "historical", "github.com/test/historical", now, "completed")
+	require.NoError(t, err)
+
+	type componentView struct {
+		ExecutionID string     `json:"execution_id"`
+		Component   string     `json:"component"`
+		Status      string     `json:"status"`
+		StartTime   *time.Time `json:"start_time"`
+		EndTime     *time.Time `json:"end_time"`
+		Error       string     `json:"error_message"`
+	}
+	get := func(id string) (int, []componentView) {
+		req := httptest.NewRequest(http.MethodGet, "/api/jobs/"+id+"/components", nil)
+		resp := httptest.NewRecorder()
+		s.ServeHTTP(resp, req)
+		var response struct {
+			Data struct {
+				Components []componentView `json:"components"`
+			} `json:"data"`
+		}
+		if resp.Code == http.StatusOK {
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+		}
+		return resp.Code, response.Data.Components
+	}
+
+	t.Run("returns ordered component rows", func(t *testing.T) {
+		status, components := get("components")
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, components, 2)
+		require.Equal(t, []string{"code", "release"}, []string{components[0].Component, components[1].Component})
+		require.Equal(t, "components", components[0].ExecutionID)
+		require.Equal(t, "pending", components[0].Status)
+		require.Nil(t, components[0].StartTime)
+		require.Nil(t, components[0].EndTime)
+		require.Empty(t, components[0].Error)
+	})
+
+	t.Run("returns an empty array for a known historical execution", func(t *testing.T) {
+		status, components := get("historical")
+		require.Equal(t, http.StatusOK, status)
+		require.NotNil(t, components)
+		require.Empty(t, components)
+	})
+
+	t.Run("returns not found for unknown execution", func(t *testing.T) {
+		status, _ := get("unknown")
+		require.Equal(t, http.StatusNotFound, status)
+	})
+}
+
 func TestGetJobsAPI(t *testing.T) {
 	testDB, err := db.Initialize(":memory:")
 	require.NoError(t, err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2,6 +2,7 @@ package server_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -75,17 +76,17 @@ func TestGetJobs(t *testing.T) {
 			expectedStatus: 200,
 			checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				var response struct {
-					Code    int `json:"code"`
+					Code    int    `json:"code"`
 					Message string `json:"message"`
 					Data    struct {
-						Jobs  []struct {
-							ID          string     `json:"id"`
-							Name        string     `json:"name"`
-							URL         string     `json:"url"`
-							Status      string     `json:"status"`
-							StartTime   *time.Time `json:"start_time"`
-							EndTime     *time.Time `json:"end_time"`
-							ErrorMessage string    `json:"error_message"`
+						Jobs []struct {
+							ID           string     `json:"id"`
+							Name         string     `json:"name"`
+							URL          string     `json:"url"`
+							Status       string     `json:"status"`
+							StartTime    *time.Time `json:"start_time"`
+							EndTime      *time.Time `json:"end_time"`
+							ErrorMessage string     `json:"error_message"`
 						} `json:"jobs"`
 						Total int64 `json:"total"`
 						Page  int   `json:"page"`
@@ -111,17 +112,17 @@ func TestGetJobs(t *testing.T) {
 			expectedStatus: 200,
 			checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				var response struct {
-					Code    int `json:"code"`
+					Code    int    `json:"code"`
 					Message string `json:"message"`
 					Data    struct {
-						Jobs  []struct {
-							ID          string     `json:"id"`
-							Name        string     `json:"name"`
-							URL         string     `json:"url"`
-							Status      string     `json:"status"`
-							StartTime   *time.Time `json:"start_time"`
-							EndTime     *time.Time `json:"end_time"`
-							ErrorMessage string    `json:"error_message"`
+						Jobs []struct {
+							ID           string     `json:"id"`
+							Name         string     `json:"name"`
+							URL          string     `json:"url"`
+							Status       string     `json:"status"`
+							StartTime    *time.Time `json:"start_time"`
+							EndTime      *time.Time `json:"end_time"`
+							ErrorMessage string     `json:"error_message"`
 						} `json:"jobs"`
 						Total int64 `json:"total"`
 						Page  int   `json:"page"`
@@ -143,17 +144,17 @@ func TestGetJobs(t *testing.T) {
 			expectedStatus: 200,
 			checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				var response struct {
-					Code    int `json:"code"`
+					Code    int    `json:"code"`
 					Message string `json:"message"`
 					Data    struct {
-						Jobs  []struct {
-							ID          string     `json:"id"`
-							Name        string     `json:"name"`
-							URL         string     `json:"url"`
-							Status      string     `json:"status"`
-							StartTime   *time.Time `json:"start_time"`
-							EndTime     *time.Time `json:"end_time"`
-							ErrorMessage string    `json:"error_message"`
+						Jobs []struct {
+							ID           string     `json:"id"`
+							Name         string     `json:"name"`
+							URL          string     `json:"url"`
+							Status       string     `json:"status"`
+							StartTime    *time.Time `json:"start_time"`
+							EndTime      *time.Time `json:"end_time"`
+							ErrorMessage string     `json:"error_message"`
 						} `json:"jobs"`
 						Total int64 `json:"total"`
 						Page  int   `json:"page"`
@@ -175,11 +176,13 @@ func TestGetJobs(t *testing.T) {
 			expectedStatus: 200,
 			checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				var response struct {
-					Code    int `json:"code"`
+					Code    int    `json:"code"`
 					Message string `json:"message"`
 					Data    struct {
-						Jobs  []struct{ Name string `json:"name"` } `json:"jobs"`
-						Total int64                               `json:"total"`
+						Jobs []struct {
+							Name string `json:"name"`
+						} `json:"jobs"`
+						Total int64 `json:"total"`
 					} `json:"data"`
 				}
 				err := json.Unmarshal(resp.Body.Bytes(), &response)
@@ -195,11 +198,13 @@ func TestGetJobs(t *testing.T) {
 			expectedStatus: 200,
 			checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				var response struct {
-					Code    int `json:"code"`
+					Code    int    `json:"code"`
 					Message string `json:"message"`
 					Data    struct {
-						Jobs  []struct{ Name string `json:"name"` } `json:"jobs"`
-						Total int64                               `json:"total"`
+						Jobs []struct {
+							Name string `json:"name"`
+						} `json:"jobs"`
+						Total int64 `json:"total"`
 					} `json:"data"`
 				}
 				err := json.Unmarshal(resp.Body.Bytes(), &response)
@@ -215,10 +220,12 @@ func TestGetJobs(t *testing.T) {
 			expectedStatus: 200,
 			checkResponse: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				var response struct {
-					Code    int `json:"code"`
-					Data    struct {
-						Jobs  []struct{ Name string `json:"name"` } `json:"jobs"`
-						Total int64                               `json:"total"`
+					Code int `json:"code"`
+					Data struct {
+						Jobs []struct {
+							Name string `json:"name"`
+						} `json:"jobs"`
+						Total int64 `json:"total"`
 					} `json:"data"`
 				}
 				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
@@ -245,7 +252,7 @@ func TestGetJobs(t *testing.T) {
 func TestCreateJob(t *testing.T) {
 	testDB, err := db.Initialize(":memory:")
 	require.NoError(t, err)
-	defer testDB.Close()
+	t.Cleanup(func() { require.NoError(t, testDB.Close()) })
 
 	cfg := &config.Config{
 		Repository: []typedef.Repository{
@@ -257,7 +264,13 @@ func TestCreateJob(t *testing.T) {
 	}
 
 	log := logger.NewLogger(testDB)
-	exec := executor.NewExecutor(log, testDB, cfg)
+	exec := executor.NewExecutorWithRunners(log, testDB, cfg, executor.Runners{
+		Code: func(ctx context.Context, _ typedef.Repository, _ []typedef.MultiStorage) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	t.Cleanup(func() { require.NoError(t, exec.Close()) })
 
 	s := server.NewTestServerWithExecutor(testDB, exec)
 
@@ -324,7 +337,26 @@ func TestCreateJob(t *testing.T) {
 		assert.Equal(t, 200, response.Code)
 		require.Len(t, response.Data.JobIDs, 1)
 		assert.NotEmpty(t, response.Data.JobIDs[0])
-		assert.Equal(t, "running", response.Data.Status)
+		assert.Equal(t, "pending", response.Data.Status)
+	})
+
+	t.Run("active_repository", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]string{
+			"repository_key": "github.com/test/repo",
+		})
+		req, _ := http.NewRequest("POST", "/api/jobs", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		s.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusConflict, resp.Code)
+		var response struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+		assert.Equal(t, http.StatusConflict, response.Code)
+		assert.Contains(t, response.Message, "already active")
 	})
 }
 

--- a/internal/server/bulk_jobs_test.go
+++ b/internal/server/bulk_jobs_test.go
@@ -280,6 +280,52 @@ func TestBulkReportsPartialResultsAndRechecksEligibilityAtEnqueueTime(t *testing
 	require.Equal(t, []string{"github.com/bulk/alpha", "github.com/bulk/echo"}, newlyQueued)
 }
 
+func TestBulkCompletionBetweenAPIRecheckAndReservedAdmissionIsNotQueued(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{{Name: "candidate", URL: "github.com/bulk/completion-race"}}}
+	runner := newBulkBlockingRunner(1)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	insertBulkExecution(t, testDB, "fixture-failed", "github.com/bulk/completion-race", "failed", now)
+
+	var rechecks atomic.Int32
+	handler.SetBulkRepositoryStats(func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error) {
+		if rechecks.Add(1) == 1 {
+			insertBulkExecution(t, testDB, "completed-after-api-recheck", "github.com/bulk/completion-race", "completed", now.Add(time.Minute))
+			return map[string]db.RepositoryRunStats{
+				"github.com/bulk/completion-race": {
+					LatestExecutionID: "fixture-failed",
+					LatestStatus:      "failed",
+					LatestStart:       now,
+					TotalRuns:         1,
+				},
+			}, nil
+		}
+		completedEnd := now.Add(2 * time.Minute)
+		return map[string]db.RepositoryRunStats{
+			"github.com/bulk/completion-race": {
+				LatestExecutionID: "completed-after-api-recheck",
+				LatestStatus:      "completed",
+				LatestStart:       now.Add(time.Minute),
+				LatestEnd:         &completedEnd,
+				LastSuccess:       &completedEnd,
+				TotalRuns:         2,
+				SuccessRuns:       1,
+				FailedRuns:        1,
+			},
+		}, nil
+	})
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"completion-race"},"expected_count":1}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, 1, result.Data.Requested)
+	require.Zero(t, result.Data.Queued)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Equal(t, 1, result.Data.NoLongerEligible)
+	require.Zero(t, result.Data.FailedToEnqueue)
+	require.Equal(t, int32(2), rechecks.Load(), "eligibility must be checked again while Executor owns the reservation")
+	require.Equal(t, 2, executionCount(t, testDB), "no redundant pending execution may be persisted")
+}
+
 func TestBulkDoesNotEnqueueAcrossRuntimeConfigGenerations(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	cfg := &config.Config{Repository: []typedef.Repository{{Name: "candidate", URL: "github.com/bulk/candidate"}}}

--- a/internal/server/bulk_jobs_test.go
+++ b/internal/server/bulk_jobs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -71,7 +72,7 @@ func (r *bulkBlockingRunner) close() {
 	r.releaseOnce.Do(func() { close(r.release) })
 }
 
-func newBulkServer(t *testing.T, cfg *config.Config, runner *bulkBlockingRunner) (*db.DB, *executor.Executor, http.Handler) {
+func newBulkServer(t *testing.T, cfg *config.Config, runner *bulkBlockingRunner) (*db.DB, *executor.Executor, *server.TestServer) {
 	t.Helper()
 	testDB, err := db.Initialize(":memory:")
 	require.NoError(t, err)
@@ -114,6 +115,16 @@ func executionCount(t *testing.T, testDB *db.DB) int {
 	var count int
 	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&count))
 	return count
+}
+
+func serveJSON(t *testing.T, handler http.Handler, method, target, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	return resp
 }
 
 func TestBulkExpectedCountConflictHasNoSideEffectsAndOnlyRetryableRepositoriesQueue(t *testing.T) {
@@ -267,6 +278,374 @@ func TestBulkReportsPartialResultsAndRechecksEligibilityAtEnqueueTime(t *testing
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, []string{"github.com/bulk/alpha", "github.com/bulk/echo"}, newlyQueued)
+}
+
+func TestBulkDoesNotEnqueueAcrossRuntimeConfigGenerations(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{{Name: "candidate", URL: "github.com/bulk/candidate"}}}
+	runner := newBulkBlockingRunner(1)
+	testDB, exec, handler := newBulkServer(t, cfg, runner)
+	insertBulkExecution(t, testDB, "fixture-candidate", "github.com/bulk/candidate", "failed", now)
+
+	recheckEntered := make(chan struct{})
+	recheckRelease := make(chan struct{})
+	handler.SetBulkRepositoryStats(func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error) {
+		close(recheckEntered)
+		<-recheckRelease
+		return map[string]db.RepositoryRunStats{
+			"github.com/bulk/candidate": {
+				LatestExecutionID: "fixture-candidate",
+				LatestStatus:      "failed",
+				LatestStart:       now,
+				TotalRuns:         1,
+			},
+		}, nil
+	})
+
+	responseReady := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodPost, "/api/jobs/bulk", bytes.NewBufferString(
+			`{"selector":{"search":"candidate"},"expected_count":1}`,
+		))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		responseReady <- resp
+	}()
+	<-recheckEntered
+	exec.RefreshConfig(&config.Config{Repository: []typedef.Repository{{Name: "replacement", URL: "github.com/bulk/replacement"}}})
+	close(recheckRelease)
+
+	resp := <-responseReady
+	var result bulkResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, 1, result.Data.Requested)
+	require.Zero(t, result.Data.Queued)
+	require.Equal(t, 1, result.Data.NoLongerEligible)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Zero(t, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 1, executionCount(t, testDB))
+}
+
+func TestRepositoryCRUDPublishesExecutorRuntimeSnapshots(t *testing.T) {
+	cfg := &config.Config{Repository: []typedef.Repository{
+		{Name: "old", URL: "github.com/config/old"},
+		{Name: "remove", URL: "github.com/config/remove"},
+	}}
+	runner := newBulkBlockingRunner(1)
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	exec := executor.NewExecutorWithRunners(logger.NewLogger(testDB), testDB, cfg, executor.Runners{Code: runner.run})
+	t.Cleanup(func() {
+		runner.close()
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+	handler := server.NewRepoTestServer(cfg, testDB, exec)
+	generation := exec.RuntimeConfigSnapshot().Generation()
+
+	serveJSON(t, handler, http.MethodPost, "/api/repositories", `{"Name":"created","URL":"github.com/config/created"}`)
+	snapshot := exec.RuntimeConfigSnapshot()
+	require.Greater(t, snapshot.Generation(), generation)
+	_, found := snapshot.Repository("github.com/config/created")
+	require.True(t, found)
+	generation = snapshot.Generation()
+
+	serveJSON(t, handler, http.MethodPut, "/api/repositories/github.com/config/old", `{"URL":"github.com/config/updated"}`)
+	snapshot = exec.RuntimeConfigSnapshot()
+	require.Greater(t, snapshot.Generation(), generation)
+	_, found = snapshot.Repository("github.com/config/old")
+	require.False(t, found)
+	_, found = snapshot.Repository("github.com/config/updated")
+	require.True(t, found)
+	generation = snapshot.Generation()
+
+	serveJSON(t, handler, http.MethodDelete, "/api/repositories/github.com/config/remove", "")
+	snapshot = exec.RuntimeConfigSnapshot()
+	require.Greater(t, snapshot.Generation(), generation)
+	_, found = snapshot.Repository("github.com/config/remove")
+	require.False(t, found)
+}
+
+func TestStorageCRUDPublishesExecutorRuntimeSnapshots(t *testing.T) {
+	cfg := &config.Config{Repository: []typedef.Repository{
+		{Name: "first", URL: "github.com/config/first", Storage: []string{"archive"}},
+		{Name: "second", URL: "github.com/config/second", Storage: []string{"archive"}},
+		{Name: "third", URL: "github.com/config/third", Storage: []string{"archive"}},
+	}}
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	storagesSeen := make(chan []typedef.MultiStorage, 3)
+	exec := executor.NewExecutorWithRunners(logger.NewLogger(testDB), testDB, cfg, executor.Runners{
+		Code: func(_ context.Context, _ typedef.Repository, storages []typedef.MultiStorage) error {
+			storagesSeen <- append([]typedef.MultiStorage(nil), storages...)
+			return nil
+		},
+	})
+	t.Cleanup(func() {
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+	handler := server.NewStorageTestServer(cfg, testDB, exec)
+	generation := exec.RuntimeConfigSnapshot().Generation()
+
+	serveJSON(t, handler, http.MethodPost, "/api/storage", `{"Name":"archive","Type":"file","Path":"one"}`)
+	require.Greater(t, exec.RuntimeConfigSnapshot().Generation(), generation)
+	_, err = exec.ExecuteJob("github.com/config/first")
+	require.NoError(t, err)
+	require.Equal(t, "one", receiveBulkStorages(t, storagesSeen)[0].Path)
+	generation = exec.RuntimeConfigSnapshot().Generation()
+
+	serveJSON(t, handler, http.MethodPut, "/api/storage/archive", `{"Path":"two"}`)
+	require.Greater(t, exec.RuntimeConfigSnapshot().Generation(), generation)
+	_, err = exec.ExecuteJob("github.com/config/second")
+	require.NoError(t, err)
+	require.Equal(t, "two", receiveBulkStorages(t, storagesSeen)[0].Path)
+	generation = exec.RuntimeConfigSnapshot().Generation()
+
+	serveJSON(t, handler, http.MethodDelete, "/api/storage/archive", "")
+	require.Greater(t, exec.RuntimeConfigSnapshot().Generation(), generation)
+	_, err = exec.ExecuteJob("github.com/config/third")
+	require.NoError(t, err)
+	require.Empty(t, receiveBulkStorages(t, storagesSeen))
+}
+
+func TestBulkUserRetryUsesUnicodePrefixIndexAndCountsOneCandidateForMultipleExecutions(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	user := typedef.Repository{Name: "unicode user", URL: "github.com/团队", Type: typedef.TypeUser, OrgName: "团队"}
+	cfg := &config.Config{ConcurrencyNum: 2, Repository: []typedef.Repository{user}}
+	runner := newBulkBlockingRunner(2)
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	exec := executor.NewExecutorWithRunners(logger.NewLogger(testDB), testDB, cfg, executor.Runners{Code: runner.run},
+		func(typedef.Repository) []typedef.Repository {
+			return []typedef.Repository{
+				{Name: "one", URL: "github.com/团队/one"},
+				{Name: "two", URL: "github.com/团队/two"},
+			}
+		},
+	)
+	t.Cleanup(func() {
+		runner.close()
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+	handler := server.NewTestServerWithExecutor(testDB, exec, cfg)
+	insertBulkExecution(t, testDB, "fixture-unicode-member", "github.com/团队/历史", "failed", now)
+	insertBulkExecution(t, testDB, "fixture-prefix-decoy", "github.com/团队0/not-a-member", "failed", now.Add(time.Minute))
+
+	plan, err := handler.BulkRepositoryStatsQueryPlan(context.Background(), user)
+	require.NoError(t, err)
+	require.Contains(t, plan, "idx_executions_repo_start", plan)
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"unicode user"},"expected_count":1}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, 1, result.Data.Requested)
+	require.Equal(t, 1, result.Data.Queued)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Zero(t, result.Data.NoLongerEligible)
+	require.Zero(t, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 4, executionCount(t, testDB), "one user candidate should create two concrete executions")
+	require.NotContains(t, resp.Body.String(), "job_ids")
+}
+
+func TestBulkCancellationAfterRecheckStopsBeforeEnqueueAndAccountsRemainder(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{
+		{Name: "one", URL: "github.com/cancel/one"},
+		{Name: "two", URL: "github.com/cancel/two"},
+		{Name: "three", URL: "github.com/cancel/three"},
+	}}
+	runner := newBulkBlockingRunner(3)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	for _, name := range []string{"one", "two", "three"} {
+		insertBulkExecution(t, testDB, "fixture-cancel-"+name, "github.com/cancel/"+name, "failed", now)
+	}
+
+	recheckEntered := make(chan struct{})
+	recheckRelease := make(chan struct{})
+	var rechecks atomic.Int32
+	handler.SetBulkRepositoryStats(func(_ context.Context, repository typedef.Repository) (map[string]db.RepositoryRunStats, error) {
+		if rechecks.Add(1) == 1 {
+			close(recheckEntered)
+			<-recheckRelease
+		}
+		return map[string]db.RepositoryRunStats{
+			repository.Key(): {
+				LatestExecutionID: "fixture",
+				LatestStatus:      "failed",
+				LatestStart:       now,
+				TotalRuns:         1,
+			},
+		}, nil
+	})
+
+	requestContext, cancel := context.WithCancel(context.Background())
+	responseReady := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodPost, "/api/jobs/bulk", bytes.NewBufferString(
+			`{"selector":{"search":"cancel"},"expected_count":3}`,
+		)).WithContext(requestContext)
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		responseReady <- resp
+	}()
+	<-recheckEntered
+	cancel()
+	close(recheckRelease)
+
+	resp := <-responseReady
+	var result bulkResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, int32(1), rechecks.Load(), "bulk continued rechecking after cancellation")
+	require.Equal(t, 3, result.Data.Requested)
+	require.Zero(t, result.Data.Queued)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Zero(t, result.Data.NoLongerEligible)
+	require.Equal(t, 3, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 3, executionCount(t, testDB))
+}
+
+func TestBulkContextCancelledRecheckStopsAndAccountsRemainderOnce(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{
+		{Name: "one", URL: "github.com/recheck/one"},
+		{Name: "two", URL: "github.com/recheck/two"},
+	}}
+	runner := newBulkBlockingRunner(2)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	for _, name := range []string{"one", "two"} {
+		insertBulkExecution(t, testDB, "fixture-recheck-"+name, "github.com/recheck/"+name, "failed", now)
+	}
+	var rechecks atomic.Int32
+	handler.SetBulkRepositoryStats(func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error) {
+		rechecks.Add(1)
+		return nil, context.Canceled
+	})
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"recheck"},"expected_count":2}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, int32(1), rechecks.Load(), "bulk retried after a context-cancelled database read")
+	require.Equal(t, 2, result.Data.Requested)
+	require.Equal(t, 2, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 2, executionCount(t, testDB))
+}
+
+func TestBulkCountsRepositoryThatBecomesActiveAfterGuardAsSkipped(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{{Name: "candidate", URL: "github.com/race/active"}}}
+	runner := newBulkBlockingRunner(1)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	insertBulkExecution(t, testDB, "fixture-race-failed", "github.com/race/active", "failed", now)
+	handler.SetBulkRepositoryStats(func(_ context.Context, repository typedef.Repository) (map[string]db.RepositoryRunStats, error) {
+		insertBulkExecution(t, testDB, "became-active-after-guard", repository.Key(), "pending", now.Add(-time.Hour))
+		return map[string]db.RepositoryRunStats{
+			repository.Key(): {
+				LatestExecutionID: "fixture-race-failed",
+				LatestStatus:      "failed",
+				LatestStart:       now,
+				TotalRuns:         2,
+			},
+		}, nil
+	})
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"race"},"expected_count":1}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, 1, result.Data.Requested)
+	require.Zero(t, result.Data.Queued)
+	require.Equal(t, 1, result.Data.SkippedActive)
+	require.Zero(t, result.Data.NoLongerEligible)
+	require.Zero(t, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 2, executionCount(t, testDB))
+}
+
+func TestBulkCountsClosedExecutorAsFailedWithoutAbortingResponse(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{{Name: "candidate", URL: "github.com/closed/candidate"}}}
+	runner := newBulkBlockingRunner(1)
+	testDB, exec, handler := newBulkServer(t, cfg, runner)
+	insertBulkExecution(t, testDB, "fixture-closed", "github.com/closed/candidate", "failed", now)
+	require.NoError(t, exec.Close())
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"closed"},"expected_count":1}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, 1, result.Data.Requested)
+	require.Zero(t, result.Data.Queued)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Zero(t, result.Data.NoLongerEligible)
+	require.Equal(t, 1, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 1, executionCount(t, testDB))
+}
+
+func TestBulkContinuesAfterOrdinaryRecheckDatabaseFailure(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{ConcurrencyNum: 1, Repository: []typedef.Repository{
+		{Name: "alpha", URL: "github.com/db-failure/alpha"},
+		{Name: "bravo", URL: "github.com/db-failure/bravo"},
+	}}
+	runner := newBulkBlockingRunner(1)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	for _, name := range []string{"alpha", "bravo"} {
+		insertBulkExecution(t, testDB, "fixture-db-failure-"+name, "github.com/db-failure/"+name, "failed", now)
+	}
+	handler.SetBulkRepositoryStats(func(_ context.Context, repository typedef.Repository) (map[string]db.RepositoryRunStats, error) {
+		if repository.Key() == "github.com/db-failure/alpha" {
+			return nil, errors.New("forced recheck read failure")
+		}
+		return map[string]db.RepositoryRunStats{
+			repository.Key(): {
+				LatestExecutionID: "fixture-db-failure-bravo",
+				LatestStatus:      "failed",
+				LatestStart:       now,
+				TotalRuns:         1,
+			},
+		}, nil
+	})
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"db-failure"},"expected_count":2}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, 2, result.Data.Requested)
+	require.Equal(t, 1, result.Data.Queued)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Zero(t, result.Data.NoLongerEligible)
+	require.Equal(t, 1, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 3, executionCount(t, testDB))
+}
+
+func TestBulkReturnsServerErrorWhenExecutorIsUnavailable(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{{Name: "candidate", URL: "github.com/nil/candidate"}}}
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testDB.Close()) })
+	insertBulkExecution(t, testDB, "fixture-nil", "github.com/nil/candidate", "failed", now)
+	handler := server.NewTestServerWithExecutor(testDB, nil, cfg)
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"nil"},"expected_count":1}`)
+	require.Equal(t, http.StatusInternalServerError, resp.Code, resp.Body.String())
+	require.Equal(t, http.StatusInternalServerError, result.Code)
+	require.Equal(t, 1, executionCount(t, testDB))
+}
+
+func receiveBulkStorages(t *testing.T, calls <-chan []typedef.MultiStorage) []typedef.MultiStorage {
+	t.Helper()
+	select {
+	case storages := <-calls:
+		return storages
+	case <-time.After(3 * time.Second):
+		t.Fatal("executor runner did not receive storage configuration")
+		return nil
+	}
 }
 
 func TestBulkUsesExecutorConcurrencyLimit(t *testing.T) {

--- a/internal/server/bulk_jobs_test.go
+++ b/internal/server/bulk_jobs_test.go
@@ -498,6 +498,32 @@ func TestBulkUserRetryUsesUnicodePrefixIndexAndCountsOneCandidateForMultipleExec
 	require.NotContains(t, resp.Body.String(), "job_ids")
 }
 
+func TestBulkEmptyUserExpansionCountsFailedToEnqueue(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	user := typedef.Repository{Name: "empty user", URL: "github.com/empty", Type: typedef.TypeUser, OrgName: "empty"}
+	cfg := &config.Config{Repository: []typedef.Repository{user}}
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	exec := executor.NewExecutorWithRunners(logger.NewLogger(testDB), testDB, cfg, executor.Runners{},
+		func(typedef.Repository) []typedef.Repository { return nil },
+	)
+	t.Cleanup(func() {
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+	handler := server.NewTestServerWithExecutor(testDB, exec, cfg)
+	insertBulkExecution(t, testDB, "fixture-empty-user", "github.com/empty/history", "failed", now)
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"empty user"},"expected_count":1}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, 1, result.Data.Requested)
+	require.Zero(t, result.Data.Queued)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Zero(t, result.Data.NoLongerEligible)
+	require.Equal(t, 1, result.Data.FailedToEnqueue)
+	require.Equal(t, 1, executionCount(t, testDB), "empty expansion must not persist a pending execution")
+}
+
 func TestBulkCancellationAfterRecheckStopsBeforeEnqueueAndAccountsRemainder(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	cfg := &config.Config{Repository: []typedef.Repository{

--- a/internal/server/bulk_jobs_test.go
+++ b/internal/server/bulk_jobs_test.go
@@ -1,0 +1,318 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/executor"
+	"github.com/wnarutou/gitrieve/internal/logger"
+	"github.com/wnarutou/gitrieve/internal/server"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+)
+
+type bulkResponse struct {
+	Code int `json:"code"`
+	Data struct {
+		ActualCount      int `json:"actual_count"`
+		Requested        int `json:"requested"`
+		Queued           int `json:"queued"`
+		SkippedActive    int `json:"skipped_active"`
+		NoLongerEligible int `json:"no_longer_eligible"`
+		FailedToEnqueue  int `json:"failed_to_enqueue"`
+	} `json:"data"`
+}
+
+type bulkBlockingRunner struct {
+	entered     chan string
+	release     chan struct{}
+	releaseOnce sync.Once
+	running     atomic.Int32
+	maxRunning  atomic.Int32
+}
+
+func newBulkBlockingRunner(capacity int) *bulkBlockingRunner {
+	return &bulkBlockingRunner{
+		entered: make(chan string, capacity),
+		release: make(chan struct{}),
+	}
+}
+
+func (r *bulkBlockingRunner) run(ctx context.Context, repo typedef.Repository, _ []typedef.MultiStorage) error {
+	running := r.running.Add(1)
+	defer r.running.Add(-1)
+	for {
+		maximum := r.maxRunning.Load()
+		if running <= maximum || r.maxRunning.CompareAndSwap(maximum, running) {
+			break
+		}
+	}
+	r.entered <- repo.Key()
+	select {
+	case <-r.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *bulkBlockingRunner) close() {
+	r.releaseOnce.Do(func() { close(r.release) })
+}
+
+func newBulkServer(t *testing.T, cfg *config.Config, runner *bulkBlockingRunner) (*db.DB, *executor.Executor, http.Handler) {
+	t.Helper()
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	exec := executor.NewExecutorWithRunners(logger.NewLogger(testDB), testDB, cfg, executor.Runners{Code: runner.run})
+	t.Cleanup(func() {
+		runner.close()
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+	return testDB, exec, server.NewTestServerWithExecutor(testDB, exec, cfg)
+}
+
+func insertBulkExecution(t *testing.T, testDB *db.DB, id, repoKey, status string, start time.Time) {
+	t.Helper()
+	var end interface{}
+	if status != "pending" && status != "running" {
+		end = start.Add(time.Minute)
+	}
+	_, err := testDB.Exec(`
+		INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`, id, id, repoKey, start, end, status, "fixture error")
+	require.NoError(t, err)
+}
+
+func postBulk(t *testing.T, handler http.Handler, body string) (*httptest.ResponseRecorder, bulkResponse) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/jobs/bulk", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	var decoded bulkResponse
+	if json.Valid(resp.Body.Bytes()) {
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &decoded), resp.Body.String())
+	}
+	return resp, decoded
+}
+
+func executionCount(t *testing.T, testDB *db.DB) int {
+	t.Helper()
+	var count int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions`).Scan(&count))
+	return count
+}
+
+func TestBulkExpectedCountConflictHasNoSideEffectsAndOnlyRetryableRepositoriesQueue(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{
+		ConcurrencyNum:     1,
+		SyncOverdueGrace:   30 * time.Minute,
+		SyncStuckThreshold: time.Hour,
+		Repository: []typedef.Repository{
+			{Name: "Zulu Failed", URL: "github.com/bulk/failed"},
+			{Name: "alpha Cancelled", URL: "github.com/bulk/cancelled"},
+			{Name: "mike Overdue", URL: "github.com/bulk/overdue", Cron: "@every 1h"},
+			{Name: "d Healthy", URL: "github.com/bulk/healthy", Cron: "@every 1h"},
+			{Name: "e Never", URL: "github.com/bulk/never"},
+			{Name: "f Pending", URL: "github.com/bulk/pending"},
+			{Name: "g Running", URL: "github.com/bulk/running"},
+			{Name: "h Stuck", URL: "github.com/bulk/stuck"},
+		},
+	}
+	runner := newBulkBlockingRunner(3)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	insertBulkExecution(t, testDB, "fixture-failed", "github.com/bulk/failed", "failed", now.Add(-10*time.Minute))
+	insertBulkExecution(t, testDB, "fixture-cancelled", "github.com/bulk/cancelled", "cancelled", now.Add(-9*time.Minute))
+	insertBulkExecution(t, testDB, "fixture-overdue", "github.com/bulk/overdue", "completed", now.Add(-3*time.Hour))
+	insertBulkExecution(t, testDB, "fixture-healthy", "github.com/bulk/healthy", "completed", now.Add(-10*time.Minute))
+	insertBulkExecution(t, testDB, "fixture-pending", "github.com/bulk/pending", "pending", now.Add(-8*time.Minute))
+	insertBulkExecution(t, testDB, "fixture-running", "github.com/bulk/running", "running", now.Add(-7*time.Minute))
+	insertBulkExecution(t, testDB, "fixture-stuck", "github.com/bulk/stuck", "running", now.Add(-2*time.Hour))
+
+	before := executionCount(t, testDB)
+	conflictRecorder, conflict := postBulk(t, handler, `{"selector":{"search":"bulk","health":""},"expected_count":2}`)
+	require.Equal(t, http.StatusConflict, conflictRecorder.Code, conflictRecorder.Body.String())
+	require.Equal(t, http.StatusConflict, conflict.Code)
+	require.Equal(t, 3, conflict.Data.ActualCount)
+	require.Equal(t, before, executionCount(t, testDB), "count conflict created executions")
+
+	acceptedRecorder, accepted := postBulk(t, handler, `{"selector":{"search":"bulk","health":""},"expected_count":3}`)
+	require.Equal(t, http.StatusOK, acceptedRecorder.Code, acceptedRecorder.Body.String())
+	require.Equal(t, http.StatusOK, accepted.Code)
+	require.Equal(t, 3, accepted.Data.Requested)
+	require.Equal(t, 3, accepted.Data.Queued)
+	require.Zero(t, accepted.Data.SkippedActive)
+	require.Zero(t, accepted.Data.NoLongerEligible)
+	require.Zero(t, accepted.Data.FailedToEnqueue)
+	require.Equal(t, accepted.Data.Requested, accepted.Data.Queued+accepted.Data.SkippedActive+accepted.Data.NoLongerEligible+accepted.Data.FailedToEnqueue)
+	require.NotContains(t, acceptedRecorder.Body.String(), "job_ids")
+	require.NotContains(t, acceptedRecorder.Body.String(), "repository_ids")
+
+	rows, err := testDB.Query(`SELECT repo_key FROM executions WHERE id NOT LIKE 'fixture-%' ORDER BY rowid`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var queued []string
+	for rows.Next() {
+		var key string
+		require.NoError(t, rows.Scan(&key))
+		queued = append(queued, key)
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, []string{
+		"github.com/bulk/cancelled",
+		"github.com/bulk/overdue",
+		"github.com/bulk/failed",
+	}, queued)
+}
+
+func TestBulkRejectsMalformedRequestsBeforeCreatingExecutions(t *testing.T) {
+	cfg := &config.Config{Repository: []typedef.Repository{{Name: "failed", URL: "github.com/bulk/failed"}}}
+	runner := newBulkBlockingRunner(1)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	insertBulkExecution(t, testDB, "fixture-failed", "github.com/bulk/failed", "failed", time.Now().Add(-time.Minute))
+
+	for _, body := range []string{
+		`{}`,
+		`{"selector":null,"expected_count":0}`,
+		`{"selector":{},"expected_count":null}`,
+		`{"selector":{},"expected_count":-1}`,
+		`{"selector":{"health":"unknown"},"expected_count":0}`,
+		`{"selector":{"overdue":"true"},"expected_count":0}`,
+		`{"selector":{"overdue":null},"expected_count":0}`,
+		`{"selector":{"stuck":true},"expected_count":0}`,
+		`{"selector":{"repository_ids":["github.com/bulk/failed"]},"expected_count":1}`,
+		`{"selector":{},"expected_count":0,"unexpected":true}`,
+		`{"selector":{},"expected_count":0}{}`,
+	} {
+		before := executionCount(t, testDB)
+		resp, result := postBulk(t, handler, body)
+		require.Equal(t, http.StatusBadRequest, resp.Code, "body %s: %s", body, resp.Body.String())
+		require.Equal(t, http.StatusBadRequest, result.Code, "body %s: %s", body, resp.Body.String())
+		require.Equal(t, before, executionCount(t, testDB), "body %s created an execution", body)
+	}
+}
+
+func TestBulkReportsPartialResultsAndRechecksEligibilityAtEnqueueTime(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{
+		ConcurrencyNum: 1,
+		Repository: []typedef.Repository{
+			{Name: "Alpha queued", URL: "github.com/bulk/alpha"},
+			{Name: "bravo active", URL: "github.com/bulk/bravo"},
+			{Name: "Charlie changes", URL: "github.com/bulk/charlie"},
+			{Name: "delta broken", URL: "github.com/bulk/delta"},
+			{Name: "Echo queued", URL: "github.com/bulk/echo"},
+		},
+	}
+	runner := newBulkBlockingRunner(2)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	for _, key := range []string{"alpha", "bravo", "charlie", "delta", "echo"} {
+		insertBulkExecution(t, testDB, "fixture-failed-"+key, "github.com/bulk/"+key, "failed", now)
+	}
+	insertBulkExecution(t, testDB, "fixture-active-bravo", "github.com/bulk/bravo", "pending", now.Add(-time.Hour))
+	_, err := testDB.Exec(`
+		CREATE TRIGGER make_charlie_healthy_after_alpha
+		AFTER INSERT ON executions
+		WHEN NEW.repo_key = 'github.com/bulk/alpha' AND NEW.status = 'pending'
+		BEGIN
+			INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status)
+			VALUES ('became-healthy-charlie', 'charlie', 'github.com/bulk/charlie',
+			        '2099-01-01T00:00:00Z', '2099-01-01T00:01:00Z', 'completed');
+		END;
+		CREATE TRIGGER reject_delta_enqueue
+		BEFORE INSERT ON executions
+		WHEN NEW.repo_key = 'github.com/bulk/delta' AND NEW.status = 'pending'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced bulk enqueue failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"bulk"},"expected_count":5}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, http.StatusOK, result.Code)
+	require.Equal(t, 5, result.Data.Requested)
+	require.Equal(t, 2, result.Data.Queued)
+	require.Equal(t, 1, result.Data.SkippedActive)
+	require.Equal(t, 1, result.Data.NoLongerEligible)
+	require.Equal(t, 1, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.NotContains(t, resp.Body.String(), "job_ids")
+
+	var newlyQueued []string
+	rows, err := testDB.Query(`
+		SELECT repo_key FROM executions
+		WHERE id NOT LIKE 'fixture-%' AND id <> 'became-healthy-charlie'
+		ORDER BY rowid`)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var key string
+		require.NoError(t, rows.Scan(&key))
+		newlyQueued = append(newlyQueued, key)
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, []string{"github.com/bulk/alpha", "github.com/bulk/echo"}, newlyQueued)
+}
+
+func TestBulkUsesExecutorConcurrencyLimit(t *testing.T) {
+	repositories := make([]typedef.Repository, 6)
+	for i := range repositories {
+		repositories[i] = typedef.Repository{
+			Name: fmt.Sprintf("repo-%d", i),
+			URL:  fmt.Sprintf("github.com/bulk/repo-%d", i),
+		}
+	}
+	cfg := &config.Config{ConcurrencyNum: 2, Repository: repositories}
+	runner := newBulkBlockingRunner(len(repositories))
+	testDB, exec, handler := newBulkServer(t, cfg, runner)
+	now := time.Now().UTC().Truncate(time.Second)
+	for i := range repositories {
+		insertBulkExecution(t, testDB, fmt.Sprintf("fixture-%d", i), repositories[i].Key(), "failed", now)
+	}
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"github.com/bulk/repo"},"expected_count":6}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, http.StatusOK, result.Code)
+	require.Equal(t, 6, result.Data.Requested)
+	require.Equal(t, 6, result.Data.Queued)
+
+	started := []string{receiveBulkRunner(t, runner.entered), receiveBulkRunner(t, runner.entered)}
+	sort.Strings(started)
+	require.Equal(t, []string{"github.com/bulk/repo-0", "github.com/bulk/repo-1"}, started)
+	var pending, running int
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions WHERE status = 'pending'`).Scan(&pending))
+	require.NoError(t, testDB.QueryRow(`SELECT COUNT(*) FROM executions WHERE status = 'running'`).Scan(&running))
+	require.Equal(t, 4, pending)
+	require.Equal(t, 2, running)
+	require.Equal(t, int32(2), runner.running.Load())
+
+	runner.close()
+	require.NoError(t, exec.Close())
+	require.Equal(t, int32(2), runner.maxRunning.Load())
+}
+
+func receiveBulkRunner(t *testing.T, entered <-chan string) string {
+	t.Helper()
+	select {
+	case key := <-entered:
+		return key
+	case <-time.After(3 * time.Second):
+		t.Fatal("bulk runner did not start")
+		return ""
+	}
+}

--- a/internal/server/bulk_jobs_test.go
+++ b/internal/server/bulk_jobs_test.go
@@ -567,6 +567,190 @@ func TestBulkCountsRepositoryThatBecomesActiveAfterGuardAsSkipped(t *testing.T) 
 	require.Equal(t, 2, executionCount(t, testDB))
 }
 
+func TestBulkCountsRepositoryMissingAtEnqueueAsNoLongerEligible(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{{Name: "candidate", URL: "github.com/race/missing"}}}
+	runner := newBulkBlockingRunner(1)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	insertBulkExecution(t, testDB, "fixture-race-missing", "github.com/race/missing", "failed", now)
+	handler.SetBulkExecute(func(context.Context, string, uint64) ([]string, error) {
+		return nil, executor.ErrRepositoryNotFound
+	})
+
+	resp, result := postBulk(t, handler, `{"selector":{"search":"candidate"},"expected_count":1}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, 1, result.Data.Requested)
+	require.Zero(t, result.Data.Queued)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Equal(t, 1, result.Data.NoLongerEligible)
+	require.Zero(t, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 1, executionCount(t, testDB))
+}
+
+func TestBulkCancellationDuringEnqueueStopsAndAccountsUntouchedRemainder(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{Repository: []typedef.Repository{
+		{Name: "one", URL: "github.com/enqueue-cancel/one"},
+		{Name: "two", URL: "github.com/enqueue-cancel/two"},
+		{Name: "three", URL: "github.com/enqueue-cancel/three"},
+	}}
+	runner := newBulkBlockingRunner(3)
+	testDB, _, handler := newBulkServer(t, cfg, runner)
+	for _, name := range []string{"one", "two", "three"} {
+		insertBulkExecution(t, testDB, "fixture-enqueue-cancel-"+name, "github.com/enqueue-cancel/"+name, "failed", now)
+	}
+
+	enqueueEntered := make(chan struct{})
+	var enqueueCalls atomic.Int32
+	handler.SetBulkExecute(func(ctx context.Context, _ string, _ uint64) ([]string, error) {
+		enqueueCalls.Add(1)
+		close(enqueueEntered)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	requestContext, cancel := context.WithCancel(context.Background())
+	responseReady := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodPost, "/api/jobs/bulk", bytes.NewBufferString(
+			`{"selector":{"search":"enqueue-cancel"},"expected_count":3}`,
+		)).WithContext(requestContext)
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		responseReady <- resp
+	}()
+	<-enqueueEntered
+	cancel()
+
+	resp := <-responseReady
+	var result bulkResponse
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &result))
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Equal(t, int32(1), enqueueCalls.Load())
+	require.Equal(t, 3, result.Data.Requested)
+	require.Zero(t, result.Data.Queued)
+	require.Zero(t, result.Data.SkippedActive)
+	require.Zero(t, result.Data.NoLongerEligible)
+	require.Equal(t, 3, result.Data.FailedToEnqueue)
+	require.Equal(t, result.Data.Requested, result.Data.Queued+result.Data.SkippedActive+result.Data.NoLongerEligible+result.Data.FailedToEnqueue)
+	require.Equal(t, 3, executionCount(t, testDB))
+}
+
+func TestConcurrentConfigMutationAndBulkSnapshotUseIsRaceSafe(t *testing.T) {
+	path := t.TempDir() + "/config.yaml"
+	writeFile(t, path, `repository:
+  - name: base
+    url: github.com/race/base
+  - name: update-target
+    url: github.com/race/update-target
+  - name: delete-target
+    url: github.com/race/delete-target
+storage:
+  - name: update-target
+    type: file
+    path: old
+  - name: delete-target
+    type: file
+    path: old
+`)
+	config.Path = path
+	config.Init()
+	t.Cleanup(func() { config.Path = "" })
+
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	cfg := config.GetIns()
+	exec := executor.NewExecutorWithRunners(logger.NewLogger(testDB), testDB, cfg, executor.Runners{})
+	t.Cleanup(func() {
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+	handler := server.NewConfigConcurrencyTestServer(cfg, testDB, exec)
+
+	requestStatus := func(method, path, body string) int {
+		req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, req)
+		return resp.Code
+	}
+	importDocument, err := json.Marshal(map[string]interface{}{
+		"config": "repository:\n  - name: base-imported\n    url: github.com/race/base\n",
+	})
+	require.NoError(t, err)
+
+	start := make(chan struct{})
+	failures := make(chan string, 140)
+	var workers sync.WaitGroup
+	workers.Add(4)
+	go func() {
+		defer workers.Done()
+		<-start
+		for index := 0; index < 20; index++ {
+			body := fmt.Sprintf(`{"Name":"repo-%d","URL":"github.com/race/repo-%d"}`, index, index)
+			if status := requestStatus(http.MethodPost, "/api/repositories", body); status != http.StatusOK {
+				failures <- fmt.Sprintf("create repository %d returned %d", index, status)
+			}
+		}
+		crudRequests := []struct {
+			method string
+			path   string
+			body   string
+		}{
+			{http.MethodPut, "/api/repositories/github.com/race/update-target", `{"Name":"updated"}`},
+			{http.MethodDelete, "/api/repositories/github.com/race/delete-target", ""},
+			{http.MethodPost, "/api/storage", `{"Name":"created-storage","Type":"file","Path":"one"}`},
+			{http.MethodPut, "/api/storage/update-target", `{"Path":"two"}`},
+			{http.MethodDelete, "/api/storage/delete-target", ""},
+		}
+		for _, request := range crudRequests {
+			if status := requestStatus(request.method, request.path, request.body); status != http.StatusOK {
+				failures <- fmt.Sprintf("%s %s returned %d", request.method, request.path, status)
+			}
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		<-start
+		for index := 0; index < 10; index++ {
+			if status := requestStatus(http.MethodPost, "/api/config/import", string(importDocument)); status != http.StatusOK {
+				failures <- fmt.Sprintf("import %d returned %d", index, status)
+			}
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		<-start
+		for index := 0; index < 10; index++ {
+			if status := requestStatus(http.MethodPost, "/api/config/reload", ""); status != http.StatusOK {
+				failures <- fmt.Sprintf("reload %d returned %d", index, status)
+			}
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		<-start
+		for index := 0; index < 100; index++ {
+			if status := requestStatus(http.MethodPost, "/api/jobs/bulk", `{"selector":{},"expected_count":0}`); status != http.StatusOK {
+				failures <- fmt.Sprintf("bulk %d returned %d", index, status)
+			}
+			snapshot := handler.Cfg()
+			if snapshot == nil || len(snapshot.Repository) == 0 {
+				failures <- "observed empty API config snapshot"
+			}
+		}
+	}()
+	close(start)
+	workers.Wait()
+	close(failures)
+	for failure := range failures {
+		require.Fail(t, failure)
+	}
+}
+
 func TestBulkCountsClosedExecutorAsFailedWithoutAbortingResponse(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	cfg := &config.Config{Repository: []typedef.Repository{{Name: "candidate", URL: "github.com/closed/candidate"}}}

--- a/internal/server/config_api.go
+++ b/internal/server/config_api.go
@@ -315,9 +315,9 @@ func (a *API) PreviewImport(c *gin.Context) {
 // ApplyImport applies a previously-previewed import. Choices select, per entry,
 // whether the imported or the existing value wins; entries without a choice use
 // the documented defaults (added/modified/globals/server -> imported, deleted ->
-// keep). Builds a complete replacement config and publishes it atomically, then
-// persists via config.Save(); the server section is written to viper (never
-// hot-applied).
+// keep). Builds a complete replacement config, then publishes, persists, and
+// refreshes schedules as one serialized generation. The server section is
+// written to viper but never hot-applied.
 func (a *API) ApplyImport(c *gin.Context) {
 	var req ImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -334,20 +334,14 @@ func (a *API) ApplyImport(c *gin.Context) {
 		return
 	}
 
-	result := a.applyImport(doc, &req)
-	published := a.configSnapshot()
-
-	msg := ""
-	if err := config.Save(); err != nil {
-		msg = "配置已应用（内存）但未能持久化: " + err.Error()
-	}
-	msg = joinMessages(msg, a.refreshSchedules(published))
+	a.configMu.Lock()
+	result, next := a.applyImportLocked(doc, &req)
+	_, msg := a.publishPersistAndRefreshConfigLocked(next, "配置已应用（内存）但未能持久化: ")
+	a.configMu.Unlock()
 	c.JSON(http.StatusOK, Response{Code: 200, Data: result, Message: msg})
 }
 
-func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportResult {
-	a.configMu.Lock()
-	defer a.configMu.Unlock()
+func (a *API) applyImportLocked(doc *config.ExportConfig, req *ImportRequest) (ImportResult, *config.Config) {
 	var result ImportResult
 	// Build a NEW config instance instead of mutating a.config in place: job
 	// goroutines read a.config / ins / e.cfg.Load() concurrently, and atomic
@@ -549,13 +543,9 @@ func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportRe
 		result.ServerUpdated++
 	}
 
-	// Publish the fully-built replacement in one place: repoint the API, the
-	// package-global ins (which config.Save() reads), and the executor's atomic
-	// pointer. Concurrent readers (job goroutines) observe either the complete
-	// old or the complete new instance, never a torn one.
-	a.publishConfigLocked(&next)
-
-	return result
+	// The caller publishes this fully-built replacement only after every
+	// selected section has been applied.
+	return result, &next
 }
 
 // ReloadConfig re-reads config.yaml from disk, repoints the API and executor at
@@ -568,7 +558,7 @@ func (a *API) ReloadConfig(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, Response{Code: 400, Message: "重载配置失败: " + err.Error()})
 		return
 	}
-	published := a.publishConfigLocked(config.GetIns())
+	_, message := a.publishPersistAndRefreshConfigLocked(config.GetIns(), "配置已重载（内存）但未能持久化: ")
 	a.configMu.Unlock()
-	c.JSON(http.StatusOK, Response{Code: 200, Data: gin.H{}, Message: a.refreshSchedules(published)})
+	c.JSON(http.StatusOK, Response{Code: 200, Data: gin.H{}, Message: message})
 }

--- a/internal/server/config_api.go
+++ b/internal/server/config_api.go
@@ -553,12 +553,12 @@ func (a *API) applyImportLocked(doc *config.ExportConfig, req *ImportRequest) (I
 // The `server:` section is NOT hot-applied and still requires a restart.
 func (a *API) ReloadConfig(c *gin.Context) {
 	a.configMu.Lock()
-	if err := config.Reload(); err != nil {
+	if err := a.reloadConfig(); err != nil {
 		a.configMu.Unlock()
 		c.JSON(http.StatusBadRequest, Response{Code: 400, Message: "重载配置失败: " + err.Error()})
 		return
 	}
-	_, message := a.publishPersistAndRefreshConfigLocked(config.GetIns(), "配置已重载（内存）但未能持久化: ")
+	_, message := a.publishAndRefreshConfigLocked(config.GetIns())
 	a.configMu.Unlock()
 	c.JSON(http.StatusOK, Response{Code: 200, Data: gin.H{}, Message: message})
 }

--- a/internal/server/config_api.go
+++ b/internal/server/config_api.go
@@ -263,7 +263,7 @@ func buildWarnings(serverChanges []FieldChange) []string {
 // ExportConfig returns the full current config as YAML, usable directly as
 // config.yaml (secrets in plaintext — the export is the source of truth).
 func (a *API) ExportConfig(c *gin.Context) {
-	yamlStr, err := config.ExportFrom(a.config)
+	yamlStr, err := config.ExportFrom(a.configSnapshot())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, Response{Code: 500, Message: "导出配置失败: " + err.Error()})
 		return
@@ -290,9 +290,10 @@ func (a *API) PreviewImport(c *gin.Context) {
 	}
 
 	curServer := config.GetServerSection()
-	repos := diffRepositories(a.config.Repository, doc.Repository)
-	storages := diffStorages(a.config.Storage, doc.Storage)
-	globals := diffGlobals(a.config, doc)
+	current := a.configSnapshot()
+	repos := diffRepositories(current.Repository, doc.Repository)
+	storages := diffStorages(current.Storage, doc.Storage)
+	globals := diffGlobals(current, doc)
 	serverChanges := diffServer(curServer, doc.Server)
 
 	data := ImportPreviewData{
@@ -334,16 +335,19 @@ func (a *API) ApplyImport(c *gin.Context) {
 	}
 
 	result := a.applyImport(doc, &req)
+	published := a.configSnapshot()
 
 	msg := ""
 	if err := config.Save(); err != nil {
 		msg = "配置已应用（内存）但未能持久化: " + err.Error()
 	}
-	msg = joinMessages(msg, a.refreshSchedules())
+	msg = joinMessages(msg, a.refreshSchedules(published))
 	c.JSON(http.StatusOK, Response{Code: 200, Data: result, Message: msg})
 }
 
 func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportResult {
+	a.configMu.Lock()
+	defer a.configMu.Unlock()
 	var result ImportResult
 	// Build a NEW config instance instead of mutating a.config in place: job
 	// goroutines read a.config / ins / e.cfg.Load() concurrently, and atomic
@@ -352,7 +356,8 @@ func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportRe
 	// built kept/keptSt arrays and writes scalar globals, never mutating shared
 	// backing arrays or nested objects. The new instance is published once it is
 	// fully built (see the publish block before return).
-	next := *a.config
+	current := config.Clone(a.config)
+	next := *current
 	choice := func(m map[string]string, key string, def string) string {
 		if v, ok := m[key]; ok {
 			return v
@@ -363,7 +368,7 @@ func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportRe
 	// Recompute the classification so choices apply only to the classes the
 	// user actually saw in the preview (modified / deleted). This reads the
 	// current config before any merge.
-	repoDiff := diffRepositories(a.config.Repository, doc.Repository)
+	repoDiff := diffRepositories(current.Repository, doc.Repository)
 	modifiedRepos := map[string]bool{}
 	deletedRepos := map[string]bool{}
 	for _, e := range repoDiff.Modified {
@@ -372,7 +377,7 @@ func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportRe
 	for _, e := range repoDiff.Deleted {
 		deletedRepos[e.Key] = true
 	}
-	stDiff := diffStorages(a.config.Storage, doc.Storage)
+	stDiff := diffStorages(current.Storage, doc.Storage)
 	modifiedStorages := map[string]bool{}
 	deletedStorages := map[string]bool{}
 	for _, e := range stDiff.Modified {
@@ -548,11 +553,7 @@ func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportRe
 	// package-global ins (which config.Save() reads), and the executor's atomic
 	// pointer. Concurrent readers (job goroutines) observe either the complete
 	// old or the complete new instance, never a torn one.
-	a.config = &next
-	config.SetIns(&next)
-	if a.executor != nil {
-		a.executor.RefreshConfig(&next)
-	}
+	a.publishConfigLocked(&next)
 
 	return result
 }
@@ -561,13 +562,13 @@ func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportRe
 // the fresh config instance, and replaces the running server's cron schedules.
 // The `server:` section is NOT hot-applied and still requires a restart.
 func (a *API) ReloadConfig(c *gin.Context) {
+	a.configMu.Lock()
 	if err := config.Reload(); err != nil {
+		a.configMu.Unlock()
 		c.JSON(http.StatusBadRequest, Response{Code: 400, Message: "重载配置失败: " + err.Error()})
 		return
 	}
-	a.config = config.GetIns()
-	if a.executor != nil {
-		a.executor.RefreshConfig(config.GetIns())
-	}
-	c.JSON(http.StatusOK, Response{Code: 200, Data: gin.H{}, Message: a.refreshSchedules()})
+	published := a.publishConfigLocked(config.GetIns())
+	a.configMu.Unlock()
+	c.JSON(http.StatusOK, Response{Code: 200, Data: gin.H{}, Message: a.refreshSchedules(published)})
 }

--- a/internal/server/config_api.go
+++ b/internal/server/config_api.go
@@ -553,12 +553,14 @@ func (a *API) applyImportLocked(doc *config.ExportConfig, req *ImportRequest) (I
 // The `server:` section is NOT hot-applied and still requires a restart.
 func (a *API) ReloadConfig(c *gin.Context) {
 	a.configMu.Lock()
-	if err := a.reloadConfig(); err != nil {
+	snapshot, err := a.readReloadSnapshot()
+	if err != nil {
 		a.configMu.Unlock()
 		c.JSON(http.StatusBadRequest, Response{Code: 400, Message: "重载配置失败: " + err.Error()})
 		return
 	}
-	_, message := a.publishAndRefreshConfigLocked(config.GetIns())
+	published := a.publishReloadConfigLocked(snapshot)
+	message := a.refreshSchedules(published)
 	a.configMu.Unlock()
 	c.JSON(http.StatusOK, Response{Code: 200, Data: gin.H{}, Message: message})
 }

--- a/internal/server/config_api.go
+++ b/internal/server/config_api.go
@@ -206,6 +206,8 @@ func diffGlobals(cur *config.Config, imp *config.ExportConfig) []FieldChange {
 		{"releaseNumLimit", cur.ReleaseNumLimit, imp.ReleaseNumLimit},
 		{"retryMaxCount", cur.RetryMaxCount, imp.RetryMaxCount},
 		{"retryBaseDelay", cur.RetryBaseDelay.String(), time.Duration(imp.RetryBaseDelay).String()},
+		{"syncOverdueGrace", cur.SyncOverdueGrace.String(), time.Duration(imp.SyncOverdueGrace).String()},
+		{"syncStuckThreshold", cur.SyncStuckThreshold.String(), time.Duration(imp.SyncStuckThreshold).String()},
 		{"githubApiConcurrency", cur.GitHubAPIConcurrency, imp.GitHubAPIConcurrency},
 		{"githubMinRequestInterval", cur.GitHubMinRequestInterval.String(), time.Duration(imp.GitHubMinRequestInterval).String()},
 		{"githubLowRemainingThreshold", cur.GitHubLowRemainingThreshold, imp.GitHubLowRemainingThreshold},
@@ -479,6 +481,20 @@ func (a *API) applyImport(doc *config.ExportConfig, req *ImportRequest) ImportRe
 		d := time.Duration(doc.RetryBaseDelay)
 		if next.RetryBaseDelay != d {
 			next.RetryBaseDelay = d
+			result.GlobalsUpdated++
+		}
+	}
+	if choice(req.Choices.GlobalChoices, "syncOverdueGrace", "imported") == "imported" {
+		d := time.Duration(doc.SyncOverdueGrace)
+		if next.SyncOverdueGrace != d {
+			next.SyncOverdueGrace = d
+			result.GlobalsUpdated++
+		}
+	}
+	if choice(req.Choices.GlobalChoices, "syncStuckThreshold", "imported") == "imported" {
+		d := time.Duration(doc.SyncStuckThreshold)
+		if next.SyncStuckThreshold != d {
+			next.SyncStuckThreshold = d
 			result.GlobalsUpdated++
 		}
 	}

--- a/internal/server/config_api_test.go
+++ b/internal/server/config_api_test.go
@@ -410,12 +410,23 @@ func TestReloadConfig(t *testing.T) {
 	s := server.NewConfigTestServer(config.GetIns(), testDB, refresher)
 	require.Equal(t, "one", s.Cfg().Repository[0].Name)
 
-	writeFile(t, path, "repository:\n  - name: two\n    url: github.com/two/repo\n    cron: '@every 1m'\n")
+	onDisk := []byte("# this is the generation Reload must publish\nrepository:\n  - name: two\n    url: github.com/two/repo\n    cron: '@every 1m'\n")
+	require.NoError(t, os.WriteFile(path, onDisk, 0o644))
+	afterRead := []byte("# operator edit made after Reload read the file\nrepository:\n  - name: three\n    url: github.com/three/repo\n")
+	s.SetReloadConfig(func() error {
+		if err := config.Reload(); err != nil {
+			return err
+		}
+		return os.WriteFile(path, afterRead, 0o644)
+	})
 	code, _ := getJSON(t, s, http.MethodPost, "/api/config/reload", "")
 	require.Equal(t, 200, code)
 	require.Equal(t, "two", s.Cfg().Repository[0].Name)
 	require.Len(t, refresher.configs, 1)
 	require.Equal(t, "@every 1m", refresher.configs[0].Repository[0].Cron)
+	afterReload, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, afterRead, afterReload, "reload must not overwrite bytes edited after its read")
 }
 
 func TestConfigSnapshotAccessorCannotMutatePublishedAPIConfig(t *testing.T) {

--- a/internal/server/config_api_test.go
+++ b/internal/server/config_api_test.go
@@ -418,6 +418,26 @@ func TestReloadConfig(t *testing.T) {
 	require.Equal(t, "@every 1m", refresher.configs[0].Repository[0].Cron)
 }
 
+func TestConfigSnapshotAccessorCannotMutatePublishedAPIConfig(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+	cfg := &config.Config{Repository: []typedef.Repository{{
+		Name:    "original",
+		URL:     "github.com/acme/original",
+		Storage: []string{"archive"},
+	}}}
+	s := server.NewConfigTestServer(cfg, testDB)
+
+	snapshot := s.Cfg()
+	snapshot.Repository[0].Name = "caller mutation"
+	snapshot.Repository[0].Storage[0] = "caller mutation"
+
+	actual := s.Cfg()
+	require.Equal(t, "original", actual.Repository[0].Name)
+	require.Equal(t, []string{"archive"}, actual.Repository[0].Storage)
+}
+
 func TestReloadConfigKeepsOldOnError(t *testing.T) {
 	path := t.TempDir() + "/config.yaml"
 	writeFile(t, path, "repository:\n  - name: one\n    url: github.com/one/repo\n")

--- a/internal/server/config_api_test.go
+++ b/internal/server/config_api_test.go
@@ -112,6 +112,8 @@ func TestPreviewImportDiff(t *testing.T) {
 		ReleaseSizeLimit:            300000000,
 		ReleaseNumLimit:             3,
 		RetryMaxCount:               3,
+		SyncOverdueGrace:            config.DefaultSyncOverdueGrace,
+		SyncStuckThreshold:          config.DefaultSyncStuckThreshold,
 		GitHubAPIConcurrency:        2,
 		GitHubMinRequestInterval:    200 * time.Millisecond,
 		GitHubLowRemainingThreshold: 100,
@@ -206,6 +208,35 @@ server:
 	// Server section changed -> warning present.
 	warnings := data["warnings"].([]interface{})
 	require.Len(t, warnings, 1)
+}
+
+func TestPreviewAndApplyImportSyncHealthGlobals(t *testing.T) {
+	path := t.TempDir() + "/config.yaml"
+	writeFile(t, path, "repository:\n  - name: one\n    url: github.com/one/repo\nsyncOverdueGrace: 20m\nsyncStuckThreshold: 8h\n")
+	config.Path = path
+	config.Init()
+	t.Cleanup(func() { config.Path = "" })
+
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+	s := server.NewConfigTestServer(config.GetIns(), testDB)
+
+	importYAML := "repository:\n  - name: one\n    url: github.com/one/repo\nsyncOverdueGrace: 45m\nsyncStuckThreshold: 12h\n"
+	body, err := json.Marshal(map[string]string{"config": importYAML})
+	require.NoError(t, err)
+
+	code, resp := getJSON(t, s, http.MethodPost, "/api/config/import/preview", string(body))
+	require.Equal(t, http.StatusOK, code)
+	summary := resp["data"].(map[string]interface{})["summary"].(map[string]interface{})
+	require.Equal(t, float64(2), summary["globals"].(map[string]interface{})["changed"])
+
+	code, resp = getJSON(t, s, http.MethodPost, "/api/config/import", string(body))
+	require.Equal(t, http.StatusOK, code)
+	result := resp["data"].(map[string]interface{})
+	require.Equal(t, float64(2), result["globals_updated"])
+	require.Equal(t, 45*time.Minute, s.Cfg().SyncOverdueGrace)
+	require.Equal(t, 12*time.Hour, s.Cfg().SyncStuckThreshold)
 }
 
 func TestApplyImportGitHubAPIGlobals(t *testing.T) {

--- a/internal/server/config_api_test.go
+++ b/internal/server/config_api_test.go
@@ -413,11 +413,12 @@ func TestReloadConfig(t *testing.T) {
 	onDisk := []byte("# this is the generation Reload must publish\nrepository:\n  - name: two\n    url: github.com/two/repo\n    cron: '@every 1m'\n")
 	require.NoError(t, os.WriteFile(path, onDisk, 0o644))
 	afterRead := []byte("# operator edit made after Reload read the file\nrepository:\n  - name: three\n    url: github.com/three/repo\n")
-	s.SetReloadConfig(func() error {
-		if err := config.Reload(); err != nil {
-			return err
+	s.SetReadReloadSnapshot(func() (*config.ReloadSnapshot, error) {
+		snapshot, err := config.ReadReloadSnapshot()
+		if err != nil {
+			return nil, err
 		}
-		return os.WriteFile(path, afterRead, 0o644)
+		return snapshot, os.WriteFile(path, afterRead, 0o644)
 	})
 	code, _ := getJSON(t, s, http.MethodPost, "/api/config/reload", "")
 	require.Equal(t, 200, code)

--- a/internal/server/config_publication_test.go
+++ b/internal/server/config_publication_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/executor"
+	"github.com/wnarutou/gitrieve/internal/logger"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+)
+
+type generationBlockingScheduleRefresher struct {
+	api          *API
+	firstRelease chan struct{}
+	entered      chan int
+	calls        atomic.Int32
+	outsideLock  atomic.Bool
+
+	mu      sync.Mutex
+	configs []*config.Config
+}
+
+func (r *generationBlockingScheduleRefresher) RefreshSchedules(cfg *config.Config) error {
+	if r.api.configMu.TryLock() {
+		r.outsideLock.Store(true)
+		r.api.configMu.Unlock()
+	}
+	call := int(r.calls.Add(1))
+	if call == 1 {
+		r.entered <- call
+		<-r.firstRelease
+	}
+	r.mu.Lock()
+	r.configs = append(r.configs, config.Clone(cfg))
+	r.mu.Unlock()
+	if call != 1 {
+		r.entered <- call
+	}
+	return nil
+}
+
+func (r *generationBlockingScheduleRefresher) lastConfig() *config.Config {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.configs) == 0 {
+		return nil
+	}
+	return config.Clone(r.configs[len(r.configs)-1])
+}
+
+func TestConfigMutationSerializesPublishPersistenceAndScheduleRefresh(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	cfg := &config.Config{Repository: []typedef.Repository{{Name: "base", URL: "github.com/acme/base"}}}
+	exec := executor.NewExecutorWithRunners(logger.NewLogger(testDB), testDB, cfg, executor.Runners{})
+	t.Cleanup(func() {
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+	api := NewAPI(cfg, testDB, exec)
+	refresher := &generationBlockingScheduleRefresher{
+		api:          api,
+		firstRelease: make(chan struct{}),
+		entered:      make(chan int, 2),
+	}
+	api.SetScheduleRefresher(refresher)
+	router := gin.New()
+	router.POST("/api/config/import", api.ApplyImport)
+	router.POST("/api/repositories", api.CreateRepository)
+
+	importBody, err := json.Marshal(map[string]string{
+		"config": "repository:\n  - name: generation-a\n    url: github.com/acme/base\n",
+	})
+	require.NoError(t, err)
+	type response struct {
+		code int
+		body string
+	}
+	applyDone := make(chan response, 1)
+	go func() {
+		req := httptest.NewRequest(http.MethodPost, "/api/config/import", bytes.NewReader(importBody))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		applyDone <- response{code: resp.Code, body: resp.Body.String()}
+	}()
+	require.Equal(t, 1, <-refresher.entered)
+
+	crudStarted := make(chan struct{})
+	crudDone := make(chan response, 1)
+	go func() {
+		close(crudStarted)
+		req := httptest.NewRequest(http.MethodPost, "/api/repositories", bytes.NewBufferString(
+			`{"Name":"generation-b","URL":"github.com/acme/generation-b"}`,
+		))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		crudDone <- response{code: resp.Code, body: resp.Body.String()}
+	}()
+	<-crudStarted
+
+	if refresher.outsideLock.Load() {
+		// On the broken implementation, let B finish its refresh before A so
+		// A deterministically overwrites the scheduler with its stale snapshot.
+		require.Equal(t, 2, <-refresher.entered)
+		close(refresher.firstRelease)
+	} else {
+		// With the generation lock held, B cannot publish until A completes.
+		close(refresher.firstRelease)
+		require.Equal(t, 2, <-refresher.entered)
+	}
+	applyResponse := <-applyDone
+	crudResponse := <-crudDone
+	require.Equal(t, http.StatusOK, applyResponse.code, applyResponse.body)
+	require.Equal(t, http.StatusOK, crudResponse.code, crudResponse.body)
+	require.False(t, refresher.outsideLock.Load(), "schedule refresh ran outside the config generation lock")
+
+	assertGenerationB := func(label string, snapshot *config.Config) {
+		t.Helper()
+		require.NotNil(t, snapshot, label)
+		require.Len(t, snapshot.Repository, 2, label)
+		require.Equal(t, "generation-a", snapshot.Repository[0].Name, label)
+		require.Equal(t, "generation-b", snapshot.Repository[1].Name, label)
+	}
+	assertGenerationB("API", api.configSnapshot())
+	assertGenerationB("Executor", exec.RuntimeConfigSnapshot().Config())
+	assertGenerationB("global", config.GetIns())
+	assertGenerationB("scheduler", refresher.lastConfig())
+}

--- a/internal/server/config_publication_test.go
+++ b/internal/server/config_publication_test.go
@@ -2,18 +2,21 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/db"
 	"github.com/wnarutou/gitrieve/internal/executor"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/logger"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 )
@@ -136,4 +139,139 @@ func TestConfigMutationSerializesPublishPersistenceAndScheduleRefresh(t *testing
 	assertGenerationB("Executor", exec.RuntimeConfigSnapshot().Config())
 	assertGenerationB("global", config.GetIns())
 	assertGenerationB("scheduler", refresher.lastConfig())
+}
+
+func TestConfigPublicationAtomicallyExposesExecutorRuntimeAndTightenedArbiterPolicy(t *testing.T) {
+	previous := config.GetIns()
+	oldConfig := &config.Config{
+		GitHubToken:              "old-token",
+		GitHubAPIConcurrency:     2,
+		GitHubMinRequestInterval: 0,
+		ConcurrencyNum:           1,
+		Repository: []typedef.Repository{{
+			Name: "old", URL: "github.com/acme/repo",
+		}},
+	}
+	config.SetIns(oldConfig)
+	t.Cleanup(func() { config.SetIns(previous) })
+
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	exec := executor.NewExecutorWithRunners(logger.NewLogger(testDB), testDB, oldConfig, executor.Runners{})
+	t.Cleanup(func() {
+		require.NoError(t, exec.Close())
+		require.NoError(t, testDB.Close())
+	})
+	api := NewAPI(oldConfig, testDB, exec)
+
+	held, err := githubapi.Acquire(context.Background(), "core")
+	require.NoError(t, err)
+	var releaseHeld sync.Once
+	t.Cleanup(func() { releaseHeld.Do(func() { held.Done(githubapi.Observation{}) }) })
+	oldPermit, err := githubapi.Acquire(context.Background(), "core")
+	require.NoError(t, err, "old concurrency policy should admit a second request")
+	oldPermit.Done(githubapi.Observation{})
+	oldRuntime := exec.RuntimeConfigSnapshot()
+
+	newConfig := &config.Config{
+		GitHubToken:              "new-token",
+		GitHubAPIConcurrency:     1,
+		GitHubMinRequestInterval: 120 * time.Millisecond,
+		ConcurrencyNum:           2,
+		Repository: []typedef.Repository{{
+			Name: "new", URL: "github.com/acme/repo",
+		}},
+	}
+	publicationEntered := make(chan struct{})
+	publicationRelease := make(chan struct{})
+	api.afterRuntimePublishForTest = func() {
+		close(publicationEntered)
+		<-publicationRelease
+	}
+	publishDone := make(chan struct{})
+	go func() {
+		api.configMu.Lock()
+		api.publishConfigLocked(newConfig)
+		api.configMu.Unlock()
+		close(publishDone)
+	}()
+	<-publicationEntered
+
+	runtimeRead := make(chan *executor.RuntimeConfigSnapshot, 1)
+	go func() { runtimeRead <- exec.RuntimeConfigSnapshot() }()
+	globalRead := make(chan *config.Config, 1)
+	go func() { globalRead <- config.GetIns() }()
+	acquireCtx, acquireCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer acquireCancel()
+	type acquireResult struct {
+		permit githubapi.Permit
+		err    error
+	}
+	acquireDone := make(chan acquireResult, 1)
+	go func() {
+		permit, acquireErr := githubapi.Acquire(acquireCtx, "core")
+		acquireDone <- acquireResult{permit: permit, err: acquireErr}
+	}()
+
+	select {
+	case runtime := <-runtimeRead:
+		t.Fatalf("runtime escaped the publication boundary with generation %d", runtime.Generation())
+	case <-time.After(30 * time.Millisecond):
+	}
+	select {
+	case cfg := <-globalRead:
+		t.Fatalf("package config escaped the publication boundary with token %q", cfg.GitHubToken)
+	case <-time.After(30 * time.Millisecond):
+	}
+	select {
+	case result := <-acquireDone:
+		if result.permit != nil {
+			result.permit.Done(githubapi.Observation{})
+		}
+		t.Fatalf("GitHub acquisition escaped the publication boundary: %v", result.err)
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	close(publicationRelease)
+	select {
+	case <-publishDone:
+	case <-time.After(time.Second):
+		t.Fatal("unified publication did not finish")
+	}
+	var newRuntime *executor.RuntimeConfigSnapshot
+	select {
+	case newRuntime = <-runtimeRead:
+	case <-time.After(time.Second):
+		t.Fatal("runtime reader did not resume after publication")
+	}
+	require.Greater(t, newRuntime.Generation(), oldRuntime.Generation())
+	require.Equal(t, "new-token", newRuntime.Config().GitHubToken)
+	require.Equal(t, "new-token", (<-globalRead).GitHubToken)
+
+	select {
+	case result := <-acquireDone:
+		if result.permit != nil {
+			result.permit.Done(githubapi.Observation{})
+		}
+		t.Fatalf("tightened concurrency policy admitted while the old permit was active: %v", result.err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	releaseHeld.Do(func() { held.Done(githubapi.Observation{}) })
+	var firstNew githubapi.Permit
+	select {
+	case result := <-acquireDone:
+		require.NoError(t, result.err)
+		firstNew = result.permit
+	case <-time.After(time.Second):
+		t.Fatal("tightened concurrency waiter did not resume after permit release")
+	}
+	firstNew.Done(githubapi.Observation{})
+
+	intervalCtx, intervalCancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer intervalCancel()
+	permit, err := githubapi.Acquire(intervalCtx, "core")
+	if permit != nil {
+		permit.Done(githubapi.Observation{})
+	}
+	require.ErrorIs(t, err, context.DeadlineExceeded, "new minimum interval policy was not published with the runtime")
 }

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -44,10 +44,10 @@ func (s *TestServer) SetBulkRepositoryStats(load func(context.Context, typedef.R
 	s.api.bulkRepositoryStats = load
 }
 
-// SetReloadConfig replaces the disk-read operation so tests can make a
-// deterministic edit after the read but before API publication completes.
-func (s *TestServer) SetReloadConfig(reload func() error) {
-	s.api.reloadConfig = reload
+// SetReadReloadSnapshot replaces the unpublished disk-read operation so tests
+// can make a deterministic edit after the read but before API publication.
+func (s *TestServer) SetReadReloadSnapshot(read func() (*config.ReloadSnapshot, error)) {
+	s.api.readReloadSnapshot = read
 }
 
 // SetBulkExecute replaces bulk's final Executor call for deterministic error

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -35,13 +35,19 @@ func (s *TestServer) Cfg() *config.Config {
 	if s.api == nil {
 		return nil
 	}
-	return s.api.config
+	return s.api.configSnapshot()
 }
 
 // SetBulkRepositoryStats replaces only the bulk enqueue-time repository-stats
 // read so tests can establish deterministic persistence/config barriers.
 func (s *TestServer) SetBulkRepositoryStats(load func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error)) {
 	s.api.bulkRepositoryStats = load
+}
+
+// SetBulkExecute replaces bulk's final Executor call for deterministic error
+// and cancellation branch coverage.
+func (s *TestServer) SetBulkExecute(execute func(context.Context, string, uint64) ([]string, error)) {
+	s.api.bulkExecute = execute
 }
 
 // BulkRepositoryStatsQueryPlan returns SQLite's plan for the exact production
@@ -169,6 +175,23 @@ func NewConfigTestServer(cfg *config.Config, testDB *db.DB, refreshers ...Schedu
 	s := &TestServer{router: gin.Default(), api: api}
 	s.router.GET("/api/config/export", api.ExportConfig)
 	s.router.POST("/api/config/import/preview", api.PreviewImport)
+	s.router.POST("/api/config/import", api.ApplyImport)
+	s.router.POST("/api/config/reload", api.ReloadConfig)
+	return s
+}
+
+// NewConfigConcurrencyTestServer exposes every route involved in concurrent
+// config publication through one API and one Executor instance.
+func NewConfigConcurrencyTestServer(cfg *config.Config, testDB *db.DB, exec *executor.Executor) *TestServer {
+	api := NewAPI(cfg, testDB, exec)
+	s := &TestServer{router: gin.Default(), api: api}
+	s.router.POST("/api/jobs/bulk", api.BulkCreateJobs)
+	s.router.POST("/api/repositories", api.CreateRepository)
+	s.router.PUT("/api/repositories/*id", api.UpdateRepository)
+	s.router.DELETE("/api/repositories/*id", api.DeleteRepository)
+	s.router.POST("/api/storage", api.CreateStorage)
+	s.router.PUT("/api/storage/:id", api.UpdateStorage)
+	s.router.DELETE("/api/storage/:id", api.DeleteStorage)
 	s.router.POST("/api/config/import", api.ApplyImport)
 	s.router.POST("/api/config/reload", api.ReloadConfig)
 	return s

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -7,7 +7,9 @@ package server
 // tests, never into production binaries.
 
 import (
+	"context"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/wnarutou/gitrieve/internal/config"
@@ -36,6 +38,36 @@ func (s *TestServer) Cfg() *config.Config {
 	return s.api.config
 }
 
+// SetBulkRepositoryStats replaces only the bulk enqueue-time repository-stats
+// read so tests can establish deterministic persistence/config barriers.
+func (s *TestServer) SetBulkRepositoryStats(load func(context.Context, typedef.Repository) (map[string]db.RepositoryRunStats, error)) {
+	s.api.bulkRepositoryStats = load
+}
+
+// BulkRepositoryStatsQueryPlan returns SQLite's plan for the exact production
+// candidate-history query.
+func (s *TestServer) BulkRepositoryStatsQueryPlan(ctx context.Context, repository typedef.Repository) (string, error) {
+	query, args := repositoryRunStatsQuery(repository)
+	rows, err := s.api.db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			return "", err
+		}
+		details = append(details, detail)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return strings.Join(details, "\n"), nil
+}
+
 // newTestConfig returns the default config used by the test servers.
 func newTestConfig() *config.Config {
 	return &config.Config{
@@ -56,7 +88,7 @@ func NewTestServer(db *db.DB) *TestServer {
 	exec := executor.NewExecutor(log, db, cfg)
 	api := NewAPI(cfg, db, exec)
 
-	s := &TestServer{router: gin.Default()}
+	s := &TestServer{router: gin.Default(), api: api}
 	s.router.POST("/api/jobs", api.CreateJob)
 	s.router.POST("/api/jobs/bulk", api.BulkCreateJobs)
 	s.router.DELETE("/api/jobs/:id", api.CancelJob)
@@ -75,7 +107,7 @@ func NewTestServerWithExecutor(db *db.DB, exec *executor.Executor, configs ...*c
 	}
 	api := NewAPI(cfg, db, exec)
 
-	s := &TestServer{router: gin.Default()}
+	s := &TestServer{router: gin.Default(), api: api}
 	s.router.POST("/api/jobs", api.CreateJob)
 	s.router.POST("/api/jobs/bulk", api.BulkCreateJobs)
 	s.router.DELETE("/api/jobs/:id", api.CancelJob)
@@ -87,11 +119,16 @@ func NewTestServerWithExecutor(db *db.DB, exec *executor.Executor, configs ...*c
 
 // NewRepoTestServer creates a test server with only the repository CRUD
 // routes registered, using a fresh executor backed by testDB.
-func NewRepoTestServer(cfg *config.Config, testDB *db.DB) *TestServer {
-	log := logger.NewLogger(testDB)
-	exec := executor.NewExecutor(log, testDB, cfg)
+func NewRepoTestServer(cfg *config.Config, testDB *db.DB, executors ...*executor.Executor) *TestServer {
+	var exec *executor.Executor
+	if len(executors) > 0 {
+		exec = executors[0]
+	} else {
+		log := logger.NewLogger(testDB)
+		exec = executor.NewExecutor(log, testDB, cfg)
+	}
 	api := NewAPI(cfg, testDB, exec)
-	s := &TestServer{router: gin.Default()}
+	s := &TestServer{router: gin.Default(), api: api}
 	s.router.GET("/api/repositories", api.GetRepositories)
 	s.router.POST("/api/repositories", api.CreateRepository)
 	// *id catch-all: identity keys are URLs containing "/" that :id cannot match.
@@ -102,11 +139,16 @@ func NewRepoTestServer(cfg *config.Config, testDB *db.DB) *TestServer {
 
 // NewStorageTestServer creates a test server with only the storage CRUD
 // routes registered, using a fresh executor backed by testDB.
-func NewStorageTestServer(cfg *config.Config, testDB *db.DB) *TestServer {
-	log := logger.NewLogger(testDB)
-	exec := executor.NewExecutor(log, testDB, cfg)
+func NewStorageTestServer(cfg *config.Config, testDB *db.DB, executors ...*executor.Executor) *TestServer {
+	var exec *executor.Executor
+	if len(executors) > 0 {
+		exec = executors[0]
+	} else {
+		log := logger.NewLogger(testDB)
+		exec = executor.NewExecutor(log, testDB, cfg)
+	}
 	api := NewAPI(cfg, testDB, exec)
-	s := &TestServer{router: gin.Default()}
+	s := &TestServer{router: gin.Default(), api: api}
 	s.router.GET("/api/storage", api.GetStorages)
 	s.router.POST("/api/storage", api.CreateStorage)
 	s.router.PUT("/api/storage/:id", api.UpdateStorage)

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -58,6 +58,7 @@ func NewTestServer(db *db.DB) *TestServer {
 
 	s := &TestServer{router: gin.Default()}
 	s.router.POST("/api/jobs", api.CreateJob)
+	s.router.POST("/api/jobs/bulk", api.BulkCreateJobs)
 	s.router.DELETE("/api/jobs/:id", api.CancelJob)
 	s.router.GET("/api/jobs", api.GetJobs)
 	s.router.GET("/api/jobs/:id/logs", api.GetJobLogs)
@@ -67,12 +68,16 @@ func NewTestServer(db *db.DB) *TestServer {
 
 // NewTestServerWithExecutor creates a new server instance with a custom
 // executor for testing, with the jobs routes registered.
-func NewTestServerWithExecutor(db *db.DB, exec *executor.Executor) *TestServer {
+func NewTestServerWithExecutor(db *db.DB, exec *executor.Executor, configs ...*config.Config) *TestServer {
 	cfg := newTestConfig()
+	if len(configs) > 0 {
+		cfg = configs[0]
+	}
 	api := NewAPI(cfg, db, exec)
 
 	s := &TestServer{router: gin.Default()}
 	s.router.POST("/api/jobs", api.CreateJob)
+	s.router.POST("/api/jobs/bulk", api.BulkCreateJobs)
 	s.router.DELETE("/api/jobs/:id", api.CancelJob)
 	s.router.GET("/api/jobs", api.GetJobs)
 	s.router.GET("/api/jobs/:id/logs", api.GetJobLogs)

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -44,10 +44,18 @@ func (s *TestServer) SetBulkRepositoryStats(load func(context.Context, typedef.R
 	s.api.bulkRepositoryStats = load
 }
 
+// SetReloadConfig replaces the disk-read operation so tests can make a
+// deterministic edit after the read but before API publication completes.
+func (s *TestServer) SetReloadConfig(reload func() error) {
+	s.api.reloadConfig = reload
+}
+
 // SetBulkExecute replaces bulk's final Executor call for deterministic error
 // and cancellation branch coverage.
 func (s *TestServer) SetBulkExecute(execute func(context.Context, string, uint64) ([]string, error)) {
-	s.api.bulkExecute = execute
+	s.api.bulkExecute = func(ctx context.Context, key string, generation uint64, _ executor.EligibilityCheck) ([]string, error) {
+		return execute(ctx, key, generation)
+	}
 }
 
 // BulkRepositoryStatsQueryPlan returns SQLite's plan for the exact production

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -61,6 +61,7 @@ func NewTestServer(db *db.DB) *TestServer {
 	s.router.DELETE("/api/jobs/:id", api.CancelJob)
 	s.router.GET("/api/jobs", api.GetJobs)
 	s.router.GET("/api/jobs/:id/logs", api.GetJobLogs)
+	s.router.GET("/api/jobs/:id/components", api.GetJobComponents)
 	return s
 }
 
@@ -75,6 +76,7 @@ func NewTestServerWithExecutor(db *db.DB, exec *executor.Executor) *TestServer {
 	s.router.DELETE("/api/jobs/:id", api.CancelJob)
 	s.router.GET("/api/jobs", api.GetJobs)
 	s.router.GET("/api/jobs/:id/logs", api.GetJobLogs)
+	s.router.GET("/api/jobs/:id/components", api.GetJobComponents)
 	return s
 }
 

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -17,13 +17,20 @@ func escapeLike(s string) string {
 // nextRunTime returns the next time a repository's cron expression will fire,
 // or nil when the expression is empty or invalid.
 func nextRunTime(cronExpr string, now time.Time) *time.Time {
-	if cronExpr == "" {
+	sched, err := parseRepositorySchedule(cronExpr)
+	if err != nil {
 		return nil
 	}
-	sched, err := cron.ParseStandard(cronExpr)
-	if err != nil {
+	if sched == nil {
 		return nil
 	}
 	t := sched.Next(now)
 	return &t
+}
+
+func parseRepositorySchedule(cronExpr string) (cron.Schedule, error) {
+	if cronExpr == "" {
+		return nil, nil
+	}
+	return cron.ParseStandard(cronExpr)
 }

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -29,3 +29,22 @@ func TestNextRunTime(t *testing.T) {
 	require.NotNil(t, nt2)
 	assert.Equal(t, time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC), *nt2)
 }
+
+func TestParseRepositoryScheduleReportsInvalidExpression(t *testing.T) {
+	schedule, err := parseRepositorySchedule("")
+	require.NoError(t, err)
+	assert.Nil(t, schedule)
+
+	schedule, err = parseRepositorySchedule("not a cron")
+	require.Error(t, err)
+	assert.Nil(t, schedule)
+
+	schedule, err = parseRepositorySchedule("30 2 * * *")
+	require.NoError(t, err)
+	require.NotNil(t, schedule)
+
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	afterDSTJump := schedule.Next(time.Date(2026, time.March, 7, 3, 30, 0, 0, newYork))
+	assert.Equal(t, time.Date(2026, time.March, 9, 2, 30, 0, 0, newYork), afterDSTJump)
+}

--- a/internal/server/repository_benchmark_test.go
+++ b/internal/server/repository_benchmark_test.go
@@ -1,0 +1,124 @@
+package server_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/db"
+	server "github.com/wnarutou/gitrieve/internal/server"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+)
+
+const (
+	benchmarkRepositoryCount = 6000
+	benchmarkHistoryCount    = 100
+)
+
+func BenchmarkGetRepositories6000(b *testing.B) {
+	b.StopTimer()
+	testDB, err := db.Initialize(":memory:")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = testDB.Close() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	repositories := make([]typedef.Repository, benchmarkRepositoryCount)
+	for repositoryIndex := range repositories {
+		repositories[repositoryIndex] = typedef.Repository{
+			Name: fmt.Sprintf("repository-%04d", repositoryIndex),
+			URL:  fmt.Sprintf("github.com/benchmark/repository-%04d", repositoryIndex),
+			Cron: "0 * * * *",
+		}
+	}
+
+	tx, err := testDB.Begin()
+	if err != nil {
+		b.Fatal(err)
+	}
+	statement, err := tx.Prepare(`
+		INSERT INTO executions
+			(id, job_name, repo_key, start_time, end_time, status, error_message)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		b.Fatal(err)
+	}
+	for repositoryIndex, repository := range repositories {
+		for historyIndex := 0; historyIndex < benchmarkHistoryCount; historyIndex++ {
+			start := now.Add(-time.Duration(benchmarkHistoryCount-historyIndex) * time.Hour)
+			end := start.Add(5 * time.Minute)
+			status := "completed"
+			message := ""
+			if historyIndex == benchmarkHistoryCount-1 {
+				switch repositoryIndex % 4 {
+				case 0:
+					status = "failed"
+					message = "benchmark failure"
+				case 3:
+					status = "cancelled"
+					message = "benchmark cancellation"
+				}
+			}
+			id := fmt.Sprintf("benchmark-%04d-%03d", repositoryIndex, historyIndex)
+			if _, err := statement.Exec(id, repository.Name, repository.Key(), start, end, status, message); err != nil {
+				_ = statement.Close()
+				_ = tx.Rollback()
+				b.Fatal(err)
+			}
+		}
+	}
+	if err := statement.Close(); err != nil {
+		_ = tx.Rollback()
+		b.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatal(err)
+	}
+
+	handler := server.NewRepoTestServer(&config.Config{
+		SyncOverdueGrace:   30 * time.Minute,
+		SyncStuckThreshold: 24 * time.Hour,
+		Repository:         repositories,
+	}, testDB)
+
+	benchmarks := []struct {
+		name  string
+		query string
+	}{
+		{name: "attention", query: "?sort=attention&page=1&limit=20"},
+		{name: "failed", query: "?health=failed&sort=attention&page=1&limit=20"},
+		{name: "overdue", query: "?overdue=true&sort=attention&page=1&limit=20"},
+		{name: "last_success", query: "?sort=last_success&direction=desc&page=1&limit=20"},
+	}
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				request := httptest.NewRequest(http.MethodGet, "/api/repositories"+benchmark.query, nil)
+				response := httptest.NewRecorder()
+				handler.ServeHTTP(response, request)
+				if response.Code != http.StatusOK {
+					b.Fatalf("GET %s returned HTTP %d: %s", request.URL.RequestURI(), response.Code, response.Body.String())
+				}
+				var body struct {
+					Code int `json:"code"`
+					Data struct {
+						Repositories []json.RawMessage `json:"repositories"`
+					} `json:"data"`
+				}
+				if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+					b.Fatalf("decode GET %s response: %v", request.URL.RequestURI(), err)
+				}
+				if body.Code != http.StatusOK || len(body.Data.Repositories) == 0 || len(body.Data.Repositories) > 20 {
+					b.Fatalf("GET %s returned invalid payload: code=%d repositories=%d", request.URL.RequestURI(), body.Code, len(body.Data.Repositories))
+				}
+			}
+		})
+	}
+}

--- a/internal/server/repository_benchmark_test.go
+++ b/internal/server/repository_benchmark_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/db"
 	server "github.com/wnarutou/gitrieve/internal/server"
@@ -18,6 +19,86 @@ const (
 	benchmarkRepositoryCount = 6000
 	benchmarkHistoryCount    = 100
 )
+
+func TestRepositoryBenchmarkFixtureIsOverdueEarlyInTheHour(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	now := time.Date(2026, time.September, 4, 12, 5, 0, 0, time.UTC)
+	repositories := []typedef.Repository{{
+		Name: "repository-0000",
+		URL:  "github.com/benchmark/repository-0000",
+		Cron: "0 * * * *",
+	}}
+	insertRepositoryBenchmarkHistory(t, testDB, repositories, benchmarkHistoryCount, now)
+
+	var latestStart time.Time
+	require.NoError(t, testDB.QueryRow(
+		`SELECT start_time FROM executions WHERE repo_key = ? ORDER BY start_time DESC LIMIT 1`,
+		repositories[0].Key(),
+	).Scan(&latestStart))
+	require.Equal(t, now.Add(-2*time.Hour), latestStart)
+	latestEligibleOccurrence := now.Add(-30 * time.Minute).Truncate(time.Hour)
+	require.True(t, latestStart.Before(latestEligibleOccurrence))
+}
+
+func insertRepositoryBenchmarkHistory(
+	tb testing.TB,
+	testDB *db.DB,
+	repositories []typedef.Repository,
+	historyCount int,
+	now time.Time,
+) {
+	tb.Helper()
+	tx, err := testDB.Begin()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	statement, err := tx.Prepare(`
+		INSERT INTO executions
+			(id, job_name, repo_key, start_time, end_time, status, error_message)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		tb.Fatal(err)
+	}
+	for repositoryIndex, repository := range repositories {
+		for historyIndex := 0; historyIndex < historyCount; historyIndex++ {
+			// Keep the newest execution at least two hours old. With an hourly
+			// schedule and a 30-minute grace period this is overdue even during
+			// the first half-hour, when the eligible occurrence is in the
+			// preceding hour.
+			start := now.Add(-time.Duration(historyCount-historyIndex+1) * time.Hour)
+			end := start.Add(5 * time.Minute)
+			status := "completed"
+			message := ""
+			if historyIndex == historyCount-1 {
+				switch repositoryIndex % 4 {
+				case 0:
+					status = "failed"
+					message = "benchmark failure"
+				case 3:
+					status = "cancelled"
+					message = "benchmark cancellation"
+				}
+			}
+			id := fmt.Sprintf("benchmark-%04d-%03d", repositoryIndex, historyIndex)
+			if _, err := statement.Exec(id, repository.Name, repository.Key(), start, end, status, message); err != nil {
+				_ = statement.Close()
+				_ = tx.Rollback()
+				tb.Fatal(err)
+			}
+		}
+	}
+	if err := statement.Close(); err != nil {
+		_ = tx.Rollback()
+		tb.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		tb.Fatal(err)
+	}
+}
 
 func BenchmarkGetRepositories6000(b *testing.B) {
 	b.StopTimer()
@@ -37,49 +118,7 @@ func BenchmarkGetRepositories6000(b *testing.B) {
 		}
 	}
 
-	tx, err := testDB.Begin()
-	if err != nil {
-		b.Fatal(err)
-	}
-	statement, err := tx.Prepare(`
-		INSERT INTO executions
-			(id, job_name, repo_key, start_time, end_time, status, error_message)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		_ = tx.Rollback()
-		b.Fatal(err)
-	}
-	for repositoryIndex, repository := range repositories {
-		for historyIndex := 0; historyIndex < benchmarkHistoryCount; historyIndex++ {
-			start := now.Add(-time.Duration(benchmarkHistoryCount-historyIndex) * time.Hour)
-			end := start.Add(5 * time.Minute)
-			status := "completed"
-			message := ""
-			if historyIndex == benchmarkHistoryCount-1 {
-				switch repositoryIndex % 4 {
-				case 0:
-					status = "failed"
-					message = "benchmark failure"
-				case 3:
-					status = "cancelled"
-					message = "benchmark cancellation"
-				}
-			}
-			id := fmt.Sprintf("benchmark-%04d-%03d", repositoryIndex, historyIndex)
-			if _, err := statement.Exec(id, repository.Name, repository.Key(), start, end, status, message); err != nil {
-				_ = statement.Close()
-				_ = tx.Rollback()
-				b.Fatal(err)
-			}
-		}
-	}
-	if err := statement.Close(); err != nil {
-		_ = tx.Rollback()
-		b.Fatal(err)
-	}
-	if err := tx.Commit(); err != nil {
-		b.Fatal(err)
-	}
+	insertRepositoryBenchmarkHistory(b, testDB, repositories, benchmarkHistoryCount, now)
 
 	handler := server.NewRepoTestServer(&config.Config{
 		SyncOverdueGrace:   30 * time.Minute,

--- a/internal/server/repository_health.go
+++ b/internal/server/repository_health.go
@@ -149,20 +149,20 @@ func latestDuration(stats db.RepositoryRunStats, hasRuns bool, now time.Time) *i
 
 func repositoryHealthStatus(overview RepositoryOverview, hasRuns bool) string {
 	switch {
-	case overview.Stuck:
-		return "stuck"
-	case overview.LastStatus == string(StatusFailed):
-		return "failed"
-	case overview.Overdue:
-		return "overdue"
 	case !hasRuns:
 		return "never_synced"
-	case overview.LastStatus == string(StatusCancelled):
-		return "cancelled"
+	case overview.Stuck:
+		return "stuck"
 	case overview.LastStatus == string(StatusPending):
 		return "pending"
 	case overview.LastStatus == string(StatusRunning):
 		return "running"
+	case overview.LastStatus == string(StatusFailed):
+		return "failed"
+	case overview.LastStatus == string(StatusCancelled):
+		return "cancelled"
+	case overview.Overdue:
+		return "overdue"
 	default:
 		return "healthy"
 	}
@@ -195,7 +195,9 @@ func summarizeRepositorySnapshot(in []RepositoryOverview) RepositoryHealthSummar
 		case string(StatusCancelled):
 			summary.Cancelled++
 		default:
-			summary.Healthy++
+			if overview.HealthStatus == "healthy" {
+				summary.Healthy++
+			}
 		}
 		if overview.Overdue {
 			summary.Overdue++

--- a/internal/server/repository_health.go
+++ b/internal/server/repository_health.go
@@ -1,0 +1,322 @@
+package server
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+)
+
+func buildRepositorySnapshot(
+	repos []typedef.Repository,
+	stats map[string]db.RepositoryRunStats,
+	now time.Time,
+	overdueGrace time.Duration,
+	stuckThreshold time.Duration,
+) []RepositoryOverview {
+	if overdueGrace <= 0 {
+		overdueGrace = config.DefaultSyncOverdueGrace
+	}
+	if stuckThreshold <= 0 {
+		stuckThreshold = config.DefaultSyncStuckThreshold
+	}
+
+	overviews := make([]RepositoryOverview, 0, len(repos))
+	for _, configured := range repos {
+		repo := configured
+		repo.URL = repo.EffectiveURL()
+		runStats, hasRuns := repositoryStats(stats, repo)
+		overview := RepositoryOverview{
+			Repository:        repo,
+			TotalRuns:         runStats.TotalRuns,
+			SuccessRuns:       runStats.SuccessRuns,
+			FailedRuns:        runStats.FailedRuns,
+			LastStatus:        runStats.LatestStatus,
+			LatestExecutionID: runStats.LatestExecutionID,
+			LastErrorMessage:  runStats.LatestError,
+		}
+
+		if hasRuns {
+			attempt := runStats.LatestStart
+			overview.LastAttemptTime = &attempt
+			overview.LastRunTime = &attempt
+		}
+		if runStats.LastSuccess != nil {
+			success := *runStats.LastSuccess
+			overview.LastSuccessTime = &success
+		}
+		if duration := latestDuration(runStats, hasRuns, now); duration != nil {
+			overview.LastDurationSeconds = duration
+		}
+
+		schedule, scheduleErr := parseRepositorySchedule(repo.Cron)
+		if scheduleErr != nil {
+			overview.ScheduleError = scheduleErr.Error()
+		} else if schedule != nil {
+			next := schedule.Next(now)
+			overview.NextRunTime = &next
+		}
+
+		active := hasRuns && (runStats.LatestStatus == string(StatusPending) || runStats.LatestStatus == string(StatusRunning))
+		if active {
+			overview.Stuck = now.Sub(runStats.LatestStart) > stuckThreshold
+		}
+		if hasRuns && !active && schedule != nil {
+			lastAttemptInScheduleLocation := runStats.LatestStart.In(now.Location())
+			overview.Overdue = !schedule.Next(lastAttemptInScheduleLocation).After(now.Add(-overdueGrace))
+		}
+		overview.HealthStatus = repositoryHealthStatus(overview, hasRuns)
+		overviews = append(overviews, overview)
+	}
+	return overviews
+}
+
+func repositoryStats(stats map[string]db.RepositoryRunStats, repo typedef.Repository) (db.RepositoryRunStats, bool) {
+	key := repo.Key()
+	if key == "" {
+		return db.RepositoryRunStats{}, false
+	}
+	if repo.GetType() != typedef.TypeOrg && repo.GetType() != typedef.TypeUser {
+		value, ok := stats[key]
+		return cloneRepositoryRunStats(value), ok
+	}
+
+	prefix := key + "/"
+	var aggregate db.RepositoryRunStats
+	found := false
+	for memberKey, member := range stats {
+		if !strings.HasPrefix(memberKey, prefix) {
+			continue
+		}
+		aggregate.TotalRuns += member.TotalRuns
+		aggregate.SuccessRuns += member.SuccessRuns
+		aggregate.FailedRuns += member.FailedRuns
+		if member.LastSuccess != nil && (aggregate.LastSuccess == nil || member.LastSuccess.After(*aggregate.LastSuccess)) {
+			lastSuccess := *member.LastSuccess
+			aggregate.LastSuccess = &lastSuccess
+		}
+		if !found || member.LatestStart.After(aggregate.LatestStart) ||
+			(member.LatestStart.Equal(aggregate.LatestStart) && member.LatestExecutionID > aggregate.LatestExecutionID) {
+			aggregate.LatestExecutionID = member.LatestExecutionID
+			aggregate.LatestStatus = member.LatestStatus
+			aggregate.LatestStart = member.LatestStart
+			aggregate.LatestError = member.LatestError
+			aggregate.LatestEnd = nil
+			if member.LatestEnd != nil {
+				latestEnd := *member.LatestEnd
+				aggregate.LatestEnd = &latestEnd
+			}
+		}
+		found = true
+	}
+	return aggregate, found
+}
+
+func cloneRepositoryRunStats(value db.RepositoryRunStats) db.RepositoryRunStats {
+	if value.LatestEnd != nil {
+		latestEnd := *value.LatestEnd
+		value.LatestEnd = &latestEnd
+	}
+	if value.LastSuccess != nil {
+		lastSuccess := *value.LastSuccess
+		value.LastSuccess = &lastSuccess
+	}
+	return value
+}
+
+func latestDuration(stats db.RepositoryRunStats, hasRuns bool, now time.Time) *int64 {
+	if !hasRuns {
+		return nil
+	}
+	var duration time.Duration
+	if stats.LatestStatus == string(StatusPending) || stats.LatestStatus == string(StatusRunning) {
+		duration = now.Sub(stats.LatestStart)
+	} else {
+		if stats.LatestEnd == nil {
+			return nil
+		}
+		duration = stats.LatestEnd.Sub(stats.LatestStart)
+	}
+	if duration < 0 {
+		duration = 0
+	}
+	seconds := int64(duration / time.Second)
+	return &seconds
+}
+
+func repositoryHealthStatus(overview RepositoryOverview, hasRuns bool) string {
+	switch {
+	case overview.Stuck:
+		return "stuck"
+	case overview.LastStatus == string(StatusFailed):
+		return "failed"
+	case overview.Overdue:
+		return "overdue"
+	case !hasRuns:
+		return "never_synced"
+	case overview.LastStatus == string(StatusCancelled):
+		return "cancelled"
+	case overview.LastStatus == string(StatusPending):
+		return "pending"
+	case overview.LastStatus == string(StatusRunning):
+		return "running"
+	default:
+		return "healthy"
+	}
+}
+
+func searchRepositorySnapshot(in []RepositoryOverview, search string) []RepositoryOverview {
+	needle := strings.ToLower(search)
+	out := make([]RepositoryOverview, 0, len(in))
+	for _, overview := range in {
+		if needle == "" || strings.Contains(strings.ToLower(overview.Name), needle) ||
+			strings.Contains(strings.ToLower(overview.EffectiveURL()), needle) {
+			out = append(out, overview)
+		}
+	}
+	return out
+}
+
+func summarizeRepositorySnapshot(in []RepositoryOverview) RepositoryHealthSummary {
+	summary := RepositoryHealthSummary{Total: len(in)}
+	for _, overview := range in {
+		switch overview.LastStatus {
+		case "":
+			summary.NeverSynced++
+		case string(StatusFailed):
+			summary.Failed++
+		case string(StatusPending):
+			summary.Pending++
+		case string(StatusRunning):
+			summary.Running++
+		case string(StatusCancelled):
+			summary.Cancelled++
+		default:
+			summary.Healthy++
+		}
+		if overview.Overdue {
+			summary.Overdue++
+		}
+		if overview.Stuck {
+			summary.Stuck++
+		}
+	}
+	return summary
+}
+
+func filterRepositorySnapshot(in []RepositoryOverview, filter RepositoryHealthFilter) []RepositoryOverview {
+	out := make([]RepositoryOverview, 0, len(in))
+	for _, overview := range in {
+		if filter.Health != "" {
+			if filter.Health == "syncing" {
+				if overview.LastStatus != string(StatusPending) && overview.LastStatus != string(StatusRunning) {
+					continue
+				}
+			} else if overview.HealthStatus != filter.Health {
+				continue
+			}
+		}
+		if filter.Overdue != nil && overview.Overdue != *filter.Overdue {
+			continue
+		}
+		if filter.Stuck != nil && overview.Stuck != *filter.Stuck {
+			continue
+		}
+		out = append(out, overview)
+	}
+	return out
+}
+
+func sortRepositorySnapshot(in []RepositoryOverview, sortKey, direction string) {
+	descending := direction == "desc"
+	sort.SliceStable(in, func(i, j int) bool {
+		left, right := in[i], in[j]
+		if sortKey == "last_attempt" && (left.LastAttemptTime == nil) != (right.LastAttemptTime == nil) {
+			return left.LastAttemptTime != nil
+		}
+		if sortKey == "last_success" && (left.LastSuccessTime == nil) != (right.LastSuccessTime == nil) {
+			return left.LastSuccessTime != nil
+		}
+		comparison := compareOverviewPrimary(left, right, sortKey)
+		if comparison != 0 {
+			if descending {
+				return comparison > 0
+			}
+			return comparison < 0
+		}
+		leftName, rightName := strings.ToLower(left.Name), strings.ToLower(right.Name)
+		if leftName != rightName {
+			return leftName < rightName
+		}
+		return typedef.NormalizeURL(left.EffectiveURL()) < typedef.NormalizeURL(right.EffectiveURL())
+	})
+}
+
+func compareOverviewPrimary(left, right RepositoryOverview, sortKey string) int {
+	switch sortKey {
+	case "attention":
+		return compareInt(attentionRank(left), attentionRank(right))
+	case "name":
+		return strings.Compare(strings.ToLower(left.Name), strings.ToLower(right.Name))
+	case "last_attempt":
+		return compareOptionalTime(left.LastAttemptTime, right.LastAttemptTime)
+	case "last_success":
+		return compareOptionalTime(left.LastSuccessTime, right.LastSuccessTime)
+	default:
+		return 0
+	}
+}
+
+func attentionRank(overview RepositoryOverview) int {
+	switch {
+	case overview.Stuck || overview.HealthStatus == "stuck":
+		return 0
+	case overview.HealthStatus == "failed":
+		return 1
+	case overview.Overdue || overview.HealthStatus == "overdue":
+		return 2
+	case overview.HealthStatus == "never_synced":
+		return 3
+	case overview.HealthStatus == "cancelled":
+		return 4
+	case overview.HealthStatus == "pending":
+		return 5
+	case overview.HealthStatus == "running":
+		return 6
+	default:
+		return 7
+	}
+}
+
+func compareOptionalTime(left, right *time.Time) int {
+	if left == nil && right == nil {
+		return 0
+	}
+	if left == nil {
+		return 1
+	}
+	if right == nil {
+		return -1
+	}
+	if left.Before(*right) {
+		return -1
+	}
+	if left.After(*right) {
+		return 1
+	}
+	return 0
+}
+
+func compareInt(left, right int) int {
+	switch {
+	case left < right:
+		return -1
+	case left > right:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/server/repository_health_test.go
+++ b/internal/server/repository_health_test.go
@@ -1,0 +1,249 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/db"
+	"github.com/wnarutou/gitrieve/internal/typedef"
+)
+
+func TestRepositoryHealthUsesAttentionPrecedenceAndSafeDurations(t *testing.T) {
+	now := time.Date(2026, time.September, 4, 12, 0, 0, 0, time.UTC)
+	ended := now.Add(-2 * time.Hour)
+	cases := []struct {
+		name            string
+		cron            string
+		stats           *db.RepositoryRunStats
+		wantHealth      string
+		wantOverdue     bool
+		wantStuck       bool
+		wantDuration    *int64
+		wantScheduleErr bool
+	}{
+		{name: "never synced", cron: "0 * * * *", wantHealth: "never_synced"},
+		{name: "stuck pending", stats: runStatsAt("pending", now.Add(-25*time.Hour), nil), wantHealth: "stuck", wantStuck: true, wantDuration: secondsPtr(25 * time.Hour)},
+		{name: "stuck running", stats: runStatsAt("running", now.Add(-25*time.Hour), nil), wantHealth: "stuck", wantStuck: true, wantDuration: secondsPtr(25 * time.Hour)},
+		{name: "exact stuck threshold is still pending", stats: runStatsAt("pending", now.Add(-24*time.Hour), nil), wantHealth: "pending", wantDuration: secondsPtr(24 * time.Hour)},
+		{name: "pending", stats: runStatsAt("pending", now.Add(-time.Hour), nil), wantHealth: "pending", wantDuration: secondsPtr(time.Hour)},
+		{name: "running", stats: runStatsAt("running", now.Add(-time.Hour), nil), wantHealth: "running", wantDuration: secondsPtr(time.Hour)},
+		{name: "failed beats overdue", cron: "0 * * * *", stats: runStatsAt("failed", now.Add(-3*time.Hour), &ended), wantHealth: "failed", wantOverdue: true, wantDuration: secondsPtr(time.Hour)},
+		{name: "cancelled", stats: runStatsAt("cancelled", now.Add(-time.Hour), &ended), wantHealth: "cancelled", wantDuration: secondsPtr(0)},
+		{name: "overdue beats cancelled", cron: "0 * * * *", stats: runStatsAt("cancelled", now.Add(-3*time.Hour), &ended), wantHealth: "overdue", wantOverdue: true, wantDuration: secondsPtr(time.Hour)},
+		{name: "overdue completed", cron: "0 * * * *", stats: runStatsAt("completed", now.Add(-3*time.Hour), &ended), wantHealth: "overdue", wantOverdue: true, wantDuration: secondsPtr(time.Hour)},
+		{name: "healthy", cron: "0 * * * *", stats: runStatsAt("completed", now.Add(-20*time.Minute), &ended), wantHealth: "healthy", wantDuration: secondsPtr(0)},
+		{name: "active is never overdue", cron: "0 * * * *", stats: runStatsAt("running", now.Add(-3*time.Hour), nil), wantHealth: "running", wantDuration: secondsPtr(3 * time.Hour)},
+		{name: "invalid cron", cron: "bad cron", stats: runStatsAt("completed", now.Add(-3*time.Hour), &ended), wantHealth: "healthy", wantDuration: secondsPtr(time.Hour), wantScheduleErr: true},
+		{name: "terminal row without end has no duration", stats: runStatsAt("failed", now.Add(-time.Hour), nil), wantHealth: "failed"},
+		{name: "future active start clamps duration", stats: runStatsAt("running", now.Add(time.Hour), nil), wantHealth: "running", wantDuration: secondsPtr(0)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := typedef.Repository{Name: tc.name, URL: "https://github.com/acme/" + tc.name, Cron: tc.cron}
+			stats := map[string]db.RepositoryRunStats{}
+			if tc.stats != nil {
+				stats[repo.Key()] = *tc.stats
+			}
+
+			got := buildRepositorySnapshot([]typedef.Repository{repo}, stats, now, 30*time.Minute, 24*time.Hour)
+			require.Len(t, got, 1)
+			require.Equal(t, tc.wantHealth, got[0].HealthStatus)
+			require.Equal(t, tc.wantOverdue, got[0].Overdue)
+			require.Equal(t, tc.wantStuck, got[0].Stuck)
+			require.Equal(t, tc.wantDuration, got[0].LastDurationSeconds)
+			require.Equal(t, tc.wantScheduleErr, got[0].ScheduleError != "")
+			if tc.stats == nil {
+				require.Nil(t, got[0].LastAttemptTime)
+				require.Nil(t, got[0].LastRunTime)
+			} else {
+				require.Equal(t, tc.stats.LatestStart, *got[0].LastAttemptTime)
+				require.Equal(t, got[0].LastAttemptTime, got[0].LastRunTime)
+			}
+		})
+	}
+}
+
+func TestRepositoryOverdueUsesCronBoundaryGraceAndLocalDST(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name        string
+		now         time.Time
+		lastAttempt time.Time
+		cron        string
+		grace       time.Duration
+		want        bool
+	}{
+		{
+			name:        "next boundary equal to grace cutoff is overdue",
+			now:         time.Date(2026, time.September, 4, 12, 30, 0, 0, time.UTC),
+			lastAttempt: time.Date(2026, time.September, 4, 10, 0, 0, 0, time.UTC),
+			cron:        "0 11 * * *",
+			grace:       90 * time.Minute,
+			want:        true,
+		},
+		{
+			name:        "next boundary after grace cutoff is current",
+			now:         time.Date(2026, time.September, 4, 12, 29, 59, 0, time.UTC),
+			lastAttempt: time.Date(2026, time.September, 4, 10, 0, 0, 0, time.UTC),
+			cron:        "0 11 * * *",
+			grace:       90 * time.Minute,
+			want:        false,
+		},
+		{
+			name:        "spring DST skips nonexistent local boundary",
+			now:         time.Date(2026, time.March, 8, 4, 0, 0, 0, newYork),
+			lastAttempt: time.Date(2026, time.March, 7, 3, 30, 0, 0, newYork),
+			cron:        "30 2 * * *",
+			grace:       30 * time.Minute,
+			want:        false,
+		},
+		{
+			name:        "fall DST evaluates boundary in repository location",
+			now:         time.Date(2026, time.November, 1, 2, 45, 0, 0, newYork),
+			lastAttempt: time.Date(2026, time.October, 31, 2, 30, 0, 0, newYork),
+			cron:        "30 2 * * *",
+			grace:       15 * time.Minute,
+			want:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			end := tc.lastAttempt.Add(time.Minute)
+			repo := typedef.Repository{Name: tc.name, URL: "github.com/acme/" + tc.name, Cron: tc.cron}
+			stats := map[string]db.RepositoryRunStats{repo.Key(): *runStatsAt("completed", tc.lastAttempt, &end)}
+			got := buildRepositorySnapshot([]typedef.Repository{repo}, stats, tc.now, tc.grace, time.Hour)
+			require.Equal(t, tc.want, got[0].Overdue)
+		})
+	}
+}
+
+func TestRepositoryHealthDefaultsThresholdsAndPreservesOrgRollup(t *testing.T) {
+	now := time.Date(2026, time.September, 4, 12, 0, 0, 0, time.UTC)
+	alphaEnd := now.Add(-47 * time.Hour)
+	betaEnd := now.Add(-22 * time.Hour)
+	stats := map[string]db.RepositoryRunStats{
+		"github.com/acme/alpha": {
+			LatestExecutionID: "alpha", LatestStatus: "completed", LatestStart: now.Add(-48 * time.Hour), LatestEnd: &alphaEnd,
+			LastSuccess: &alphaEnd, TotalRuns: 2, SuccessRuns: 2,
+		},
+		"github.com/acme/beta": {
+			LatestExecutionID: "beta", LatestStatus: "failed", LatestStart: now.Add(-23 * time.Hour), LatestEnd: &betaEnd,
+			LatestError: "beta failed", TotalRuns: 3, FailedRuns: 3,
+		},
+		"github.com/acme2/outside": {
+			LatestExecutionID: "outside", LatestStatus: "running", LatestStart: now.Add(-48 * time.Hour), TotalRuns: 99,
+		},
+	}
+	repos := []typedef.Repository{{Name: "Acme", Type: typedef.TypeOrg, OrgName: "acme"}}
+
+	got := buildRepositorySnapshot(repos, stats, now, 0, 0)
+	require.Len(t, got, 1)
+	require.Equal(t, "https://github.com/acme", got[0].URL)
+	require.Equal(t, int64(5), got[0].TotalRuns)
+	require.Equal(t, int64(2), got[0].SuccessRuns)
+	require.Equal(t, int64(3), got[0].FailedRuns)
+	require.Equal(t, "beta", got[0].LatestExecutionID)
+	require.Equal(t, "failed", got[0].HealthStatus)
+	require.Equal(t, "beta failed", got[0].LastErrorMessage)
+	require.Equal(t, config.DefaultSyncOverdueGrace, 30*time.Minute)
+	require.Equal(t, config.DefaultSyncStuckThreshold, 24*time.Hour)
+	require.Empty(t, repos[0].URL, "snapshot projection must not mutate config entries")
+
+	pendingRecent := typedef.Repository{Name: "recent", URL: "github.com/acme/recent"}
+	pendingOld := typedef.Repository{Name: "old", URL: "github.com/acme/old"}
+	graceBoundary := typedef.Repository{Name: "grace", URL: "github.com/acme/grace", Cron: "45 * * * *"}
+	graceEnd := now.Add(-59 * time.Minute)
+	defaultStats := map[string]db.RepositoryRunStats{
+		pendingRecent.Key(): *runStatsAt("pending", now.Add(-23*time.Hour), nil),
+		pendingOld.Key():    *runStatsAt("pending", now.Add(-25*time.Hour), nil),
+		graceBoundary.Key(): *runStatsAt("completed", now.Add(-time.Hour), &graceEnd),
+	}
+	defaults := buildRepositorySnapshot([]typedef.Repository{pendingRecent, pendingOld, graceBoundary}, defaultStats, now, -time.Second, 0)
+	require.False(t, defaults[0].Stuck)
+	require.True(t, defaults[1].Stuck)
+	require.False(t, defaults[2].Overdue, "default grace keeps the 11:45 boundary within grace at noon")
+}
+
+func TestRepositoryHealthSearchFilterSummaryAndSortAreDeterministic(t *testing.T) {
+	when := time.Date(2026, time.September, 4, 8, 0, 0, 0, time.UTC)
+	input := []RepositoryOverview{
+		{Repository: typedef.Repository{Name: "beta", URL: "https://github.com/acme/beta"}, HealthStatus: "failed", LastStatus: "failed", LastAttemptTime: timePointer(when.Add(time.Hour)), LastSuccessTime: timePointer(when), Overdue: true},
+		{Repository: typedef.Repository{Name: "Alpha", URL: "https://github.com/acme/zeta"}, HealthStatus: "pending", LastStatus: "pending", LastAttemptTime: timePointer(when), Stuck: true},
+		{Repository: typedef.Repository{Name: "alpha", URL: "https://github.com/acme/alpha"}, HealthStatus: "running", LastStatus: "running", LastAttemptTime: timePointer(when)},
+		{Repository: typedef.Repository{Name: "never", URL: "https://gitlab.com/other/never"}, HealthStatus: "never_synced"},
+		{Repository: typedef.Repository{Name: "done", URL: "https://github.com/acme/done"}, HealthStatus: "overdue", LastStatus: "completed", LastSuccessTime: timePointer(when.Add(-time.Hour)), Overdue: true},
+		{Repository: typedef.Repository{Name: "stop", URL: "https://github.com/acme/stop"}, HealthStatus: "cancelled", LastStatus: "cancelled"},
+	}
+
+	searched := searchRepositorySnapshot(input, "GITHUB.COM/ACME")
+	require.Len(t, searched, 5)
+	summary := summarizeRepositorySnapshot(searched)
+	require.Equal(t, RepositoryHealthSummary{Total: 5, Healthy: 1, Failed: 1, Pending: 1, Running: 1, Cancelled: 1, Overdue: 2, Stuck: 1}, summary)
+
+	syncing := filterRepositorySnapshot(searched, RepositoryHealthFilter{Health: "syncing"})
+	require.Len(t, syncing, 2)
+	require.Equal(t, []string{"Alpha", "alpha"}, overviewNames(syncing))
+	require.Len(t, filterRepositorySnapshot(searched, RepositoryHealthFilter{Health: "failed", Overdue: boolPointer(true)}), 1)
+	require.Len(t, filterRepositorySnapshot(searched, RepositoryHealthFilter{Stuck: boolPointer(false)}), 4)
+
+	sorted := append([]RepositoryOverview(nil), input...)
+	sortRepositorySnapshot(sorted, "attention", "asc")
+	require.Equal(t, []string{"Alpha", "beta", "done", "never", "stop", "alpha"}, overviewNames(sorted))
+	sortRepositorySnapshot(sorted, "name", "asc")
+	require.Equal(t, []string{"alpha", "Alpha", "beta", "done", "never", "stop"}, overviewNames(sorted), "normalized key breaks case-folded name ties")
+	sortRepositorySnapshot(sorted, "last_attempt", "desc")
+	require.Equal(t, []string{"beta", "alpha", "Alpha", "done", "never", "stop"}, overviewNames(sorted), "descending times keep nil values last")
+
+	sortCases := []struct {
+		sortKey   string
+		direction string
+		want      []string
+	}{
+		{sortKey: "attention", direction: "desc", want: []string{"alpha", "stop", "never", "done", "beta", "Alpha"}},
+		{sortKey: "name", direction: "desc", want: []string{"stop", "never", "done", "beta", "alpha", "Alpha"}},
+		{sortKey: "last_attempt", direction: "asc", want: []string{"alpha", "Alpha", "beta", "done", "never", "stop"}},
+		{sortKey: "last_success", direction: "asc", want: []string{"done", "beta", "alpha", "Alpha", "never", "stop"}},
+		{sortKey: "last_success", direction: "desc", want: []string{"beta", "done", "alpha", "Alpha", "never", "stop"}},
+	}
+	for _, tc := range sortCases {
+		candidate := append([]RepositoryOverview(nil), input...)
+		sortRepositorySnapshot(candidate, tc.sortKey, tc.direction)
+		require.Equal(t, tc.want, overviewNames(candidate), tc.sortKey+" "+tc.direction)
+	}
+
+	require.Equal(t, "beta", input[0].Name, "helpers must not mutate shared snapshot inputs except the explicit sort target")
+}
+
+func runStatsAt(status string, start time.Time, end *time.Time) *db.RepositoryRunStats {
+	return &db.RepositoryRunStats{
+		LatestExecutionID: "execution-" + status,
+		LatestStatus:      status,
+		LatestStart:       start,
+		LatestEnd:         end,
+		LatestError:       "error-" + status,
+		TotalRuns:         1,
+	}
+}
+
+func secondsPtr(duration time.Duration) *int64 {
+	seconds := int64(duration / time.Second)
+	return &seconds
+}
+
+func timePointer(value time.Time) *time.Time { return &value }
+
+func boolPointer(value bool) *bool { return &value }
+
+func overviewNames(overviews []RepositoryOverview) []string {
+	names := make([]string, len(overviews))
+	for i := range overviews {
+		names[i] = overviews[i].Name
+	}
+	return names
+}

--- a/internal/server/repository_health_test.go
+++ b/internal/server/repository_health_test.go
@@ -31,7 +31,7 @@ func TestRepositoryHealthUsesAttentionPrecedenceAndSafeDurations(t *testing.T) {
 		{name: "running", stats: runStatsAt("running", now.Add(-time.Hour), nil), wantHealth: "running", wantDuration: secondsPtr(time.Hour)},
 		{name: "failed beats overdue", cron: "0 * * * *", stats: runStatsAt("failed", now.Add(-3*time.Hour), &ended), wantHealth: "failed", wantOverdue: true, wantDuration: secondsPtr(time.Hour)},
 		{name: "cancelled", stats: runStatsAt("cancelled", now.Add(-time.Hour), &ended), wantHealth: "cancelled", wantDuration: secondsPtr(0)},
-		{name: "overdue beats cancelled", cron: "0 * * * *", stats: runStatsAt("cancelled", now.Add(-3*time.Hour), &ended), wantHealth: "overdue", wantOverdue: true, wantDuration: secondsPtr(time.Hour)},
+		{name: "cancelled beats overdue", cron: "0 * * * *", stats: runStatsAt("cancelled", now.Add(-3*time.Hour), &ended), wantHealth: "cancelled", wantOverdue: true, wantDuration: secondsPtr(time.Hour)},
 		{name: "overdue completed", cron: "0 * * * *", stats: runStatsAt("completed", now.Add(-3*time.Hour), &ended), wantHealth: "overdue", wantOverdue: true, wantDuration: secondsPtr(time.Hour)},
 		{name: "healthy", cron: "0 * * * *", stats: runStatsAt("completed", now.Add(-20*time.Minute), &ended), wantHealth: "healthy", wantDuration: secondsPtr(0)},
 		{name: "active is never overdue", cron: "0 * * * *", stats: runStatsAt("running", now.Add(-3*time.Hour), nil), wantHealth: "running", wantDuration: secondsPtr(3 * time.Hour)},
@@ -184,7 +184,9 @@ func TestRepositoryHealthSearchFilterSummaryAndSortAreDeterministic(t *testing.T
 	searched := searchRepositorySnapshot(input, "GITHUB.COM/ACME")
 	require.Len(t, searched, 5)
 	summary := summarizeRepositorySnapshot(searched)
-	require.Equal(t, RepositoryHealthSummary{Total: 5, Healthy: 1, Failed: 1, Pending: 1, Running: 1, Cancelled: 1, Overdue: 2, Stuck: 1}, summary)
+	require.Equal(t, RepositoryHealthSummary{Total: 5, Failed: 1, Pending: 1, Running: 1, Cancelled: 1, Overdue: 2, Stuck: 1}, summary)
+	healthy := filterRepositorySnapshot(searched, RepositoryHealthFilter{Health: "healthy"})
+	require.Equal(t, summary.Healthy, len(healthy), "Healthy summary card must equal its health filter")
 
 	syncing := filterRepositorySnapshot(searched, RepositoryHealthFilter{Health: "syncing"})
 	require.Len(t, syncing, 2)

--- a/internal/server/repository_test.go
+++ b/internal/server/repository_test.go
@@ -276,7 +276,10 @@ func TestGetRepositoriesHealthFiltersSortsAndSummarizesSearchMatches(t *testing.
 		status, data := get("?search=match&health=failed&page=1&limit=1")
 		require.Equal(t, http.StatusOK, status)
 		require.Equal(t, 1, data.Total)
-		require.Equal(t, healthSummary{Total: 5, Healthy: 1, Failed: 1, Pending: 1, Running: 2, Overdue: 1, Stuck: 1}, data.Summary)
+		require.Equal(t, healthSummary{Total: 5, Failed: 1, Pending: 1, Running: 2, Overdue: 1, Stuck: 1}, data.Summary)
+		status, healthy := get("?search=match&health=healthy")
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, data.Summary.Healthy, healthy.Total, "Healthy card count must match the same search/filter endpoint")
 	})
 
 	t.Run("sorts each supported key and direction", func(t *testing.T) {

--- a/internal/server/repository_test.go
+++ b/internal/server/repository_test.go
@@ -152,6 +152,159 @@ func TestGetRepositories(t *testing.T) {
 	})
 }
 
+func TestGetRepositoriesHealthFiltersSortsAndSummarizesSearchMatches(t *testing.T) {
+	testDB, err := db.Initialize(":memory:")
+	require.NoError(t, err)
+	defer testDB.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	cfg := &config.Config{
+		SyncStuckThreshold: 90 * time.Minute,
+		Repository: []typedef.Repository{
+			{Name: "match-failed", URL: "github.com/health/failed"},
+			{Name: "match-pending", URL: "github.com/health/pending"},
+			{Name: "match-running", URL: "github.com/health/running"},
+			{Name: "match-overdue", URL: "github.com/health/overdue", Cron: "0 * * * *"},
+			{Name: "match-stuck", URL: "github.com/health/stuck"},
+			{Name: "outside", URL: "github.com/health/outside"},
+		},
+	}
+	insertExecution := func(id, repoKey, status string, start time.Time, end *time.Time) {
+		_, err := testDB.Exec(`INSERT INTO executions (id, job_name, repo_key, start_time, end_time, status, error_message) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			id, id, repoKey, start, end, status, "error-"+id)
+		require.NoError(t, err)
+	}
+	failedEnd := now.Add(-9 * time.Minute)
+	overdueEnd := now.Add(-3 * time.Hour)
+	insertExecution("failed", "github.com/health/failed", "failed", now.Add(-10*time.Minute), &failedEnd)
+	insertExecution("pending", "github.com/health/pending", "pending", now.Add(-8*time.Minute), nil)
+	insertExecution("running", "github.com/health/running", "running", now.Add(-7*time.Minute), nil)
+	insertExecution("overdue", "github.com/health/overdue", "completed", now.Add(-4*time.Hour), &overdueEnd)
+	insertExecution("stuck", "github.com/health/stuck", "running", now.Add(-2*time.Hour), nil)
+
+	s := server.NewRepoTestServer(cfg, testDB)
+	type repoView struct {
+		Name                string     `json:"Name"`
+		LastStatus          string     `json:"last_status"`
+		HealthStatus        string     `json:"health_status"`
+		LastAttemptTime     *time.Time `json:"last_attempt_time"`
+		LastSuccessTime     *time.Time `json:"last_success_time"`
+		LastDurationSeconds *int64     `json:"last_duration_seconds"`
+		LatestExecutionID   string     `json:"latest_execution_id"`
+		LastErrorMessage    string     `json:"last_error_message"`
+		Overdue             bool       `json:"overdue"`
+		Stuck               bool       `json:"stuck"`
+		ScheduleError       string     `json:"schedule_error"`
+	}
+	type healthSummary struct {
+		Total       int `json:"total"`
+		Healthy     int `json:"healthy"`
+		Failed      int `json:"failed"`
+		Pending     int `json:"pending"`
+		Running     int `json:"running"`
+		NeverSynced int `json:"never_synced"`
+		Cancelled   int `json:"cancelled"`
+		Overdue     int `json:"overdue"`
+		Stuck       int `json:"stuck"`
+	}
+	type listData struct {
+		Repositories []repoView    `json:"repositories"`
+		Summary      healthSummary `json:"summary"`
+		Total        int           `json:"total"`
+		Page         int           `json:"page"`
+		Limit        int           `json:"limit"`
+	}
+	get := func(query string) (int, listData) {
+		req := httptest.NewRequest(http.MethodGet, "/api/repositories"+query, nil)
+		resp := httptest.NewRecorder()
+		s.ServeHTTP(resp, req)
+		var response struct {
+			Data listData `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &response))
+		return resp.Code, response.Data
+	}
+	names := func(repositories []repoView) []string {
+		out := make([]string, len(repositories))
+		for i, repository := range repositories {
+			out[i] = repository.Name
+		}
+		return out
+	}
+
+	t.Run("returns health response fields and legacy fields together", func(t *testing.T) {
+		status, data := get("?search=match&health=failed")
+		require.Equal(t, http.StatusOK, status)
+		require.Len(t, data.Repositories, 1)
+		failed := data.Repositories[0]
+		require.Equal(t, "match-failed", failed.Name)
+		require.Equal(t, "failed", failed.LastStatus)
+		require.Equal(t, "failed", failed.HealthStatus)
+		require.NotNil(t, failed.LastAttemptTime)
+		require.NotNil(t, failed.LastDurationSeconds)
+		require.Equal(t, "failed", failed.LatestExecutionID)
+		require.Equal(t, "error-failed", failed.LastErrorMessage)
+		require.False(t, failed.Overdue)
+		require.False(t, failed.Stuck)
+		require.Empty(t, failed.ScheduleError)
+	})
+
+	t.Run("filters health booleans and paginates after filtering", func(t *testing.T) {
+		status, syncing := get("?search=match&health=syncing")
+		require.Equal(t, http.StatusOK, status)
+		require.ElementsMatch(t, []string{"match-pending", "match-running", "match-stuck"}, names(syncing.Repositories))
+
+		status, overdue := get("?search=match&overdue=true")
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, []string{"match-overdue"}, names(overdue.Repositories))
+
+		status, stuck := get("?search=match&stuck=true")
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, []string{"match-stuck"}, names(stuck.Repositories))
+
+		status, page := get("?search=match&health=syncing&sort=name&direction=asc&page=2&limit=1")
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, 3, page.Total)
+		require.Equal(t, 2, page.Page)
+		require.Equal(t, 1, page.Limit)
+		require.Equal(t, []string{"match-running"}, names(page.Repositories))
+	})
+
+	t.Run("summarizes all search matches before current filters and page", func(t *testing.T) {
+		status, data := get("?search=match&health=failed&page=1&limit=1")
+		require.Equal(t, http.StatusOK, status)
+		require.Equal(t, 1, data.Total)
+		require.Equal(t, healthSummary{Total: 5, Healthy: 1, Failed: 1, Pending: 1, Running: 2, Overdue: 1, Stuck: 1}, data.Summary)
+	})
+
+	t.Run("sorts each supported key and direction", func(t *testing.T) {
+		for _, query := range []string{
+			"?search=match&sort=attention&direction=asc",
+			"?search=match&sort=attention&direction=desc",
+			"?search=match&sort=name&direction=asc",
+			"?search=match&sort=name&direction=desc",
+			"?search=match&sort=last_attempt&direction=asc",
+			"?search=match&sort=last_attempt&direction=desc",
+			"?search=match&sort=last_success&direction=asc",
+			"?search=match&sort=last_success&direction=desc",
+		} {
+			status, data := get(query)
+			require.Equal(t, http.StatusOK, status, query)
+			require.Len(t, data.Repositories, 5, query)
+		}
+	})
+
+	t.Run("rejects malformed filters sort pagination and direction", func(t *testing.T) {
+		for _, query := range []string{
+			"?health=unknown", "?health=", "?overdue=maybe", "?stuck=1", "?sort=unknown", "?sort=", "?direction=sideways", "?direction=",
+			"?page=0", "?page=not-a-number", "?limit=0", "?limit=101", "?limit=not-a-number",
+		} {
+			status, _ := get(query)
+			require.Equal(t, http.StatusBadRequest, status, query)
+		}
+	})
+}
+
 func TestGetRepositoriesSynthesizesOrgURL(t *testing.T) {
 	testDB, err := db.Initialize(":memory:")
 	require.NoError(t, err)

--- a/internal/server/repository_test.go
+++ b/internal/server/repository_test.go
@@ -175,7 +175,9 @@ func TestGetRepositoriesHealthFiltersSortsAndSummarizesSearchMatches(t *testing.
 		require.NoError(t, err)
 	}
 	failedEnd := now.Add(-9 * time.Minute)
+	failedSuccessEnd := now.Add(-time.Hour)
 	overdueEnd := now.Add(-3 * time.Hour)
+	insertExecution("failed-success", "github.com/health/failed", "completed", now.Add(-2*time.Hour), &failedSuccessEnd)
 	insertExecution("failed", "github.com/health/failed", "failed", now.Add(-10*time.Minute), &failedEnd)
 	insertExecution("pending", "github.com/health/pending", "pending", now.Add(-8*time.Minute), nil)
 	insertExecution("running", "github.com/health/running", "running", now.Add(-7*time.Minute), nil)
@@ -278,19 +280,22 @@ func TestGetRepositoriesHealthFiltersSortsAndSummarizesSearchMatches(t *testing.
 	})
 
 	t.Run("sorts each supported key and direction", func(t *testing.T) {
-		for _, query := range []string{
-			"?search=match&sort=attention&direction=asc",
-			"?search=match&sort=attention&direction=desc",
-			"?search=match&sort=name&direction=asc",
-			"?search=match&sort=name&direction=desc",
-			"?search=match&sort=last_attempt&direction=asc",
-			"?search=match&sort=last_attempt&direction=desc",
-			"?search=match&sort=last_success&direction=asc",
-			"?search=match&sort=last_success&direction=desc",
+		for _, tc := range []struct {
+			query string
+			want  []string
+		}{
+			{query: "?search=match&sort=attention&direction=asc", want: []string{"match-stuck", "match-failed", "match-overdue", "match-pending", "match-running"}},
+			{query: "?search=match&sort=attention&direction=desc", want: []string{"match-running", "match-pending", "match-overdue", "match-failed", "match-stuck"}},
+			{query: "?search=match&sort=name&direction=asc", want: []string{"match-failed", "match-overdue", "match-pending", "match-running", "match-stuck"}},
+			{query: "?search=match&sort=name&direction=desc", want: []string{"match-stuck", "match-running", "match-pending", "match-overdue", "match-failed"}},
+			{query: "?search=match&sort=last_attempt&direction=asc", want: []string{"match-overdue", "match-stuck", "match-failed", "match-pending", "match-running"}},
+			{query: "?search=match&sort=last_attempt&direction=desc", want: []string{"match-running", "match-pending", "match-failed", "match-stuck", "match-overdue"}},
+			{query: "?search=match&sort=last_success&direction=asc", want: []string{"match-overdue", "match-failed", "match-pending", "match-running", "match-stuck"}},
+			{query: "?search=match&sort=last_success&direction=desc", want: []string{"match-failed", "match-overdue", "match-pending", "match-running", "match-stuck"}},
 		} {
-			status, data := get(query)
-			require.Equal(t, http.StatusOK, status, query)
-			require.Len(t, data.Repositories, 5, query)
+			status, data := get(tc.query)
+			require.Equal(t, http.StatusOK, status, tc.query)
+			require.Equal(t, tc.want, names(data.Repositories), tc.query)
 		}
 	})
 

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -67,11 +67,42 @@ const (
 
 type RepositoryOverview struct {
 	typedef.Repository
-	LastRunTime *time.Time `json:"last_run_time"`
-	NextRunTime *time.Time `json:"next_run_time"`
-	TotalRuns   int64      `json:"total_runs"`
-	SuccessRuns int64      `json:"success_runs"`
-	FailedRuns  int64      `json:"failed_runs"`
+	LastRunTime         *time.Time `json:"last_run_time"`
+	NextRunTime         *time.Time `json:"next_run_time"`
+	TotalRuns           int64      `json:"total_runs"`
+	SuccessRuns         int64      `json:"success_runs"`
+	FailedRuns          int64      `json:"failed_runs"`
+	LastStatus          string     `json:"last_status"`
+	HealthStatus        string     `json:"health_status"`
+	LastAttemptTime     *time.Time `json:"last_attempt_time"`
+	LastSuccessTime     *time.Time `json:"last_success_time"`
+	LastDurationSeconds *int64     `json:"last_duration_seconds"`
+	LatestExecutionID   string     `json:"latest_execution_id"`
+	LastErrorMessage    string     `json:"last_error_message"`
+	Overdue             bool       `json:"overdue"`
+	Stuck               bool       `json:"stuck"`
+	ScheduleError       string     `json:"schedule_error"`
+}
+
+type RepositoryHealthFilter struct {
+	Search    string
+	Health    string
+	Overdue   *bool
+	Stuck     *bool
+	Sort      string
+	Direction string
+}
+
+type RepositoryHealthSummary struct {
+	Total       int `json:"total"`
+	Healthy     int `json:"healthy"`
+	Failed      int `json:"failed"`
+	Pending     int `json:"pending"`
+	Running     int `json:"running"`
+	NeverSynced int `json:"never_synced"`
+	Cancelled   int `json:"cancelled"`
+	Overdue     int `json:"overdue"`
+	Stuck       int `json:"stuck"`
 }
 
 type ListRepositoriesResponse struct {

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -3,6 +3,7 @@ package server
 import (
 	"time"
 
+	"github.com/wnarutou/gitrieve/internal/db"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 )
 
@@ -106,10 +107,15 @@ type RepositoryHealthSummary struct {
 }
 
 type ListRepositoriesResponse struct {
-	Repositories []RepositoryOverview `json:"repositories"`
-	Total        int                  `json:"total"`
-	Page         int                  `json:"page"`
-	Limit        int                  `json:"limit"`
+	Repositories []RepositoryOverview    `json:"repositories"`
+	Summary      RepositoryHealthSummary `json:"summary"`
+	Total        int                     `json:"total"`
+	Page         int                     `json:"page"`
+	Limit        int                     `json:"limit"`
+}
+
+type ListComponentsResponse struct {
+	Components []db.ComponentExecution `json:"components"`
 }
 
 type ImportPreviewRequest struct {

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -32,6 +32,28 @@ type CreateJobResponse struct {
 	Status string   `json:"status"`
 }
 
+type BulkJobSelector struct {
+	Search  string `json:"search"`
+	Health  string `json:"health"`
+	Overdue *bool  `json:"overdue,omitempty"`
+}
+
+type BulkCreateJobsRequest struct {
+	Selector      BulkJobSelector `json:"selector"`
+	ExpectedCount int             `json:"expected_count"`
+}
+
+// BulkCreateJobsResponse accounts for every repository in the server-confirmed
+// eligible set: Requested = Queued + SkippedActive + NoLongerEligible +
+// FailedToEnqueue.
+type BulkCreateJobsResponse struct {
+	Requested        int `json:"requested"`
+	Queued           int `json:"queued"`
+	SkippedActive    int `json:"skipped_active"`
+	NoLongerEligible int `json:"no_longer_eligible"`
+	FailedToEnqueue  int `json:"failed_to_enqueue"`
+}
+
 type CancelJobResponse struct {
 	Status string `json:"status"`
 }

--- a/internal/syncresult/syncresult.go
+++ b/internal/syncresult/syncresult.go
@@ -16,8 +16,14 @@ func Skip(reason string) error {
 
 func SkippedReason(err error) (string, bool) {
 	var skipped SkippedError
-	if !errors.As(err, &skipped) {
-		return "", false
+	if errors.As(err, &skipped) {
+		return skipped.Reason, true
 	}
-	return skipped.Reason, true
+
+	var skippedPointer *SkippedError
+	if errors.As(err, &skippedPointer) && skippedPointer != nil {
+		return skippedPointer.Reason, true
+	}
+
+	return "", false
 }

--- a/internal/syncresult/syncresult.go
+++ b/internal/syncresult/syncresult.go
@@ -1,0 +1,23 @@
+package syncresult
+
+import "errors"
+
+type SkippedError struct {
+	Reason string
+}
+
+func (e SkippedError) Error() string {
+	return e.Reason
+}
+
+func Skip(reason string) error {
+	return SkippedError{Reason: reason}
+}
+
+func SkippedReason(err error) (string, bool) {
+	var skipped SkippedError
+	if !errors.As(err, &skipped) {
+		return "", false
+	}
+	return skipped.Reason, true
+}

--- a/internal/syncresult/syncresult_test.go
+++ b/internal/syncresult/syncresult_test.go
@@ -17,3 +17,25 @@ func TestSkippedReasonSurvivesWrapping(t *testing.T) {
 	_, ok = SkippedReason(errors.New("network down"))
 	require.False(t, ok)
 }
+
+func TestSkippedReasonRecognizesPointer(t *testing.T) {
+	reason, ok := SkippedReason(&SkippedError{Reason: "repository has no wiki"})
+
+	require.True(t, ok)
+	require.Equal(t, "repository has no wiki", reason)
+}
+
+func TestSkippedReasonRecognizesWrappedPointer(t *testing.T) {
+	err := fmt.Errorf("wiki preflight: %w", &SkippedError{Reason: "repository has no wiki"})
+	reason, ok := SkippedReason(err)
+
+	require.True(t, ok)
+	require.Equal(t, "repository has no wiki", reason)
+}
+
+func TestSkippedReasonRejectsNilPointer(t *testing.T) {
+	var skipped *SkippedError
+
+	_, ok := SkippedReason(skipped)
+	require.False(t, ok)
+}

--- a/internal/syncresult/syncresult_test.go
+++ b/internal/syncresult/syncresult_test.go
@@ -1,0 +1,19 @@
+package syncresult
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkippedReasonSurvivesWrapping(t *testing.T) {
+	err := fmt.Errorf("wiki preflight: %w", Skip("repository has no wiki"))
+	reason, ok := SkippedReason(err)
+	require.True(t, ok)
+	require.Equal(t, "repository has no wiki", reason)
+
+	_, ok = SkippedReason(errors.New("network down"))
+	require.False(t, ok)
+}

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -35,10 +35,10 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 		return err
 	}
 
-	cfg := config.GetIns()
+	cfg := config.GetExecutionConfig(ctx)
 	client := gh.NewClient(nil).WithAuthToken(cfg.GitHubToken)
 
-	gitrepo, _, err := client.Repositories.Get(context.Background(), r.Owner, r.Name)
+	gitrepo, _, err := client.Repositories.Get(ctx, r.Owner, r.Name)
 	if err != nil {
 		ui.Errorf("Get repository %s fail", repo.URL)
 		return err

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -6,7 +6,9 @@ import (
 
 	gh "github.com/google/go-github/v56/github"
 	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/repository"
+	"github.com/wnarutou/gitrieve/internal/retry"
 	"github.com/wnarutou/gitrieve/internal/scm"
 	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
@@ -38,7 +40,18 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 	cfg := config.GetExecutionConfig(ctx)
 	client := gh.NewClient(nil).WithAuthToken(cfg.GitHubToken)
 
-	gitrepo, _, err := client.Repositories.Get(ctx, r.Owner, r.Name)
+	var gitrepo *gh.Repository
+	err = retry.Do(ctx, config.GetRetryConfigContext(ctx), func() error {
+		permit, acquireErr := githubapi.Acquire(ctx, "core")
+		if acquireErr != nil {
+			return acquireErr
+		}
+		var response *gh.Response
+		var apiErr error
+		gitrepo, response, apiErr = client.Repositories.Get(ctx, r.Owner, r.Name)
+		permit.Done(githubapi.ObserveREST(response, apiErr))
+		return apiErr
+	})
 	if err != nil {
 		ui.Errorf("Get repository %s fail", repo.URL)
 		return err

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -45,8 +45,6 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 	}
 
 	if err := wikiAvailability(repo.URL, gitrepo.GetHasWiki()); err != nil {
-		reason, _ := syncresult.SkippedReason(err)
-		ui.Printf("Skipped: %s", reason)
 		return err
 	}
 

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -2,14 +2,23 @@ package wiki
 
 import (
 	"context"
+	"fmt"
 
 	gh "github.com/google/go-github/v56/github"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/repository"
 	"github.com/wnarutou/gitrieve/internal/scm"
+	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 	"github.com/wnarutou/gitrieve/internal/ui"
 )
+
+func wikiAvailability(repoURL string, hasWiki bool) error {
+	if hasWiki {
+		return nil
+	}
+	return syncresult.Skip(fmt.Sprintf("repository %s has no wiki", repoURL))
+}
 
 func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.MultiStorage) error {
 	if ctx.Err() != nil {
@@ -35,8 +44,10 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 		return err
 	}
 
-	if !gitrepo.GetHasWiki() {
-		ui.Errorf("repository %s has no wiki", repo.URL)
+	if err := wikiAvailability(repo.URL, gitrepo.GetHasWiki()); err != nil {
+		reason, _ := syncresult.SkippedReason(err)
+		ui.Printf("Skipped: %s", reason)
+		return err
 	}
 
 	ui.Printf("Running %s's wiki", repo.Name)

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -2,12 +2,32 @@ package wiki
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
+	"github.com/wnarutou/gitrieve/internal/ui"
 )
+
+type wikiRoundTripper func(*http.Request) (*http.Response, error)
+
+func (fn wikiRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type wikiLogSink struct {
+	logs []string
+}
+
+func (s *wikiLogSink) Log(_, _, level, message string) error {
+	s.logs = append(s.logs, level+":"+message)
+	return nil
+}
 
 func TestWikiAvailabilitySkipsRepositoryWithoutWiki(t *testing.T) {
 	err := wikiAvailability("github.com/test/repo", false)
@@ -16,6 +36,39 @@ func TestWikiAvailabilitySkipsRepositoryWithoutWiki(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "repository github.com/test/repo has no wiki", reason)
 	require.NoError(t, wikiAvailability("github.com/test/repo", true))
+}
+
+func TestSyncSkipsUnavailableWikiWithoutPresentationOrRepositorySync(t *testing.T) {
+	previousConfig := config.GetIns()
+	config.SetIns(&config.Config{})
+	if previousConfig != nil {
+		t.Cleanup(func() { config.SetIns(previousConfig) })
+	}
+
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = wikiRoundTripper(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "/repos/test/repo", req.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"has_wiki":false}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+	sink := &wikiLogSink{}
+	ui.SetSink(sink)
+	t.Cleanup(func() { ui.SetSink(nil) })
+	unbind := ui.Bind("execution-1", "wiki")
+	defer unbind()
+
+	err := Sync(context.Background(), typedef.Repository{Name: "repo", URL: "github.com/test/repo"}, nil)
+	reason, ok := syncresult.SkippedReason(err)
+
+	require.True(t, ok)
+	require.Equal(t, "repository github.com/test/repo has no wiki", reason)
+	require.Empty(t, sink.logs)
 }
 
 func TestSyncCancelledContextReturnsImmediately(t *testing.T) {

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -5,10 +5,13 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/config"
+	"github.com/wnarutou/gitrieve/internal/githubapi"
 	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 	"github.com/wnarutou/gitrieve/internal/ui"
@@ -77,4 +80,135 @@ func TestSyncCancelledContextReturnsImmediately(t *testing.T) {
 
 	err := Sync(ctx, typedef.Repository{URL: "github.com/test/repo"}, nil)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func wikiExecutionContext(parent context.Context, cfg *config.Config) context.Context {
+	ctx := config.WithExecutionSnapshot(parent, config.NewExecutionSnapshot(cfg))
+	return githubapi.WithScope(ctx, githubapi.NewScope(config.GitHubAPIConfigFrom(cfg)))
+}
+
+func TestWikiPreflightWaitsForScopedPermitAndReleasesItAfterObservation(t *testing.T) {
+	githubapi.Configure(githubapi.Config{Concurrency: 1})
+	held, err := githubapi.Acquire(context.Background(), "core")
+	require.NoError(t, err)
+	var releaseHeld sync.Once
+	t.Cleanup(func() { releaseHeld.Do(func() { held.Done(githubapi.Observation{}) }) })
+
+	requestSeen := make(chan struct{}, 1)
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = wikiRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requestSeen <- struct{}{}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"has_wiki":false}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+	cfg := &config.Config{RetryMaxCount: 0}
+	done := make(chan error, 1)
+	go func() {
+		done <- Sync(wikiExecutionContext(context.Background(), cfg), typedef.Repository{Name: "repo", URL: "github.com/test/repo"}, nil)
+	}()
+	select {
+	case <-requestSeen:
+		t.Fatal("wiki preflight reached HTTP while the process-wide permit was held")
+	case err := <-done:
+		t.Fatalf("wiki preflight returned before the held permit was released: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	releaseHeld.Do(func() { held.Done(githubapi.Observation{}) })
+	select {
+	case err := <-done:
+		_, skipped := syncresult.SkippedReason(err)
+		require.True(t, skipped)
+	case <-time.After(time.Second):
+		t.Fatal("wiki preflight did not resume after the permit was released")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	permit, err := githubapi.Acquire(ctx, "core")
+	require.NoError(t, err, "wiki observation did not release its permit")
+	permit.Done(githubapi.Observation{})
+}
+
+func TestWikiPreflightCancellationInterruptsPermitWait(t *testing.T) {
+	githubapi.Configure(githubapi.Config{Concurrency: 1})
+	held, err := githubapi.Acquire(context.Background(), "core")
+	require.NoError(t, err)
+	defer held.Done(githubapi.Observation{})
+
+	requestSeen := make(chan struct{}, 1)
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = wikiRoundTripper(func(req *http.Request) (*http.Response, error) {
+		requestSeen <- struct{}{}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"has_wiki":false}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+	ctx, cancel := context.WithCancel(wikiExecutionContext(context.Background(), &config.Config{}))
+	done := make(chan error, 1)
+	go func() {
+		done <- Sync(ctx, typedef.Repository{Name: "repo", URL: "github.com/test/repo"}, nil)
+	}()
+	select {
+	case <-requestSeen:
+		t.Fatal("wiki preflight bypassed the held permit")
+	case err := <-done:
+		t.Fatalf("wiki preflight returned before cancellation: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	cancel()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not interrupt wiki preflight permit wait")
+	}
+	select {
+	case <-requestSeen:
+		t.Fatal("cancelled wiki preflight reached HTTP")
+	default:
+	}
+}
+
+func TestWikiPreflightRetriesFromJobSnapshot(t *testing.T) {
+	githubapi.Configure(githubapi.Config{Concurrency: 1})
+	previousConfig := config.GetIns()
+	config.SetIns(&config.Config{RetryMaxCount: 0})
+	t.Cleanup(func() { config.SetIns(previousConfig) })
+
+	var calls int
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = wikiRoundTripper(func(req *http.Request) (*http.Response, error) {
+		calls++
+		status := http.StatusInternalServerError
+		body := `{"message":"temporary"}`
+		if calls == 2 {
+			status = http.StatusOK
+			body = `{"has_wiki":false}`
+		}
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+	cfg := &config.Config{RetryMaxCount: 1, RetryBaseDelay: time.Millisecond}
+	err := Sync(wikiExecutionContext(context.Background(), cfg), typedef.Repository{Name: "repo", URL: "github.com/test/repo"}, nil)
+	_, skipped := syncresult.SkippedReason(err)
+	require.True(t, skipped)
+	require.Equal(t, 2, calls, "wiki preflight must use the job snapshot retry count")
 }

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -5,8 +5,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wnarutou/gitrieve/internal/syncresult"
 	"github.com/wnarutou/gitrieve/internal/typedef"
 )
+
+func TestWikiAvailabilitySkipsRepositoryWithoutWiki(t *testing.T) {
+	err := wikiAvailability("github.com/test/repo", false)
+	reason, ok := syncresult.SkippedReason(err)
+
+	require.True(t, ok)
+	require.Equal(t, "repository github.com/test/repo has no wiki", reason)
+	require.NoError(t, wikiAvailability("github.com/test/repo", true))
+}
 
 func TestSyncCancelledContextReturnsImmediately(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -358,3 +358,81 @@ select:focus, input:focus {
 .diff-header strong { flex: 1; }
 .radio { display: inline-flex; align-items: center; gap: 4px; margin-right: 12px; font-size: 13px; color: var(--muted); }
 .alert.warn { padding: 10px 12px; border-radius: 8px; background: #fef3c7; color: #92400e; margin-bottom: 12px; }
+
+/* Repository sync health */
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 10px;
+    margin-bottom: 16px;
+}
+
+.summary-card {
+    appearance: none;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    padding: 14px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--panel);
+    color: var(--text);
+    cursor: pointer;
+    text-align: left;
+}
+
+.summary-card:hover { border-color: var(--primary); background: #f8fbff; }
+.summary-card strong { font-size: 22px; line-height: 1.1; }
+.summary-card span { color: var(--muted); font-size: 12px; }
+.repository-toolbar { margin-bottom: 16px; }
+.repository-table { overflow: visible; }
+
+.badge.health-healthy, .badge.component-completed { background: #dcfce7; color: #166534; }
+.badge.health-failed, .badge.component-failed { background: #fee2e2; color: #991b1b; }
+.badge.health-cancelled, .badge.component-cancelled { background: #e5e7eb; color: #374151; }
+.badge.health-overdue, .badge.health-stuck { background: #ffedd5; color: #9a3412; }
+.badge.health-never_synced { background: #f3e8ff; color: #6b21a8; }
+.badge.health-pending, .badge.component-pending { background: #fef3c7; color: #92400e; }
+.badge.health-running, .badge.health-syncing, .badge.component-running { background: #dbeafe; color: #1d4ed8; }
+.badge.component-skipped { background: #f3f4f6; color: #4b5563; }
+
+.component-details {
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--border);
+    background: #fafbfc;
+}
+
+.component-details h3 { margin: 0 0 8px; font-size: 14px; }
+.component-row {
+    display: grid;
+    grid-template-columns: minmax(90px, 0.8fr) auto minmax(72px, 0.5fr) minmax(0, 2fr);
+    gap: 10px;
+    align-items: center;
+    padding: 7px 0;
+    border-top: 1px solid var(--border);
+}
+.component-row:first-child { border-top: 0; }
+.component-error { color: var(--danger); overflow-wrap: anywhere; }
+
+button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible {
+    outline: 3px solid rgba(47,111,237,0.35);
+    outline-offset: 2px;
+}
+
+@media (max-width: 960px) {
+    .summary-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .repository-toolbar .toolbar { align-items: flex-start; }
+}
+
+@media (max-width: 640px) {
+    .app { margin: 16px auto; padding: 0 12px; }
+    .topbar { padding: 0 12px; gap: 8px; }
+    .nav-links a { padding: 6px 7px; }
+    .summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .toolbar, .toolbar-group, .page-header { align-items: stretch; }
+    .toolbar-group { flex-wrap: wrap; }
+    .toolbar-group input[type="text"] { min-width: 0; flex: 1 1 180px; }
+    .component-row { grid-template-columns: 1fr auto; }
+    .component-row .component-error { grid-column: 1 / -1; }
+}

--- a/web/static/css/main.css
+++ b/web/static/css/main.css
@@ -404,6 +404,22 @@ select:focus, input:focus {
 }
 
 .component-details h3 { margin: 0 0 8px; font-size: 14px; }
+.execution-details {
+    padding: 14px 20px;
+    border-bottom: 1px solid var(--border);
+    background: #fff;
+}
+.execution-details h3 { margin: 0 0 8px; font-size: 14px; }
+.execution-summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px 16px;
+    margin: 0 0 10px;
+}
+.execution-summary div { min-width: 0; }
+.execution-summary dt { color: var(--muted); font-size: 12px; }
+.execution-summary dd { margin: 1px 0 0; overflow-wrap: anywhere; }
+.execution-summary .execution-error { grid-column: 1 / -1; color: var(--danger); }
 .component-row {
     display: grid;
     grid-template-columns: minmax(90px, 0.8fr) auto minmax(72px, 0.5fr) minmax(0, 2fr);
@@ -435,4 +451,6 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
     .toolbar-group input[type="text"] { min-width: 0; flex: 1 1 180px; }
     .component-row { grid-template-columns: 1fr auto; }
     .component-row .component-error { grid-column: 1 / -1; }
+    .execution-summary { grid-template-columns: 1fr 1fr; }
+    .execution-summary .execution-error { grid-column: 1 / -1; }
 }

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -406,6 +406,7 @@ function renderExecutionDetails(repository, detailSerial, routeEpoch) {
     $('#execution-error').textContent = repository.last_error_message || '-';
     const retry = $('#btn-retry-execution');
     retry.onclick = null;
+    retry.disabled = false;
     retry.classList.toggle('hidden', !repositoryCanRetry(repository));
     if (repositoryCanRetry(repository)) {
         retry.onclick = () => retryExecutionRepository(repository, detailSerial, routeEpoch);
@@ -423,9 +424,16 @@ async function retryExecutionRepository(repository, detailSerial, routeEpoch) {
         });
         if (!isActiveRepositoryRoute(routeEpoch) || detailSerial !== state.componentDetailSerial) return;
         const jobIDs = (data && data.job_ids) || [];
-        toast('Repository retry started');
-        renderRepositories(routeEpoch);
-        if (jobIDs.length === 1) openLogModal(jobIDs[0], repository.Name);
+        if (jobIDs.length === 1) {
+            toast('Repository retry started');
+            renderRepositories(routeEpoch);
+            openLogModal(jobIDs[0], repository.Name);
+        } else {
+            closeLogModal();
+            if (jobIDs.length > 1) toast('Started ' + jobIDs.length + ' jobs (repository expansion)');
+            else toast('Repository retry accepted; no execution log was returned');
+            renderRepositories(routeEpoch);
+        }
     } catch (e) {
         if (isActiveRepositoryRoute(routeEpoch) && detailSerial === state.componentDetailSerial) {
             toast('Repository retry failed: ' + e.message, true);
@@ -535,12 +543,11 @@ async function saveRepo(ev) {
     try {
         if (originalKey) {
             await api('/api/repositories/' + encodeURIComponent(originalKey), { method: 'PUT', body: JSON.stringify(repo) });
-            toast('Repository updated');
         } else {
             await api('/api/repositories', { method: 'POST', body: JSON.stringify(repo) });
-            toast('Repository added');
         }
         if (!isActiveRepositoryRoute(routeEpoch)) return;
+        toast(originalKey ? 'Repository updated' : 'Repository added');
         $('#repo-modal').classList.add('hidden');
         renderRepositories(routeEpoch);
     } catch (e) {

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -41,6 +41,8 @@ async function api(path, opts) {
     try { body = await resp.json(); } catch (e) { /* ignore */ }
     if (!resp.ok || (body && typeof body.code === 'number' && body.code >= 400)) {
         const err = new Error((body && body.message) || ('HTTP ' + resp.status));
+        err.status = resp.status;
+        err.data = body ? body.data : null;
         if (body && body.data && Array.isArray(body.data.errors)) err.errors = body.data.errors;
         throw err;
     }
@@ -73,6 +75,12 @@ const state = {
     jobsRepo: '',
     reposPage: 1,
     reposSearch: '',
+    reposHealth: '',
+    reposOverdue: false,
+    reposSort: 'attention',
+    reposDirection: 'asc',
+    reposRenderSerial: 0,
+    componentDetailSerial: 0,
     es: null,
     logJob: null,
     logIds: {}
@@ -92,16 +100,58 @@ function setActiveNav(route) {
 
 function renderApp() {
     const hash = (location.hash || '#/jobs').replace(/^#\/?/, '');
-    const parts = hash.split('/');
-    const route = parts[0] || 'jobs';
+    const route = (hash.split('?')[0].split('/')[0]) || 'jobs';
     setActiveNav(route);
-    if (route === 'repositories') renderRepositories();
-    else if (route === 'storage') renderStorage();
-    else if (route === 'config') renderConfig();
-    else renderJobs();
+    if (route === 'repositories') {
+        applyRepositoryRoute(hash);
+        renderRepositories();
+    }
+    else {
+        state.reposRenderSerial++;
+        if (route === 'storage') renderStorage();
+        else if (route === 'config') renderConfig();
+        else renderJobs();
+    }
 }
 
 window.addEventListener('hashchange', renderApp);
+
+const repositoryHealthValues = ['healthy', 'failed', 'overdue', 'stuck', 'never_synced', 'cancelled', 'pending', 'running', 'syncing'];
+const repositorySortValues = ['attention', 'name', 'last_attempt', 'last_success'];
+
+function applyRepositoryRoute(hash) {
+    const query = (hash || '').split('?')[1] || '';
+    const p = new URLSearchParams(query);
+    const page = parseInt(p.get('page') || '1', 10);
+    const health = p.get('health') || '';
+    const sort = p.get('sort') || 'attention';
+    const direction = p.get('direction') || 'asc';
+    state.reposPage = Number.isFinite(page) && page > 0 ? page : 1;
+    state.reposSearch = p.get('search') || '';
+    state.reposHealth = repositoryHealthValues.includes(health) ? health : '';
+    state.reposOverdue = p.get('overdue') === 'true';
+    state.reposSort = repositorySortValues.includes(sort) ? sort : 'attention';
+    state.reposDirection = direction === 'desc' ? 'desc' : 'asc';
+}
+
+function repositoryParams() {
+    const p = new URLSearchParams({ page: state.reposPage, limit: 20 });
+    if (state.reposSearch) p.set('search', state.reposSearch);
+    if (state.reposHealth) p.set('health', state.reposHealth);
+    if (state.reposOverdue) p.set('overdue', 'true');
+    p.set('sort', state.reposSort || 'attention');
+    p.set('direction', state.reposDirection || 'asc');
+    return p;
+}
+
+function setRepositoryRoute(next) {
+    Object.assign(state, next);
+    const p = repositoryParams();
+    p.delete('limit');
+    const nextHash = '#/repositories?' + p.toString();
+    if (location.hash === nextHash) renderRepositories();
+    else location.hash = nextHash;
+}
 
 async function refreshMetrics() {
     const dot = $('#server-status');
@@ -262,14 +312,16 @@ async function runRepo(key, name, btn) {
     }
 }
 
-function openLogModal(jobId, jobName) {
+function openLogModal(jobId, jobName, showComponents) {
     if (state.es) state.es.close();
+    if (!showComponents) state.componentDetailSerial++;
     state.logJob = jobId;
     state.logIds = {};
     $('#log-modal-title').textContent = 'Logs: ' + jobName;
     $('#log-modal-state').textContent = '';
     const consoleEl = $('#log-console');
     consoleEl.innerHTML = '<div class="log-line muted">Waiting for logs\u2026</div>';
+    if (!showComponents) $('#component-details').classList.add('hidden');
     $('#log-modal').classList.remove('hidden');
 
     const es = new EventSource('/api/jobs/' + encodeURIComponent(jobId) + '/logs');
@@ -282,7 +334,6 @@ function openLogModal(jobId, jobName) {
         $('#log-modal-state').textContent = 'finished';
         es.close();
         if (state.es === es) state.es = null;
-        if (state.logJob === jobId) renderApp();
     });
 
     es.onmessage = (ev) => {
@@ -294,6 +345,44 @@ function openLogModal(jobId, jobName) {
     };
 
     es.onerror = () => { /* EventSource auto-reconnects; dedupe + done event handle the rest */ };
+}
+
+function componentBadge(status) {
+    const value = String(status || 'pending');
+    const cls = ['pending', 'running', 'completed', 'failed', 'skipped', 'cancelled'].includes(value) ? value : 'pending';
+    return '<span class="badge component-' + cls + '">' + esc(value) + '</span>';
+}
+
+function renderComponentDetails(components) {
+    const list = $('#component-list');
+    if (!components.length) {
+        list.textContent = 'Component details unavailable';
+        return;
+    }
+    list.innerHTML = components.map(component => `
+        <div class="component-row">
+            <strong>${esc(component.component)}</strong>
+            ${componentBadge(component.status)}
+            <span class="muted">${esc(fmtDuration(component.start_time, component.end_time))}</span>
+            <span class="component-error">${esc(component.error_message || '')}</span>
+        </div>`).join('');
+}
+
+async function openExecutionDetails(executionID, name) {
+    const detailSerial = ++state.componentDetailSerial;
+    $('#component-details').classList.remove('hidden');
+    $('#component-list').textContent = 'Loading component details…';
+    let components = [];
+    try {
+        const data = await api('/api/jobs/' + encodeURIComponent(executionID) + '/components');
+        components = (data && data.components) || [];
+    } catch (e) {
+        components = null;
+    }
+    if (detailSerial !== state.componentDetailSerial) return;
+    if (components === null) $('#component-list').textContent = 'Component details unavailable';
+    else renderComponentDetails(components);
+    openLogModal(executionID, name, true);
 }
 
 function appendLogLine(entry) {
@@ -311,6 +400,7 @@ function appendLogLine(entry) {
 
 async function closeLogModal() {
     if (state.es) { state.es.close(); state.es = null; }
+    state.componentDetailSerial++;
     $('#log-modal').classList.add('hidden');
 }
 
@@ -397,82 +487,159 @@ async function deleteRepo(key) {
     }
 }
 
+function repositoryHealthBadge(repo) {
+    const value = String(repo.health_status || 'never_synced');
+    const cls = repositoryHealthValues.includes(value) ? value : 'never_synced';
+    return '<span class="badge health-' + cls + '">' + esc(value) + '</span>';
+}
+
+function repositorySummaryCards(summary) {
+    const s = summary || {};
+    const cards = [
+        { label: 'All', count: s.total || 0, health: '' },
+        { label: 'Healthy', count: s.healthy || 0, health: 'healthy' },
+        { label: 'Failed', count: s.failed || 0, health: 'failed' },
+        { label: 'Syncing', count: (s.pending || 0) + (s.running || 0), health: 'syncing' },
+        { label: 'Never synced', count: s.never_synced || 0, health: 'never_synced' },
+        { label: 'Overdue', count: s.overdue || 0, overdue: true }
+    ];
+    return cards.map(card =>
+        '<button type="button" class="summary-card" data-health="' + esc(card.health || '') +
+        '" data-overdue="' + (card.overdue ? 'true' : '') + '"><strong>' +
+        esc(card.count) + '</strong><span>' + esc(card.label) + '</span></button>'
+    ).join('');
+}
+
+function repositoryBulkSelector() {
+    const selector = { search: state.reposSearch, health: state.reposHealth };
+    if (state.reposOverdue) selector.overdue = true;
+    return selector;
+}
+
+function canRetryFilteredRepositories() {
+    return state.reposHealth === 'failed' || state.reposHealth === 'cancelled' ||
+        state.reposHealth === 'overdue' || state.reposOverdue;
+}
+
+async function retryFilteredRepositories(expectedCount, retryAfterConflict) {
+    const count = Number(expectedCount) || 0;
+    if (!count) {
+        toast('No eligible repositories to retry');
+        return;
+    }
+    const wording = retryAfterConflict ? 'The eligible set changed. Retry ' + count + ' repositories?' :
+        'Retry ' + count + ' eligible repositories?';
+    if (!confirm(wording)) return;
+    try {
+        const data = await api('/api/jobs/bulk', {
+            method: 'POST',
+            body: JSON.stringify({ selector: repositoryBulkSelector(), expected_count: count })
+        });
+        const result = data || {};
+        toast('Bulk retry: requested ' + (result.requested || 0) + ', queued ' + (result.queued || 0) +
+            ', skipped active ' + (result.skipped_active || 0) + ', no longer eligible ' +
+            (result.no_longer_eligible || 0) + ', failed to enqueue ' + (result.failed_to_enqueue || 0));
+        renderRepositories();
+    } catch (e) {
+        const actual = e && e.data && e.data.actual_count;
+        if (e.status === 409 && Number.isInteger(actual) && !retryAfterConflict) {
+            retryFilteredRepositories(actual, true);
+            return;
+        }
+        toast('Bulk retry failed: ' + e.message, true);
+    }
+}
+
 async function renderRepositories() {
+    const renderSerial = ++state.reposRenderSerial;
     $('#app').innerHTML = '<div class="loading">Loading repositories\u2026</div>';
-
-    const params = new URLSearchParams({ page: state.reposPage, limit: 20 });
-    if (state.reposSearch) params.set('search', state.reposSearch);
-
     let data = null;
     try {
-        data = await api('/api/repositories?' + params.toString());
+        data = await api('/api/repositories?' + repositoryParams().toString());
     } catch (e) {
+        if (renderSerial !== state.reposRenderSerial) return;
         $('#app').innerHTML = '<div class="empty error-text">Failed to load repositories: ' + esc(e.message) + '</div>';
         return;
     }
+    if (renderSerial !== state.reposRenderSerial) return;
     const repos = (data && data.repositories) || [];
     const total = (data && data.total) || 0;
     const pages = Math.max(1, Math.ceil(total / 20));
-
-    const rows = repos.map(r => `
-        <tr>
-            <td><strong>${esc(r.Name)}</strong></td>
-            <td class="muted">${esc(r.URL || '-')}</td>
-            <td>${esc(r.Type || 'repo')}</td>
-            <td class="muted">${esc(r.Cron || '-')}</td>
-            <td class="muted">${fmtTime(r.next_run_time)}</td>
-            <td class="muted">${fmtTime(r.last_run_time)}</td>
-            <td class="muted">${r.total_runs} total \u00b7 ${r.success_runs} ok \u00b7 ${r.failed_runs} fail</td>
-            <td class="muted">${esc((r.Storage || []).join(', ') || '-')}</td>
-            <td class="muted">${optionsCell(r)}</td>
-            <td class="actions">
+    const summary = (data && data.summary) || {};
+    const rows = repos.map(r => {
+        const nextRun = r.schedule_error ? 'Schedule error: ' + r.schedule_error : fmtTime(r.next_run_time);
+        const detail = r.latest_execution_id
+            ? '<button class="btn btn-sm btn-execution-details" data-jobid="' + esc(r.latest_execution_id) +
+                '" data-jobname="' + esc(r.Name) + '">Details</button>' : '';
+        return `<tr>
+            <td>${repositoryHealthBadge(r)}</td>
+            <td><strong>${esc(r.Name)}</strong><br><span class="muted">${esc(r.URL || '-')}</span></td>
+            <td>${fmtTime(r.last_attempt_time)}</td>
+            <td>${fmtTime(r.last_success_time)}</td>
+            <td>${esc(r.last_duration_seconds === null || r.last_duration_seconds === undefined ? '-' : r.last_duration_seconds + 's')}</td>
+            <td class="muted" title="${esc(r.schedule_error || '')}">${esc(nextRun)}</td>
+            <td class="err-cell" title="${esc(r.last_error_message || '')}">${esc(r.last_error_message || '-')}</td>
+            <td class="actions">${detail}
                 <button class="btn btn-sm btn-primary btn-run-repo" data-key="${esc(repoKey(r))}">Execute</button>
                 <button class="btn btn-sm btn-edit-repo" data-key="${esc(repoKey(r))}">Edit</button>
                 <button class="btn btn-sm btn-danger btn-del-repo" data-key="${esc(repoKey(r))}">Delete</button>
             </td>
-        </tr>`).join('');
+        </tr>`;
+    }).join('');
 
     $('#app').innerHTML = `
-        <div class="page-header">
-            <h2>Repositories</h2>
-            <div class="toolbar-group">
-                <input type="text" id="repos-search" placeholder="Filter by name or URL\u2026" value="${esc(state.reposSearch)}">
-                <button id="btn-search-repos" class="btn">Search</button>
-                <button id="btn-add-repo" class="btn btn-primary">Add Repository</button>
-                <button id="btn-refresh-repos" class="btn">Refresh</button>
-            </div>
+        <div class="page-header"><h2>Repositories</h2>
+            <div class="toolbar-group"><button id="btn-add-repo" class="btn btn-primary">Add Repository</button>
+                <button id="btn-refresh-repos" class="btn">Refresh</button></div>
         </div>
-        <div class="panel">
-            ${repos.length
-                ? '<div class="table-wrap"><table class="table"><thead><tr><th>Name</th><th>URL</th><th>Type</th><th>Cron</th><th>Next Run</th><th>Last Run</th><th>Stats</th><th>Storage</th><th>Options</th><th></th></tr></thead><tbody>' + rows + '</tbody></table></div>'
-                : (state.reposSearch
-                    ? '<div class="empty">No repositories match your search.</div>'
-                    : '<div class="empty">No repositories configured. Click <strong>Add Repository</strong>.</div>')}
+        <div class="summary-grid">${repositorySummaryCards(summary)}</div>
+        <div class="panel repository-toolbar"><div class="toolbar">
+            <div class="toolbar-group"><input type="text" id="repos-search" placeholder="Filter by name or URL\u2026" value="${esc(state.reposSearch)}">
+                <button id="btn-search-repos" class="btn">Search</button></div>
+            <div class="toolbar-group"><label>Health <select id="repos-health">
+                <option value="">All health</option><option value="healthy">Healthy</option><option value="failed">Failed</option>
+                <option value="cancelled">Cancelled</option><option value="overdue">Overdue</option><option value="stuck">Stuck</option>
+                <option value="never_synced">Never synced</option><option value="pending">Pending</option>
+                <option value="running">Running</option><option value="syncing">Syncing</option></select></label>
+                <label class="checkbox"><input type="checkbox" id="repos-overdue"> Overdue only</label></div>
+            <div class="toolbar-group"><label>Sort <select id="repos-sort"><option value="attention">Attention</option>
+                <option value="name">Name</option><option value="last_attempt">Last attempt</option><option value="last_success">Last success</option></select></label>
+                <label>Direction <select id="repos-direction"><option value="asc">Ascending</option><option value="desc">Descending</option></select></label>
+                ${canRetryFilteredRepositories() ? '<button id="btn-retry-filtered" class="btn btn-danger" ' + (total ? '' : 'disabled') + '>Retry filtered (' + esc(total) + ')</button>' : ''}
+            </div>
+        </div></div>
+        <div class="panel repository-table">
+            ${repos.length ? '<div class="table-wrap"><table class="table"><thead><tr><th>Status</th><th>Name / URL</th><th>Last attempt</th><th>Last success</th><th>Duration</th><th>Next run</th><th>Error summary</th><th>Actions</th></tr></thead><tbody>' + rows + '</tbody></table></div>' :
+                '<div class="empty">No repositories match this view.</div>'}
             ${repos.length ? paginationHTML(state.reposPage, pages, total, 'repos') : ''}
         </div>`;
 
+    $('#repos-health').value = state.reposHealth;
+    $('#repos-overdue').checked = state.reposOverdue;
+    $('#repos-sort').value = state.reposSort;
+    $('#repos-direction').value = state.reposDirection;
     $('#btn-add-repo').addEventListener('click', () => openRepoForm(null));
     $('#btn-refresh-repos').addEventListener('click', () => renderRepositories());
-    // Query only on explicit action (Search button or Enter), never on every
-    // keystroke, so the input keeps focus while typing.
-    const applyRepoSearch = () => {
-        state.reposSearch = $('#repos-search').value.trim();
-        state.reposPage = 1;
-        renderRepositories();
-    };
-    $('#btn-search-repos').addEventListener('click', applyRepoSearch);
-    $('#repos-search').addEventListener('keydown', (ev) => {
-        if (ev.key === 'Enter') {
-            ev.preventDefault();
-            applyRepoSearch();
-        }
+    const applyRepositoryFilters = () => setRepositoryRoute({
+        reposSearch: $('#repos-search').value.trim(), reposHealth: $('#repos-health').value,
+        reposOverdue: $('#repos-overdue').checked, reposSort: $('#repos-sort').value,
+        reposDirection: $('#repos-direction').value, reposPage: 1
     });
-
+    $('#btn-search-repos').addEventListener('click', applyRepositoryFilters);
+    $('#repos-search').addEventListener('keydown', ev => { if (ev.key === 'Enter') { ev.preventDefault(); applyRepositoryFilters(); } });
+    $('#repos-health').addEventListener('change', applyRepositoryFilters);
+    $('#repos-overdue').addEventListener('change', applyRepositoryFilters);
+    $('#repos-sort').addEventListener('change', applyRepositoryFilters);
+    $('#repos-direction').addEventListener('change', applyRepositoryFilters);
+    $$('.summary-card').forEach(button => button.addEventListener('click', () => setRepositoryRoute({
+        reposHealth: button.dataset.health || '', reposOverdue: button.dataset.overdue === 'true', reposPage: 1
+    })));
+    const retry = $('#btn-retry-filtered');
+    if (retry) retry.addEventListener('click', () => retryFilteredRepositories(total, false));
     const prev = $('#pg-prev-repos');
     const next = $('#pg-next-repos');
-    if (prev) prev.addEventListener('click', () => { if (state.reposPage > 1) { state.reposPage--; renderRepositories(); } });
-    if (next) next.addEventListener('click', () => { state.reposPage++; renderRepositories(); });
-
+    if (prev) prev.addEventListener('click', () => { if (state.reposPage > 1) setRepositoryRoute({ reposPage: state.reposPage - 1 }); });
+    if (next) next.addEventListener('click', () => setRepositoryRoute({ reposPage: state.reposPage + 1 }));
     $$('.btn-run-repo').forEach(b => b.addEventListener('click', () => {
         const r = repos.find(x => repoKey(x) === b.dataset.key);
         runRepo(b.dataset.key, r ? r.Name : '', b);
@@ -482,6 +649,7 @@ async function renderRepositories() {
         if (r) openRepoForm(r);
     }));
     $$('.btn-del-repo').forEach(b => b.addEventListener('click', () => deleteRepo(b.dataset.key)));
+    $$('.btn-execution-details').forEach(b => b.addEventListener('click', () => openExecutionDetails(b.dataset.jobid, b.dataset.jobname)));
 }
 
 function openStorageForm(storage) {

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -81,6 +81,8 @@ const state = {
     reposDirection: 'asc',
     reposRenderSerial: 0,
     componentDetailSerial: 0,
+    activeRoute: '',
+    routeEpoch: 0,
     es: null,
     logJob: null,
     logIds: {}
@@ -98,13 +100,21 @@ function setActiveNav(route) {
     $$('.nav-links a').forEach(a => a.classList.toggle('active', a.dataset.route === route));
 }
 
+function routeFromHash() {
+    const hash = (location.hash || '#/jobs').replace(/^#\/?/, '');
+    return (hash.split('?')[0].split('/')[0]) || 'jobs';
+}
+
 function renderApp() {
     const hash = (location.hash || '#/jobs').replace(/^#\/?/, '');
-    const route = (hash.split('?')[0].split('/')[0]) || 'jobs';
+    const route = routeFromHash();
+    const routeEpoch = ++state.routeEpoch;
+    state.activeRoute = route;
+    state.componentDetailSerial++;
     setActiveNav(route);
     if (route === 'repositories') {
         applyRepositoryRoute(hash);
-        renderRepositories();
+        renderRepositories(routeEpoch);
     }
     else {
         state.reposRenderSerial++;
@@ -118,6 +128,11 @@ window.addEventListener('hashchange', renderApp);
 
 const repositoryHealthValues = ['healthy', 'failed', 'overdue', 'stuck', 'never_synced', 'cancelled', 'pending', 'running', 'syncing'];
 const repositorySortValues = ['attention', 'name', 'last_attempt', 'last_success'];
+
+function isActiveRepositoryRoute(routeEpoch) {
+    if (routeEpoch !== state.routeEpoch) return false;
+    return state.activeRoute === 'repositories' && routeFromHash() === 'repositories';
+}
 
 function applyRepositoryRoute(hash) {
     const query = (hash || '').split('?')[1] || '';
@@ -295,9 +310,11 @@ async function cancelJob(jobId) {
 
 async function runRepo(key, name, btn) {
     if (!key) return;
+    const routeEpoch = state.routeEpoch;
     btn.disabled = true;
     try {
         const data = await api('/api/jobs', { method: 'POST', body: JSON.stringify({ repository_key: key }) });
+        if (!isActiveRepositoryRoute(routeEpoch)) return;
         const jobIDs = (data && data.job_ids) || [];
         if (jobIDs.length === 1) {
             toast('Job started (' + jobIDs[0].slice(0, 8) + '…)');
@@ -305,8 +322,9 @@ async function runRepo(key, name, btn) {
         } else {
             toast('Started ' + jobIDs.length + ' jobs (org expansion)');
         }
-        renderRepositories();
+        renderRepositories(routeEpoch);
     } catch (e) {
+        if (!isActiveRepositoryRoute(routeEpoch)) return;
         toast('Failed to start job: ' + e.message, true);
         btn.disabled = false;
     }
@@ -321,13 +339,17 @@ function openLogModal(jobId, jobName, showComponents) {
     $('#log-modal-state').textContent = '';
     const consoleEl = $('#log-console');
     consoleEl.innerHTML = '<div class="log-line muted">Waiting for logs\u2026</div>';
-    if (!showComponents) $('#component-details').classList.add('hidden');
+    if (!showComponents) {
+        $('#execution-details').classList.add('hidden');
+        $('#component-details').classList.add('hidden');
+    }
     $('#log-modal').classList.remove('hidden');
 
     const es = new EventSource('/api/jobs/' + encodeURIComponent(jobId) + '/logs');
     state.es = es;
 
     es.addEventListener('done', (ev) => {
+        if (state.es !== es) return;
         let status = '';
         try { status = (JSON.parse(ev.data) || {}).status || ''; } catch (e) { /* ignore */ }
         appendLogLine({ level: 'info', message: 'Job finished (status: ' + status + ')' });
@@ -337,6 +359,7 @@ function openLogModal(jobId, jobName, showComponents) {
     });
 
     es.onmessage = (ev) => {
+        if (state.es !== es) return;
         let entry = null;
         try { entry = JSON.parse(ev.data); } catch (e) { return; }
         if (entry && entry.id && state.logIds[entry.id]) return;
@@ -368,8 +391,55 @@ function renderComponentDetails(components) {
         </div>`).join('');
 }
 
-async function openExecutionDetails(executionID, name) {
+function repositoryCanRetry(repository) {
+    const status = repository.last_status || '';
+    return !repository.stuck && !['pending', 'running'].includes(status) &&
+        (status === 'failed' || status === 'cancelled' || repository.overdue);
+}
+
+function renderExecutionDetails(repository, detailSerial, routeEpoch) {
+    $('#execution-details').classList.remove('hidden');
+    $('#execution-status').textContent = repository.last_status || repository.health_status || 'unknown';
+    $('#execution-attempt').textContent = fmtTime(repository.last_attempt_time);
+    $('#execution-duration').textContent = repository.last_duration_seconds === null ||
+        repository.last_duration_seconds === undefined ? '-' : repository.last_duration_seconds + 's';
+    $('#execution-error').textContent = repository.last_error_message || '-';
+    const retry = $('#btn-retry-execution');
+    retry.onclick = null;
+    retry.classList.toggle('hidden', !repositoryCanRetry(repository));
+    if (repositoryCanRetry(repository)) {
+        retry.onclick = () => retryExecutionRepository(repository, detailSerial, routeEpoch);
+    }
+}
+
+async function retryExecutionRepository(repository, detailSerial, routeEpoch) {
+    if (!isActiveRepositoryRoute(routeEpoch) || detailSerial !== state.componentDetailSerial) return;
+    const retry = $('#btn-retry-execution');
+    retry.disabled = true;
+    try {
+        const data = await api('/api/jobs', {
+            method: 'POST',
+            body: JSON.stringify({ repository_key: repoKey(repository) })
+        });
+        if (!isActiveRepositoryRoute(routeEpoch) || detailSerial !== state.componentDetailSerial) return;
+        const jobIDs = (data && data.job_ids) || [];
+        toast('Repository retry started');
+        renderRepositories(routeEpoch);
+        if (jobIDs.length === 1) openLogModal(jobIDs[0], repository.Name);
+    } catch (e) {
+        if (isActiveRepositoryRoute(routeEpoch) && detailSerial === state.componentDetailSerial) {
+            toast('Repository retry failed: ' + e.message, true);
+            retry.disabled = false;
+        }
+    }
+}
+
+async function openExecutionDetails(executionID, name, repository) {
+    const routeEpoch = state.routeEpoch;
+    if (!isActiveRepositoryRoute(routeEpoch)) return;
     const detailSerial = ++state.componentDetailSerial;
+    const snapshot = Object.freeze(Object.assign({}, repository));
+    renderExecutionDetails(snapshot, detailSerial, routeEpoch);
     $('#component-details').classList.remove('hidden');
     $('#component-list').textContent = 'Loading component details…';
     let components = [];
@@ -379,7 +449,7 @@ async function openExecutionDetails(executionID, name) {
     } catch (e) {
         components = null;
     }
-    if (detailSerial !== state.componentDetailSerial) return;
+    if (detailSerial !== state.componentDetailSerial || !isActiveRepositoryRoute(routeEpoch)) return;
     if (components === null) $('#component-list').textContent = 'Component details unavailable';
     else renderComponentDetails(components);
     openLogModal(executionID, name, true);
@@ -440,6 +510,7 @@ function openRepoForm(repo) {
 
 async function saveRepo(ev) {
     ev.preventDefault();
+    const routeEpoch = state.routeEpoch;
     const originalKey = $('#repo-original-key').value;
     const name = $('#repo-name').value.trim();
     if (!name) { toast('Name is required', true); return; }
@@ -469,20 +540,25 @@ async function saveRepo(ev) {
             await api('/api/repositories', { method: 'POST', body: JSON.stringify(repo) });
             toast('Repository added');
         }
+        if (!isActiveRepositoryRoute(routeEpoch)) return;
         $('#repo-modal').classList.add('hidden');
-        renderRepositories();
+        renderRepositories(routeEpoch);
     } catch (e) {
+        if (!isActiveRepositoryRoute(routeEpoch)) return;
         toast('Failed to save repository: ' + e.message, true);
     }
 }
 
 async function deleteRepo(key) {
     if (!confirm('Delete repository?')) return;
+    const routeEpoch = state.routeEpoch;
     try {
         await api('/api/repositories/' + encodeURIComponent(key), { method: 'DELETE' });
+        if (!isActiveRepositoryRoute(routeEpoch)) return;
         toast('Repository deleted');
-        renderRepositories();
+        renderRepositories(routeEpoch);
     } catch (e) {
+        if (!isActiveRepositoryRoute(routeEpoch)) return;
         toast('Failed to delete repository: ' + e.message, true);
     }
 }
@@ -516,52 +592,87 @@ function repositoryBulkSelector() {
     return selector;
 }
 
+function selectorsEqual(left, right) {
+    return left.search === right.search && left.health === right.health &&
+        Boolean(left.overdue) === Boolean(right.overdue);
+}
+
+function freezeBulkRetryAttempt(selector, expectedCount, routeEpoch) {
+    const frozenSelector = { search: selector.search || '', health: selector.health || '' };
+    if (selector.overdue) frozenSelector.overdue = true;
+    return Object.freeze({
+        selector: Object.freeze(frozenSelector),
+        expectedCount: Number(expectedCount) || 0,
+        routeEpoch: routeEpoch
+    });
+}
+
+function bulkRetryAttemptIsCurrent(attempt) {
+    return isActiveRepositoryRoute(attempt.routeEpoch) &&
+        selectorsEqual(attempt.selector, repositoryBulkSelector());
+}
+
 function canRetryFilteredRepositories() {
     return state.reposHealth === 'failed' || state.reposHealth === 'cancelled' ||
         state.reposHealth === 'overdue' || state.reposOverdue;
 }
 
-async function retryFilteredRepositories(expectedCount, retryAfterConflict) {
-    const count = Number(expectedCount) || 0;
-    if (!count) {
+async function retryFilteredRepositories(attempt, retryAfterConflict) {
+    if (!attempt.expectedCount) {
         toast('No eligible repositories to retry');
         return;
     }
-    const wording = retryAfterConflict ? 'The eligible set changed. Retry ' + count + ' repositories?' :
-        'Retry ' + count + ' eligible repositories?';
+    if (!bulkRetryAttemptIsCurrent(attempt)) {
+        toast('Repository filters changed. Retry from the current view.', true);
+        return;
+    }
+    const wording = retryAfterConflict ? 'The eligible set changed. Retry ' + attempt.expectedCount + ' repositories?' :
+        'Retry ' + attempt.expectedCount + ' eligible repositories?';
     if (!confirm(wording)) return;
+    if (!bulkRetryAttemptIsCurrent(attempt)) {
+        toast('Repository filters changed. Retry from the current view.', true);
+        return;
+    }
     try {
         const data = await api('/api/jobs/bulk', {
             method: 'POST',
-            body: JSON.stringify({ selector: repositoryBulkSelector(), expected_count: count })
+            body: JSON.stringify({ selector: attempt.selector, expected_count: attempt.expectedCount })
         });
+        if (!bulkRetryAttemptIsCurrent(attempt)) return;
         const result = data || {};
         toast('Bulk retry: requested ' + (result.requested || 0) + ', queued ' + (result.queued || 0) +
             ', skipped active ' + (result.skipped_active || 0) + ', no longer eligible ' +
             (result.no_longer_eligible || 0) + ', failed to enqueue ' + (result.failed_to_enqueue || 0));
-        renderRepositories();
+        renderRepositories(attempt.routeEpoch);
     } catch (e) {
-        const actual = e && e.data && e.data.actual_count;
+        const actual = e && e.data ? e.data.actual_count : null;
         if (e.status === 409 && Number.isInteger(actual) && !retryAfterConflict) {
-            retryFilteredRepositories(actual, true);
+            if (!bulkRetryAttemptIsCurrent(attempt)) {
+                toast('Repository filters changed. Retry from the current view.', true);
+                return;
+            }
+            retryFilteredRepositories(freezeBulkRetryAttempt(attempt.selector, actual, attempt.routeEpoch), true);
             return;
         }
-        toast('Bulk retry failed: ' + e.message, true);
+        if (bulkRetryAttemptIsCurrent(attempt)) toast('Bulk retry failed: ' + e.message, true);
     }
 }
 
-async function renderRepositories() {
+async function renderRepositories(expectedRouteEpoch) {
+    const routeEpoch = expectedRouteEpoch === undefined ? state.routeEpoch : expectedRouteEpoch;
+    if (!isActiveRepositoryRoute(routeEpoch)) return;
     const renderSerial = ++state.reposRenderSerial;
+    if (!isActiveRepositoryRoute(routeEpoch)) return;
     $('#app').innerHTML = '<div class="loading">Loading repositories\u2026</div>';
     let data = null;
     try {
         data = await api('/api/repositories?' + repositoryParams().toString());
     } catch (e) {
-        if (renderSerial !== state.reposRenderSerial) return;
+        if (renderSerial !== state.reposRenderSerial || !isActiveRepositoryRoute(routeEpoch)) return;
         $('#app').innerHTML = '<div class="empty error-text">Failed to load repositories: ' + esc(e.message) + '</div>';
         return;
     }
-    if (renderSerial !== state.reposRenderSerial) return;
+    if (renderSerial !== state.reposRenderSerial || !isActiveRepositoryRoute(routeEpoch)) return;
     const repos = (data && data.repositories) || [];
     const total = (data && data.total) || 0;
     const pages = Math.max(1, Math.ceil(total / 20));
@@ -569,8 +680,7 @@ async function renderRepositories() {
     const rows = repos.map(r => {
         const nextRun = r.schedule_error ? 'Schedule error: ' + r.schedule_error : fmtTime(r.next_run_time);
         const detail = r.latest_execution_id
-            ? '<button class="btn btn-sm btn-execution-details" data-jobid="' + esc(r.latest_execution_id) +
-                '" data-jobname="' + esc(r.Name) + '">Details</button>' : '';
+            ? '<button class="btn btn-sm btn-execution-details" data-key="' + esc(repoKey(r)) + '">Details</button>' : '';
         return `<tr>
             <td>${repositoryHealthBadge(r)}</td>
             <td><strong>${esc(r.Name)}</strong><br><span class="muted">${esc(r.URL || '-')}</span></td>
@@ -635,7 +745,10 @@ async function renderRepositories() {
         reposHealth: button.dataset.health || '', reposOverdue: button.dataset.overdue === 'true', reposPage: 1
     })));
     const retry = $('#btn-retry-filtered');
-    if (retry) retry.addEventListener('click', () => retryFilteredRepositories(total, false));
+    if (retry) {
+        const retryAttempt = freezeBulkRetryAttempt(repositoryBulkSelector(), total, routeEpoch);
+        retry.addEventListener('click', () => retryFilteredRepositories(retryAttempt, false));
+    }
     const prev = $('#pg-prev-repos');
     const next = $('#pg-next-repos');
     if (prev) prev.addEventListener('click', () => { if (state.reposPage > 1) setRepositoryRoute({ reposPage: state.reposPage - 1 }); });
@@ -649,7 +762,10 @@ async function renderRepositories() {
         if (r) openRepoForm(r);
     }));
     $$('.btn-del-repo').forEach(b => b.addEventListener('click', () => deleteRepo(b.dataset.key)));
-    $$('.btn-execution-details').forEach(b => b.addEventListener('click', () => openExecutionDetails(b.dataset.jobid, b.dataset.jobname)));
+    $$('.btn-execution-details').forEach(b => b.addEventListener('click', () => {
+        const r = repos.find(x => repoKey(x) === b.dataset.key);
+        if (r) openExecutionDetails(r.latest_execution_id, r.Name, r);
+    }));
 }
 
 function openStorageForm(storage) {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -30,6 +30,10 @@
                 <span id="log-modal-state" class="log-state"></span>
                 <button id="log-modal-close" class="btn btn-sm">Close</button>
             </div>
+            <section id="component-details" class="component-details hidden" aria-live="polite">
+                <h3>Components</h3>
+                <div id="component-list"></div>
+            </section>
             <div class="log-console" id="log-console"></div>
         </div>
     </div>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -30,6 +30,16 @@
                 <span id="log-modal-state" class="log-state"></span>
                 <button id="log-modal-close" class="btn btn-sm">Close</button>
             </div>
+            <section id="execution-details" class="execution-details hidden" aria-live="polite">
+                <h3>Latest execution</h3>
+                <dl class="execution-summary">
+                    <div><dt>Status</dt><dd id="execution-status"></dd></div>
+                    <div><dt>Last attempt</dt><dd id="execution-attempt"></dd></div>
+                    <div><dt>Duration</dt><dd id="execution-duration"></dd></div>
+                    <div class="execution-error"><dt>Error</dt><dd id="execution-error"></dd></div>
+                </dl>
+                <button id="btn-retry-execution" class="btn btn-sm btn-primary hidden">Retry repository</button>
+            </section>
             <section id="component-details" class="component-details hidden" aria-live="polite">
                 <h3>Components</h3>
                 <div id="component-list"></div>


### PR DESCRIPTION
## Summary

- add fleet-wide repository sync health status, filters, sorting, summary counts, and last-attempt/last-success visibility
- persist component outcomes and enforce one executor concurrency model for cron, manual runs, and safe bulk retry
- add immutable configuration generations, restart reconciliation, indexed repository snapshots, and process-wide GitHub API arbitration
- keep the Repositories page manual-refresh-only, with no polling or SSE-triggered reloads

## Verification

- go test ./... -count=1
- go vet ./...
- go test -race ./internal/config ./internal/db ./internal/githubapi ./internal/repository ./internal/wiki ./internal/executor ./internal/server ./cmd/server -count=1
- BenchmarkGetRepositories6000: 12/12 measurements below 1 second, final range 497-528 ms/op
- node --check web/static/js/main.js
- git diff --check