### PR TITLE
fix(wiki): treat enabled empty wikis as successful

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -10,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/uuid"
 	"github.com/wnarutou/gitrieve/internal/archive"
 	internalconfig "github.com/wnarutou/gitrieve/internal/config"
@@ -33,6 +35,10 @@ type contextualRepoLister interface {
 // newGithubClient 是可替换的包级 seam：生产用真客户端，测试注入 fake。
 var newGithubClient = func() (repoLister, error) { return github.New() }
 var newGithubClientWithContext = func(ctx context.Context) (contextualRepoLister, error) { return github.NewWithContext(ctx) }
+
+func shouldLogCloneError(isWiki bool, err error) bool {
+	return !isWiki || !errors.Is(err, transport.ErrAuthenticationRequired)
+}
 
 func GetRepositories(name string) []typedef.Repository {
 	repositories := make([]typedef.Repository, 0)
@@ -199,7 +205,9 @@ func Sync(ctx context.Context, repo typedef.Repository, iswiki bool, storages []
 			// deletion-safe guarantee only covers existing local history, which
 			// is handled by the fetch/pull path below.
 			os.RemoveAll(gitDir)
-			ui.Errorf("Error cloning repository, %s", err)
+			if shouldLogCloneError(iswiki, err) {
+				ui.Errorf("Error cloning repository, %s", err)
+			}
 			return err
 		}
 	}

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -2,11 +2,13 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"testing"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/lock"
@@ -66,4 +68,12 @@ func TestSyncBlocksWhileWikiLockHeld(t *testing.T) {
 	defer cancel()
 	err = Sync(ctx, repo, true, nil)
 	require.Equal(t, context.DeadlineExceeded, err, "wiki Sync must block on the held wiki lock")
+}
+
+func TestWikiCloneRepositoryNotFoundIsReportedByWikiLayer(t *testing.T) {
+	err := fmt.Errorf("%w: Repository not found", transport.ErrAuthenticationRequired)
+
+	require.False(t, shouldLogCloneError(true, err))
+	require.True(t, shouldLogCloneError(false, err))
+	require.True(t, shouldLogCloneError(true, context.DeadlineExceeded))
 }

--- a/internal/wiki/wiki.go
+++ b/internal/wiki/wiki.go
@@ -2,8 +2,10 @@ package wiki
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	gh "github.com/google/go-github/v56/github"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/githubapi"
@@ -15,11 +17,17 @@ import (
 	"github.com/wnarutou/gitrieve/internal/ui"
 )
 
+var syncRepository = repository.Sync
+
 func wikiAvailability(repoURL string, hasWiki bool) error {
 	if hasWiki {
 		return nil
 	}
 	return syncresult.Skip(fmt.Sprintf("repository %s has no wiki", repoURL))
+}
+
+func uninitializedPublicWiki(hasWiki, private bool, err error) bool {
+	return hasWiki && !private && errors.Is(err, transport.ErrAuthenticationRequired)
 }
 
 func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.MultiStorage) error {
@@ -62,7 +70,11 @@ func Sync(ctx context.Context, repo typedef.Repository, storages []typedef.Multi
 	}
 
 	ui.Printf("Running %s's wiki", repo.Name)
-	if err := repository.Sync(ctx, repo, true, storages); err != nil {
+	if err := syncRepository(ctx, repo, true, storages); err != nil {
+		if uninitializedPublicWiki(gitrepo.GetHasWiki(), gitrepo.GetPrivate(), err) {
+			ui.Printf("Wiki for %s is enabled but has no pages", repo.URL)
+			return nil
+		}
 		if ctx.Err() == nil {
 			ui.Errorf("Error running %s's wiki, %s", repo.Name, err)
 		}

--- a/internal/wiki/wiki_test.go
+++ b/internal/wiki/wiki_test.go
@@ -2,6 +2,8 @@ package wiki
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -9,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/stretchr/testify/require"
 	"github.com/wnarutou/gitrieve/internal/config"
 	"github.com/wnarutou/gitrieve/internal/githubapi"
@@ -72,6 +75,52 @@ func TestSyncSkipsUnavailableWikiWithoutPresentationOrRepositorySync(t *testing.
 	require.True(t, ok)
 	require.Equal(t, "repository github.com/test/repo has no wiki", reason)
 	require.Empty(t, sink.logs)
+}
+
+func TestSyncCompletesWhenPublicWikiIsEnabledButHasNoPages(t *testing.T) {
+	previousConfig := config.GetIns()
+	config.SetIns(&config.Config{})
+	if previousConfig != nil {
+		t.Cleanup(func() { config.SetIns(previousConfig) })
+	}
+
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = wikiRoundTripper(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "/repos/test/repo", req.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"has_wiki":true,"private":false}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+	previousSyncRepository := syncRepository
+	syncRepository = func(context.Context, typedef.Repository, bool, []typedef.MultiStorage) error {
+		return fmt.Errorf("clone wiki: %w: Repository not found", transport.ErrAuthenticationRequired)
+	}
+	t.Cleanup(func() { syncRepository = previousSyncRepository })
+
+	sink := &wikiLogSink{}
+	ui.SetSink(sink)
+	t.Cleanup(func() { ui.SetSink(nil) })
+	unbind := ui.Bind("execution-1", "wiki")
+	defer unbind()
+
+	err := Sync(context.Background(), typedef.Repository{Name: "repo", URL: "github.com/test/repo"}, nil)
+
+	require.NoError(t, err)
+	require.Contains(t, sink.logs, "info:Wiki for github.com/test/repo is enabled but has no pages")
+}
+
+func TestUninitializedWikiDoesNotHidePrivateRepositoryAuthenticationFailure(t *testing.T) {
+	err := fmt.Errorf("clone wiki: %w: Repository not found", transport.ErrAuthenticationRequired)
+
+	require.False(t, uninitializedPublicWiki(true, true, err))
+	require.True(t, uninitializedPublicWiki(true, false, err))
+	require.False(t, uninitializedPublicWiki(false, false, err))
+	require.False(t, uninitializedPublicWiki(true, false, errors.New("network down")))
 }
 
 func TestSyncCancelledContextReturnsImmediately(t *testing.T) {


### PR DESCRIPTION
Treat GitHub repositories with enabled but uninitialized public wikis as successful syncs. Suppress misleading clone authentication errors for that state while preserving private repository and other clone failures. Tests: go test -count=1 ./...